### PR TITLE
Menu-Bar + Working Shortcuts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,15 @@
-import { app, BrowserWindow, screen } from 'electron';
+// import { app, BrowserWindow, screen } from 'electron';
+import { screen } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
+// import Menu = Electron.Menu;
 
 let win, serve;
 const args = process.argv.slice(1);
 serve = args.some(val => val === '--serve');
+
+const electron = require('electron');
+const {app, BrowserWindow, Menu } = electron;
 
 function createWindow() {
 
@@ -44,14 +49,71 @@ function createWindow() {
 
 }
 
+// Edited version of template menu provided by electron API,
+// refer to https://electronjs.org/docs/api/menu for more information.
+const mainMenuTemplate: Electron.MenuItemConstructorOptions[] = [
+  {
+    label: 'File',
+    submenu: [
+      {
+        label: 'Quit CATcher',
+        accelerator: 'CmdOrCtrl+Q',
+        click() {
+          app.quit();
+        }
+      }
+    ]
+  },
+  {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'selectAll' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'delete' },
+      {
+        label: 'Speech',
+        submenu: [
+          { role: 'startspeaking' },
+          { role: 'stopspeaking' }
+        ]
+      }
+    ]
+  },
+  {
+    label: 'View',
+    submenu: [
+      { role: 'resetzoom' },
+      { role: 'zoomin' },
+      { role: 'zoomout' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' }
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
+        // TODO: Change below url to course-site / application github site.
+        click () { require('electron').shell.openExternal('https://electronjs.org'); }
+      }
+    ]
+  }
+];
+
 try {
 
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
   app.on('ready', () => {
-    // const menu = Menu.buildFromTemplate(template);
-    // Menu.setApplicationMenu(menu);
+    const mainMenu = Menu.buildFromTemplate(mainMenuTemplate);
+    Menu.setApplicationMenu(mainMenu);
     createWindow();
   });
 

--- a/main.ts
+++ b/main.ts
@@ -66,13 +66,6 @@ const mainMenuTemplate: Electron.MenuItemConstructorOptions[] = [
       { role: 'copy' },
       { role: 'paste' },
       { role: 'delete' },
-      {
-        label: 'Speech',
-        submenu: [
-          { role: 'startspeaking' },
-          { role: 'stopspeaking' }
-        ]
-      }
     ]
   },
   {

--- a/main.ts
+++ b/main.ts
@@ -1,15 +1,10 @@
-// import { app, BrowserWindow, screen } from 'electron';
-import { screen } from 'electron';
+import { app, BrowserWindow, screen, Menu } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
-// import Menu = Electron.Menu;
 
 let win, serve;
 const args = process.argv.slice(1);
 serve = args.some(val => val === '--serve');
-
-const electron = require('electron');
-const {app, BrowserWindow, Menu } = electron;
 
 function createWindow() {
 
@@ -49,18 +44,14 @@ function createWindow() {
 
 }
 
-// Edited version of template menu provided by electron API,
+// Edited version of a template menu-bar provided by the electron API,
 // refer to https://electronjs.org/docs/api/menu for more information.
 const mainMenuTemplate: Electron.MenuItemConstructorOptions[] = [
   {
     label: 'File',
     submenu: [
       {
-        label: 'Quit CATcher',
-        accelerator: 'CmdOrCtrl+Q',
-        click() {
-          app.quit();
-        }
+        label: 'Quit CATcher', accelerator: 'CmdOrCtrl+Q', click() { app.quit(); }
       }
     ]
   },
@@ -112,8 +103,11 @@ try {
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
   app.on('ready', () => {
+
+    // Build and Attach Menu-bar template to application.
     const mainMenu = Menu.buildFromTemplate(mainMenuTemplate);
     Menu.setApplicationMenu(mainMenu);
+
     createWindow();
   });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@angular/animations": "~7.2.7",
-    "@angular/cdk": "7.3.2",
+    "@angular/cdk": "7.3.7",
     "@angular/common": "~7.2.7",
     "@angular/compiler": "~7.2.7",
     "@angular/core": "~7.2.7",

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title>CATcher</title>
-  <base href="./">
+  <!--<base href="./"> //TODO: Uncomment Prior to Release-->
+  <base href="/"> <!--//TODO: Comment Out Prior to Release-->
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>CATcher</title>
-  <base href="/">
+  <base href="./">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
Fixing the build issue, where application would not go past the loading screen for MacOS `CATcher.app`, required minor changes in the `src/index.html` code.
Application shortcuts are now working on MacOS.

Fixes #47 