### PR TITLE
CATcher V2

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -35,7 +35,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.loginForm = this.formBuilder.group({
       username: ['', Validators.required],
       password: ['', Validators.required],
-      encodedText: ['phase1=https://github.com/CATcher-org/pe@phase2=https://github.com/CATcher-org/pe-results' +
+      encodedText: ['CATcher-org@phase1=https://github.com/testathorStudent/pe@phase2=https://github.com/CATcher-org/pe-results' +
       '@phase3=https://github.com/CATcher-org/pe-evaluation', Validators.required],
     });
   }

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -7,6 +7,7 @@ const Octokit = require('@octokit/rest');
 
 
 let ORG_NAME = '';
+let MOD_ORG = '';
 let REPO = '';
 const DATA_REPO = 'public_data';
 let octokit;
@@ -28,9 +29,10 @@ export class GithubService {
     });
   }
 
-  updatePhaseDetails(repoName: string, orgName: string) {
+  updatePhaseDetails(repoName: string, orgName: string, modOrg: string) {
     ORG_NAME = orgName;
     REPO = repoName;
+    MOD_ORG = modOrg;
   }
   /**
    * Will return an Observable with array of issues in JSON format.
@@ -145,7 +147,7 @@ export class GithubService {
   }
 
   fetchDataFile(): Observable<{}> {
-    return from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
+    return from(octokit.repos.getContents({owner: MOD_ORG, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
       return JSON.parse(atob(resp['data']['content']));
     }));
   }


### PR DESCRIPTION
Resolve #78 
Changed the authentication to allow tester to specify their own repository.

The encoded text must now specify the Org name, where the public_data file is located
(e.g **[CATcher-org]**@phase1=https://github.com/testathorStudent/pe@phase2=https://github.com/CATcher-org/pe-results@phase3=https://github.com/CATcher-org/pe-evaluation)

Tester should also provide their own repository's url in the encoded text phase1