### PR TITLE
Row Clickability

### DIFF
--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -112,7 +112,7 @@ export class IssueService {
   hasResponse(issueId: number): boolean {
     const responseType = this.phaseService.currentPhase === Phase.phase2 ? RespondType.teamResponse : RespondType.tutorResponse;
     return !!this.issueCommentService.comments.get(issueId)[responseType];
-}
+  }
 
   /**
    * Obtain an Observable array of issues that are duplicate of the given issue.

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -112,7 +112,7 @@ export class IssueService {
   hasResponse(issueId: number): boolean {
     const responseType = this.phaseService.currentPhase === Phase.phase2 ? RespondType.teamResponse : RespondType.tutorResponse;
     return !!this.issueCommentService.comments.get(issueId)[responseType];
-  }
+}
 
   /**
    * Obtain an Observable array of issues that are duplicate of the given issue.

--- a/src/app/phase1/phase1.component.html
+++ b/src/app/phase1/phase1.component.html
@@ -59,7 +59,7 @@
 
     <ng-container matColumnDef="actions" >
       <th mat-header-cell *matHeaderCellDef> {{permissions.canDeleteIssue() ? 'Actions' : ''}} </th>
-      <td mat-cell *matCellDef="let issue">
+      <td mat-cell *matCellDef="let issue" (click)="$event.stopPropagation()">
         <button mat-button color="warn" *ngIf="permissions.canDeleteIssue() && !issuesPendingDeletion[issue.id]"
                 (click)="deleteIssue(issue.id)"> Delete </button>
         <mat-spinner color="warn" [diameter]="25" style="display: inline; padding-right: 30px; margin-left: 5px"

--- a/src/app/phase1/phase1.component.html
+++ b/src/app/phase1/phase1.component.html
@@ -68,7 +68,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let issue; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let issue; columns: displayedColumns;" [routerLink]="'issues/' + issue.id"></tr>
   </table>
   <mat-card *ngIf="issuesDataSource.isLoading$ | async"
             style="display: flex; justify-content: center; align-items: center">

--- a/src/app/phase2/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase2/issues-faulty/issues-faulty.component.html
@@ -100,7 +100,7 @@
 
     <ng-container *ngIf="userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin'" matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef> Action </th>
-      <td mat-cell *matCellDef="let issue">
+      <td mat-cell *matCellDef="let issue" (click)="$event.stopPropagation()">
         <button *ngIf="permissions.canCRUDTeamResponse()"
                 [routerLink]="'/phase2/issues/' + issue.id" mat-button color="accent">
           Fix
@@ -109,7 +109,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let issue; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let issue; columns: displayedColumns;" [routerLink]="'issues/' + issue.id"></tr>
   </table>
   <mat-card *ngIf="issuesDataSource.isLoading$ | async"
             style="display: flex; justify-content: center; align-items: center">

--- a/src/app/phase2/issues-pending/issues-pending.component.html
+++ b/src/app/phase2/issues-pending/issues-pending.component.html
@@ -58,7 +58,7 @@
 
     <ng-container matColumnDef="actions" *ngIf="permissions.canCRUDTeamResponse()">
       <th mat-header-cell *matHeaderCellDef> Actions </th>
-      <td mat-cell *matCellDef="let issue">
+      <td mat-cell *matCellDef="let issue" (click)="$event.stopPropagation()">
         <button *ngIf="permissions.canCRUDTeamResponse() && !issueService.hasResponse(issue.id)"
           [routerLink]="'/phase2/issues/' + issue.id" mat-button color="accent">
           Respond
@@ -71,7 +71,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let issue; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let issue; columns: displayedColumns;" [routerLink]="'issues/' + issue.id"></tr>
   </table>
   <mat-card *ngIf="issuesDataSource.isLoading$ | async"
             style="display: flex; justify-content: center; align-items: center">

--- a/src/app/phase2/issues-responded/issues-responded.component.html
+++ b/src/app/phase2/issues-responded/issues-responded.component.html
@@ -101,11 +101,11 @@
 
     <ng-container *ngIf="userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin'" matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef> Action </th>
-      <td mat-cell *matCellDef="let issue"> <button color="primary" mat-button (click)="markAsPending(issue)">Mark as pending</button> </td>
+      <td mat-cell *matCellDef="let issue" (click)="$event.stopPropagation()"> <button color="primary" mat-button (click)="markAsPending(issue)">Mark as pending</button> </td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let issue; columns: displayedColumns;"></tr>
+    <tr mat-row *matRowDef="let issue; columns: displayedColumns;" [routerLink]="'issues/' + issue.id"></tr>
   </table>
   <mat-card *ngIf="issuesDataSource.isLoading$ | async"
             style="display: flex; justify-content: center; align-items: center">

--- a/src/app/phase3/phase3.component.html
+++ b/src/app/phase3/phase3.component.html
@@ -61,7 +61,7 @@
 
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let issue; columns: displayedColumns;"></tr>
+  <tr mat-row *matRowDef="let issue; columns: displayedColumns;" [routerLink]="'issues/' + issue.id"></tr>
 </table>
 <mat-card *ngIf="issuesDataSource.isLoading$ | async"
           style="display: flex; justify-content: center; align-items: center">


### PR DESCRIPTION
Fixes #51 
## Row Click-ability
The entire row is now click-able and works as shown below.

![RowClick](https://user-images.githubusercontent.com/39243082/57837580-a9bdec80-77f5-11e9-91e6-083aff3606e9.gif)

## Note
When implementing the full-row click, I encountered the issue where when buttons in the row were clicked (e.g. Mark as Pending), both the row click and button click were registered and carried out (e.g. Resulting in me being routed to the individual issue page and the issue being shifted to the pending table). A solution i found to this is to add a `(click)="$event.stopPropogation()`. As seen in some of the changed files such as [issues-faulty-component.html](src/app/phase2/issues-faulty/issues-faulty.component.html). Where,

>`<td mat-cell *matCellDef="let issue" (click)="$event.stopPropagation()">
        <button *ngIf="permissions.canCRUDTeamResponse()"
                [routerLink]="'/phase2/issues/' + issue.id" mat-button color="accent">`

This allows the button to absorb the click event and prevents the row from receiving it. 👍 