### PR TITLE
CSV Import Functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ This application assumes 4 repositories will be created under the above organiza
 For each phase, users with write access will be able to upload files (e.g. screenshots, .txt files, etc...) onto the repository's `/file` folder. These files are used in conjuction with issue description and comments in a form of a link. As for images, the actual image will be displayed.
 
 ### 2.2.1. `public_data` Repository
-The name of this repository must be **exactly** `public_data`. This repository must contain 1 file called `data.json`. In this JSON file, it will contain the following information:
+The name of this repository must be **exactly** `public_data`. This repository must contain 1 file called `data.csv`. This `.csv` file, will contain the following information:
 1. Roles of users. (Student, Tutor, Admin)
-2. Team structure. For each team, the JSON must specify which student is in that team.
-3. Student's team allocation. For each student, the JSON must specify which team the student is in.
-4. Tutor's team allocation. For each tutor, the JSON must specify which team the tutor is assigned to.
-5. Admin's team allocation. For each admin, the JSON must specify which team the admin is responsible for. (The application will still give admin full access to the repository.)
+2. Student's team allocation. For each student, the `.csv` file must specify which team the student is in.
+3. Tutor's team allocation. For each tutor, the `.csv` must specify which teams the tutor is assigned to.
 
-An example of `data.json`: https://github.com/CATcher-org/public_data/blob/master/data.json
+An example of `data.csv`: https://github.com/CATcher-org/public_data/blob/master/data.csv
 
 ### 2.2.2. Bug Reporting Repository
 All the bug reports that are created from the application will be posted into this repository.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@angular/router": "~7.2.7",
     "@octokit/rest": "^16.13.1",
     "core-js": "2.6.1",
+    "csv-parse": "^4.4.3",
     "moment": "^2.24.0",
     "ngx-markdown": "^7.1.1",
     "node-fetch": "^2.3.0",

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,10 +1,10 @@
-import {Injectable} from '@angular/core';
-import {GithubService} from './github.service';
-import {map} from 'rxjs/operators';
-import {DataFile} from '../models/data-file.model';
-import {Team} from '../models/team.model';
-import {User, UserRole} from '../models/user.model';
-import {forkJoin, Observable, Subject} from 'rxjs';
+import { Injectable } from '@angular/core';
+import { GithubService } from './github.service';
+import { map } from 'rxjs/operators';
+import { DataFile } from '../models/data-file.model';
+import { Team } from '../models/team.model';
+import { User, UserRole } from '../models/user.model';
+import { Observable } from 'rxjs';
 const parse = require('csv-parse/lib/sync');
 
 @Injectable({

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -90,11 +90,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === UserRole.Tutor.toLowerCase()) {
-        const tutor = entry[NAME] in tutors ? tutors[entry[NAME]] : {};
-        tutor[entry[TEAM]] = 'true';
-        tutors[entry[NAME]] = tutor;
+      if (!(entry[ROLE] === UserRole.Tutor.toLowerCase())) {
+        return;
       }
+      const tutor = entry[NAME] in tutors ? tutors[entry[NAME]] : {};
+      tutor[entry[TEAM]] = 'true';
+      tutors[entry[NAME]] = tutor;
     });
 
     return tutors;
@@ -120,11 +121,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
-        const newStudent = {};
-        newStudent[TEAM_ID] = entry[TEAM];
-        students[entry[NAME]] = newStudent;
+      if (!(entry[ROLE] === UserRole.Student.toLowerCase())) {
+        return;
       }
+      const newStudent = {};
+      newStudent[TEAM_ID] = entry[TEAM];
+      students[entry[NAME]] = newStudent;
     });
 
     return students;
@@ -148,11 +150,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
-        const team = entry[TEAM] in teams ? teams[entry[TEAM]] : {};
-        team[entry[NAME]] = 'true';
-        teams[entry[TEAM]] = team;
+      if (!(entry[ROLE] === UserRole.Student.toLowerCase())) {
+        return;
       }
+      const team = entry[TEAM] in teams ? teams[entry[TEAM]] : {};
+      team[entry[NAME]] = 'true';
+      teams[entry[TEAM]] = team;
     });
 
     return teams;

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -4,7 +4,8 @@ import {map} from 'rxjs/operators';
 import {DataFile} from '../models/data-file.model';
 import {Team} from '../models/team.model';
 import {User, UserRole} from '../models/user.model';
-import {Observable} from 'rxjs';
+import {forkJoin, Observable, Subject} from 'rxjs';
+const parse = require('csv-parse/lib/sync');
 
 @Injectable({
   providedIn: 'root',
@@ -15,10 +16,207 @@ export class DataService {
   constructor(private githubService: GithubService) {}
 
   getDataFile(): Observable<{}> {
-    return this.githubService.fetchDataFile().pipe(map((jsonData: {}) => {
-      this.dataFile = <DataFile>{teamStructure: this.extractTeamStructure(jsonData)};
-      return jsonData;
-    }));
+    return this.githubService.fetchDataFile().pipe(
+      map(allCsvData => {
+
+        let roles: {};
+        let teams: {};
+        let studentAllocations: {};
+        let tutorsAllocations: {};
+        let adminsAllocations: {};
+        roles = this.parseRolesData(allCsvData['first']);
+        teams = this.parseTeamStructureData(allCsvData['second']);
+        studentAllocations = this.parseStudentAllocation(allCsvData['second']);
+        tutorsAllocations = this.parseTutorAllocation(allCsvData['third']);
+        adminsAllocations = this.parseAdminAllocation(allCsvData['fourth']);
+
+        return [roles, teams, studentAllocations, tutorsAllocations, adminsAllocations];
+      }),
+      map(([first, second, third, fourth, fifth]) => {
+        return {first, second, third, fourth, fifth};
+      }),
+      map(outputData => {
+        const jsonData = {};
+
+        jsonData['roles'] = outputData['first'];
+        jsonData['team-structure'] = outputData['second'];
+        jsonData['students-allocation'] = outputData['third'];
+        jsonData['tutors-allocation'] = outputData['fourth'];
+        jsonData['admins-allocation'] = outputData['fifth'];
+
+        return jsonData;
+      }),
+      map((jsonData: {}) => {
+        this.dataFile = <DataFile>{teamStructure: this.extractTeamStructure(jsonData)};
+        return jsonData;
+      })
+    );
+  }
+
+  /**
+   *
+   * @param csvInput - string containing csv data.
+   * @return Subject<{}> - that tracks the changes to admin data
+   *                       in JSON format.
+   */
+  parseAdminAllocation(csvInput: string): {} {
+    const NAME = 'name';
+    const TEAM = 'team';
+
+    const admins = {};
+    let parsedCSV: [{}];
+    parsedCSV = this.csvParser(csvInput);
+
+    parsedCSV.forEach(entry => {
+      if (entry[NAME] in admins) {
+        const currAdmin = admins[entry[NAME]];
+        currAdmin[entry[TEAM]] = 'true';
+        admins[entry[NAME]] = currAdmin;
+      } else {
+        const newAdmin = {};
+        newAdmin[entry[TEAM]] = 'true';
+        admins[entry[NAME]] = newAdmin;
+      }
+    });
+
+    return admins;
+  }
+
+  /**
+   *
+   * @param csvInput - string containing csv data.
+   * @return Subject<{}> - that tracks the changes to student data
+   *                       in JSON format.
+   */
+  parseTutorAllocation(csvInput: string): {} {
+    const NAME = 'name';
+    const TEAM = 'team';
+
+    const tutors = {};
+    let parsedCSV: [{}];
+    parsedCSV = this.csvParser(csvInput);
+
+    parsedCSV.forEach(entry => {
+      if (entry[NAME] in tutors) {
+        const currTutor = tutors[entry[NAME]];
+        currTutor[entry[TEAM]] = 'true';
+        tutors[entry[NAME]] = currTutor;
+      } else {
+        const newTutor = {};
+        newTutor[entry[TEAM]] = 'true';
+        tutors[entry[NAME]] = newTutor;
+      }
+    });
+
+    return tutors;
+  }
+
+  /**
+   *
+   * @param csvInput - string containing csv data.
+   * @return Subject<{}> - that tracks the changes to student data
+   *                       in JSON format.
+   */
+  parseStudentAllocation(csvInput: string): {} {
+    const TEAM = 'team';
+    const TEAM_ID = 'teamId';
+    const NAME = 'member';
+
+    const students = {};
+    let parsedCSV: [{}];
+    parsedCSV = this.csvParser(csvInput);
+
+    parsedCSV.forEach(entry => {
+      const newStudent = {};
+      newStudent[TEAM_ID] = entry[TEAM];
+      students[entry[NAME]] = newStudent;
+    });
+
+    return students;
+  }
+
+  /**
+   *
+   * @param csvInput - string containing csv data.
+   * @return Subject<{}> - that tracks the changes to team data
+   *                       in JSON format.
+   */
+  parseTeamStructureData(csvInput: string): {} {
+    const TEAM = 'team';
+    const NAME = 'member';
+
+    const teams = {};
+    let parsedCSV: [{}];
+    parsedCSV = this.csvParser(csvInput);
+
+    parsedCSV.forEach(entry => {
+      if (entry[TEAM] in teams) {
+        const currTeam = teams[entry[TEAM]];
+        currTeam[entry[NAME]] = 'true';
+        teams[entry[TEAM]] = currTeam;
+      } else {
+        const newTeam = {};
+        newTeam[entry[NAME]] = 'true';
+        teams[entry[TEAM]] = newTeam;
+      }
+    });
+
+    return teams;
+  }
+
+  /**
+   * Parses the csv data containing information on
+   * user roles into a readable json format.
+   * @param csvInput - string containing csv data.
+   * @return Subject<{}> - that tracks the changes to roles data
+   *                       in JSON format.
+   */
+  parseRolesData(csvInput: string): {} {
+    const ROLE = 'role';
+    const NAME = 'member';
+    const ROLE_STUDENT = 'student';
+    const ROLE_TUTOR = 'tutor';
+    const ROLE_ADMIN = 'admin';
+
+    const roles = {
+      'students': {},
+      'tutors' : {},
+      'admins' : {}
+    };
+    const students = {};
+    const tutors = {};
+    const admins = {};
+    let parsedCSV: [{}];
+    parsedCSV = this.csvParser(csvInput);
+
+    parsedCSV.forEach(entry => {
+      if (entry[ROLE] === ROLE_STUDENT) {
+        students[entry[NAME]] = 'true';
+      } else if (entry[ROLE] === ROLE_TUTOR) {
+        tutors[entry[NAME]] = 'true';
+      } else if (entry[ROLE] === ROLE_ADMIN) {
+        admins[entry[NAME]] = 'true';
+      }
+    });
+
+    roles['students'] = students;
+    roles['tutors'] = tutors;
+    roles['admins'] = admins;
+
+    return roles;
+  }
+
+  /**
+   * Converts the input csv information to an array of
+   * objects syncrhonously. Each object's values are
+   * marked by the respective csv table headers.
+   * @param csvText - csv information.
+   * @return - Subjects that tracks the parsed data.
+   */
+  csvParser(csvText: string): [{}] {
+    return parse(csvText, {
+      columns: true
+    });
   }
 
   getTeam(teamId: string): Team {

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -17,8 +17,8 @@ export class DataService {
 
   getDataFile(): Observable<{}> {
     return this.githubService.fetchDataFile().pipe(
-      map((allCsvData: {}) => {
-        return this.mergeCsvData(allCsvData);
+      map((allCsvDataWrapper: {}) => {
+        return this.constructData(allCsvDataWrapper);
       }),
       map((jsonData: {}) => {
         this.dataFile = <DataFile>{
@@ -31,22 +31,18 @@ export class DataService {
   /**
    * Merges all parsed Csv Data into a single readable JSON
    * format.
-   * @param allCsvData - Object containing strings of csv data.
+   * @param allCsvDataWrapper - Object containing strings of csv data.
    * @return jsonData - Object representing merged data file.
    */
-  mergeCsvData(allCsvData: {}): {} {
+  constructData(allCsvDataWrapper: {}): {} {
     const jsonData: {} = {};
+    const allCsvData: string = allCsvDataWrapper['data'];
 
-    jsonData['roles'] =
-      this.parseRolesData(allCsvData['roles']);
-    jsonData['team-structure'] =
-      this.parseTeamStructureData(allCsvData['teamStructure']);
-    jsonData['students-allocation'] =
-      this.parseStudentAllocation(allCsvData['teamStructure']);
-    jsonData['tutors-allocation'] =
-      this.parseTutorAllocation(allCsvData['tutorsAllocation']);
-    jsonData['admins-allocation'] =
-      this.parseAdminAllocation(allCsvData['adminsAllocation']);
+    jsonData['roles'] = this.parseRolesData(allCsvData);
+    jsonData['team-structure'] = this.parseTeamStructureData(allCsvData);
+    jsonData['students-allocation'] = this.parseStudentAllocation(allCsvData);
+    jsonData['tutors-allocation'] = this.parseTutorAllocation(allCsvData);
+    jsonData['admins-allocation'] = this.parseAdminAllocation(allCsvData);
 
     return jsonData;
   }

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -91,15 +91,9 @@ export class DataService {
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       if (entry[ROLE] === UserRole.Tutor.toLowerCase()) {
-        if (entry[NAME] in tutors) {
-          const currTutor = tutors[entry[NAME]];
-          currTutor[entry[TEAM]] = 'true';
-          tutors[entry[NAME]] = currTutor;
-        } else {
-          const newTutor = {};
-          newTutor[entry[TEAM]] = 'true';
-          tutors[entry[NAME]] = newTutor;
-        }
+        const tutor = entry[NAME] in tutors ? tutors[entry[NAME]] : {};
+        tutor[entry[TEAM]] = 'true';
+        tutors[entry[NAME]] = tutor;
       }
     });
 
@@ -155,15 +149,9 @@ export class DataService {
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       if (entry[ROLE] === UserRole.Student.toLowerCase()) {
-        if (entry[TEAM] in teams) {
-          const currTeam = teams[entry[TEAM]];
-          currTeam[entry[NAME]] = 'true';
-          teams[entry[TEAM]] = currTeam;
-        } else {
-          const newTeam = {};
-          newTeam[entry[NAME]] = 'true';
-          teams[entry[TEAM]] = newTeam;
-        }
+        const team = entry[TEAM] in teams ? teams[entry[TEAM]] : {};
+        team[entry[NAME]] = 'true';
+        teams[entry[TEAM]] = team;
       }
     });
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -17,49 +17,48 @@ export class DataService {
 
   getDataFile(): Observable<{}> {
     return this.githubService.fetchDataFile().pipe(
-      map(allCsvData => {
-
-        let roles: {};
-        let teams: {};
-        let studentAllocations: {};
-        let tutorsAllocations: {};
-        let adminsAllocations: {};
-        roles = this.parseRolesData(allCsvData['first']);
-        teams = this.parseTeamStructureData(allCsvData['second']);
-        studentAllocations = this.parseStudentAllocation(allCsvData['second']);
-        tutorsAllocations = this.parseTutorAllocation(allCsvData['third']);
-        adminsAllocations = this.parseAdminAllocation(allCsvData['fourth']);
-
-        return [roles, teams, studentAllocations, tutorsAllocations, adminsAllocations];
-      }),
-      map(([first, second, third, fourth, fifth]) => {
-        return {first, second, third, fourth, fifth};
-      }),
-      map(outputData => {
-        const jsonData = {};
-
-        jsonData['roles'] = outputData['first'];
-        jsonData['team-structure'] = outputData['second'];
-        jsonData['students-allocation'] = outputData['third'];
-        jsonData['tutors-allocation'] = outputData['fourth'];
-        jsonData['admins-allocation'] = outputData['fifth'];
-
-        return jsonData;
+      map((allCsvData: {}) => {
+        return this.mergeCsvData(allCsvData);
       }),
       map((jsonData: {}) => {
-        this.dataFile = <DataFile>{teamStructure: this.extractTeamStructure(jsonData)};
+        this.dataFile = <DataFile>{
+          teamStructure: this.extractTeamStructure(jsonData)};
         return jsonData;
       })
     );
   }
 
   /**
-   *
+   * Merges all parsed Csv Data into a single readable JSON
+   * format.
+   * @param allCsvData - Object containing strings of csv data.
+   * @return jsonData - Object representing merged data file.
+   */
+  mergeCsvData(allCsvData: {}): {} {
+    const jsonData: {} = {};
+
+    jsonData['roles'] =
+      this.parseRolesData(allCsvData['roles']);
+    jsonData['team-structure'] =
+      this.parseTeamStructureData(allCsvData['teamStructure']);
+    jsonData['students-allocation'] =
+      this.parseStudentAllocation(allCsvData['teamStructure']);
+    jsonData['tutors-allocation'] =
+      this.parseTutorAllocation(allCsvData['tutorsAllocation']);
+    jsonData['admins-allocation'] =
+      this.parseAdminAllocation(allCsvData['adminsAllocation']);
+
+    return jsonData;
+  }
+
+  /**
+   * Parses the input string containing admin allocation information
+   * into application readable Object.
    * @param csvInput - string containing csv data.
-   * @return Subject<{}> - that tracks the changes to admin data
-   *                       in JSON format.
+   * @return admins - object that represents parsed csv data.
    */
   parseAdminAllocation(csvInput: string): {} {
+    // CSV Headers
     const NAME = 'name';
     const TEAM = 'team';
 
@@ -67,6 +66,7 @@ export class DataService {
     let parsedCSV: [{}];
     parsedCSV = this.csvParser(csvInput);
 
+    // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       if (entry[NAME] in admins) {
         const currAdmin = admins[entry[NAME]];
@@ -83,12 +83,13 @@ export class DataService {
   }
 
   /**
-   *
+   * Parses the input string containing tutor allocation information
+   * into application readable Object.
    * @param csvInput - string containing csv data.
-   * @return Subject<{}> - that tracks the changes to student data
-   *                       in JSON format.
+   * @return admins - object that represents parsed csv data.
    */
   parseTutorAllocation(csvInput: string): {} {
+    // CSV Headers
     const NAME = 'name';
     const TEAM = 'team';
 
@@ -96,6 +97,7 @@ export class DataService {
     let parsedCSV: [{}];
     parsedCSV = this.csvParser(csvInput);
 
+    // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       if (entry[NAME] in tutors) {
         const currTutor = tutors[entry[NAME]];
@@ -112,20 +114,23 @@ export class DataService {
   }
 
   /**
-   *
+   * Parses the input string containing student allocation information
+   * into application readable Object.
    * @param csvInput - string containing csv data.
-   * @return Subject<{}> - that tracks the changes to student data
-   *                       in JSON format.
+   * @return admins - object that represents parsed csv data.
    */
   parseStudentAllocation(csvInput: string): {} {
+    // CSV Headers
     const TEAM = 'team';
+    const NAME = 'name';
+    // Team Notation
     const TEAM_ID = 'teamId';
-    const NAME = 'member';
 
     const students = {};
     let parsedCSV: [{}];
     parsedCSV = this.csvParser(csvInput);
 
+    // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       const newStudent = {};
       newStudent[TEAM_ID] = entry[TEAM];
@@ -136,19 +141,21 @@ export class DataService {
   }
 
   /**
-   *
+   * Parses the input string containing team structure information
+   * into application readable Object.
    * @param csvInput - string containing csv data.
-   * @return Subject<{}> - that tracks the changes to team data
-   *                       in JSON format.
+   * @return admins - object that represents parsed csv data.
    */
   parseTeamStructureData(csvInput: string): {} {
+    // CSV Headers
     const TEAM = 'team';
-    const NAME = 'member';
+    const NAME = 'name';
 
     const teams = {};
     let parsedCSV: [{}];
     parsedCSV = this.csvParser(csvInput);
 
+    // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
       if (entry[TEAM] in teams) {
         const currTeam = teams[entry[TEAM]];
@@ -165,36 +172,30 @@ export class DataService {
   }
 
   /**
-   * Parses the csv data containing information on
-   * user roles into a readable json format.
+   * Parses the input string containing roles information
+   * into application readable Object.
    * @param csvInput - string containing csv data.
-   * @return Subject<{}> - that tracks the changes to roles data
-   *                       in JSON format.
+   * @return admins - object that represents parsed csv data.
    */
   parseRolesData(csvInput: string): {} {
+    // CSV Headers
     const ROLE = 'role';
     const NAME = 'member';
-    const ROLE_STUDENT = 'student';
-    const ROLE_TUTOR = 'tutor';
-    const ROLE_ADMIN = 'admin';
 
-    const roles = {
-      'students': {},
-      'tutors' : {},
-      'admins' : {}
-    };
+    const roles = {};
     const students = {};
     const tutors = {};
     const admins = {};
     let parsedCSV: [{}];
     parsedCSV = this.csvParser(csvInput);
 
+    // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === ROLE_STUDENT) {
+      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
         students[entry[NAME]] = 'true';
-      } else if (entry[ROLE] === ROLE_TUTOR) {
+      } else if (entry[ROLE] === UserRole.Tutor.toLowerCase()) {
         tutors[entry[NAME]] = 'true';
-      } else if (entry[ROLE] === ROLE_ADMIN) {
+      } else if (entry[ROLE] === UserRole.Admin.toLowerCase()) {
         admins[entry[NAME]] = 'true';
       }
     });

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -56,7 +56,7 @@ export class DataService {
   parseAdminAllocation(csvInput: string): {} {
     // CSV Headers
     const NAME = 'name';
-    const TEAM = 'team';
+    const ROLE = 'role';
 
     const admins = {};
     let parsedCSV: [{}];
@@ -64,14 +64,8 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[NAME] in admins) {
-        const currAdmin = admins[entry[NAME]];
-        currAdmin[entry[TEAM]] = 'true';
-        admins[entry[NAME]] = currAdmin;
-      } else {
-        const newAdmin = {};
-        newAdmin[entry[TEAM]] = 'true';
-        admins[entry[NAME]] = newAdmin;
+      if (entry[ROLE] === UserRole.Admin.toLowerCase()) {
+        admins[entry[NAME]] = {};
       }
     });
 
@@ -88,6 +82,7 @@ export class DataService {
     // CSV Headers
     const NAME = 'name';
     const TEAM = 'team';
+    const ROLE = 'role';
 
     const tutors = {};
     let parsedCSV: [{}];
@@ -95,14 +90,16 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[NAME] in tutors) {
-        const currTutor = tutors[entry[NAME]];
-        currTutor[entry[TEAM]] = 'true';
-        tutors[entry[NAME]] = currTutor;
-      } else {
-        const newTutor = {};
-        newTutor[entry[TEAM]] = 'true';
-        tutors[entry[NAME]] = newTutor;
+      if (entry[ROLE] === UserRole.Tutor.toLowerCase()) {
+        if (entry[NAME] in tutors) {
+          const currTutor = tutors[entry[NAME]];
+          currTutor[entry[TEAM]] = 'true';
+          tutors[entry[NAME]] = currTutor;
+        } else {
+          const newTutor = {};
+          newTutor[entry[TEAM]] = 'true';
+          tutors[entry[NAME]] = newTutor;
+        }
       }
     });
 
@@ -119,6 +116,7 @@ export class DataService {
     // CSV Headers
     const TEAM = 'team';
     const NAME = 'name';
+    const ROLE = 'role';
     // Team Notation
     const TEAM_ID = 'teamId';
 
@@ -128,9 +126,11 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      const newStudent = {};
-      newStudent[TEAM_ID] = entry[TEAM];
-      students[entry[NAME]] = newStudent;
+      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
+        const newStudent = {};
+        newStudent[TEAM_ID] = entry[TEAM];
+        students[entry[NAME]] = newStudent;
+      }
     });
 
     return students;
@@ -146,6 +146,7 @@ export class DataService {
     // CSV Headers
     const TEAM = 'team';
     const NAME = 'name';
+    const ROLE = 'role';
 
     const teams = {};
     let parsedCSV: [{}];
@@ -153,14 +154,16 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[TEAM] in teams) {
-        const currTeam = teams[entry[TEAM]];
-        currTeam[entry[NAME]] = 'true';
-        teams[entry[TEAM]] = currTeam;
-      } else {
-        const newTeam = {};
-        newTeam[entry[NAME]] = 'true';
-        teams[entry[TEAM]] = newTeam;
+      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
+        if (entry[TEAM] in teams) {
+          const currTeam = teams[entry[TEAM]];
+          currTeam[entry[NAME]] = 'true';
+          teams[entry[TEAM]] = currTeam;
+        } else {
+          const newTeam = {};
+          newTeam[entry[NAME]] = 'true';
+          teams[entry[TEAM]] = newTeam;
+        }
       }
     });
 

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -180,7 +180,7 @@ export class DataService {
   parseRolesData(csvInput: string): {} {
     // CSV Headers
     const ROLE = 'role';
-    const NAME = 'member';
+    const NAME = 'name';
 
     const roles = {};
     const students = {};

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -144,77 +144,30 @@ export class GithubService {
     );
   }
 
-  parseRolesData(csvInput: string): {} {
-    const CSV_HEADER_USER_TYPE = 'role';
-    const CSV_HEADER_USER_NAME = 'member';
-
-    const roles = {
-      'roles' : {
-        'students': {},
-        'tutors' : {},
-        'admins' : {}
-      }
-    };
-    const students = {};
-    const tutors = {};
-    const admins = {};
-    const rolesOutput = this.csvToObject(csvInput);
-
-    rolesOutput.forEach(entry => {
-      if (entry[CSV_HEADER_USER_TYPE] === 'student') {
-        students[entry[CSV_HEADER_USER_NAME]] = 'true';
-      } else if (entry[CSV_HEADER_USER_TYPE] === 'tutor') {
-        tutors[entry[CSV_HEADER_USER_NAME]] = 'true';
-      } else {
-        admins[entry[CSV_HEADER_USER_NAME]] = 'true';
-      }
-    });
-
-    roles['roles']['students'] = students;
-    roles['roles']['tutors'] = tutors;
-    roles['roles']['admins'] = admins;
-
-    return roles;
-  }
-
   fetchDataFile(): Observable<{}> {
     // roles information
-    from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'})).subscribe(resp => {
-      // const parser = require('csv-parse');
-      console.log(this.parseRolesData(atob(resp['data']['content'])));
-    });
-    return from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
-      console.log(JSON.parse(atob(resp['data']['content'])));
-      return JSON.parse(atob(resp['data']['content']));
-    }));
-  }
-
-  /**
-   * Converts the input csv information to an array of
-   * objects marked by the header values of the csv.
-   * @param csvText - csv information.
-   * @return - array of objects representing input csv info.
-   */
-  csvToObject(csvText) {
-    // Split all the text into seperate lines on new lines and carriage return feeds
-    const allTextLines = csvText.split(/\r\n|\n/);
-    // Split per line on tabs and commas
-    const headers = allTextLines[0].split(/\t|,/);
-    const entries = [];
-
-    for (let i = 1; i < allTextLines.length; i++) {
-
-      const data = allTextLines[i].split(/\t|,/);
-
-      if (data.length === headers.length) {
-
-        const location = { 'roles' : data[0], 'members' : data[1] };
-        entries.push(location);
-
-      }
-
-    }
-    return entries;
+    return forkJoin(
+      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'}))
+        .pipe(map(rawData => atob(rawData['data']['content']))),
+      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'teamstructure.csv'}))
+        .pipe(map(rawData => atob(rawData['data']['content']))),
+      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'tutorsallocation.csv'}))
+        .pipe(map(rawData => atob(rawData['data']['content']))),
+      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'adminsallocation.csv'}))
+        .pipe(map(rawData => atob(rawData['data']['content'])))
+    ).pipe(
+      map(([first, second, third, fourth]) => {
+        return {first, second, third, fourth};
+      })
+    );
+    // from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'})).subscribe(resp => {
+    //   this.parseRolesData(atob(resp['data']['content'])).subscribe(
+    //     output => console.log(output)
+    //   );
+    // });
+    // return from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
+    //   return JSON.parse(atob(resp['data']['content']));
+    // }));
   }
 
   private getNumberOfIssuePages(filter?: {}): Observable<number> {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -156,8 +156,8 @@ export class GithubService {
       from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'adminsallocation.csv'}))
         .pipe(map(rawData => atob(rawData['data']['content'])))
     ).pipe(
-      map(([first, second, third, fourth]) => {
-        return {first, second, third, fourth};
+      map(([roles, teamStructure, tutorsAllocation, adminsAllocation]) => {
+        return {roles, teamStructure, tutorsAllocation, adminsAllocation};
       })
     );
     // from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'})).subscribe(resp => {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -147,27 +147,13 @@ export class GithubService {
   fetchDataFile(): Observable<{}> {
     // roles information
     return forkJoin(
-      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'}))
-        .pipe(map(rawData => atob(rawData['data']['content']))),
-      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'teamstructure.csv'}))
-        .pipe(map(rawData => atob(rawData['data']['content']))),
-      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'tutorsallocation.csv'}))
-        .pipe(map(rawData => atob(rawData['data']['content']))),
-      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'adminsallocation.csv'}))
+      from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.csv'}))
         .pipe(map(rawData => atob(rawData['data']['content'])))
     ).pipe(
-      map(([roles, teamStructure, tutorsAllocation, adminsAllocation]) => {
-        return {roles, teamStructure, tutorsAllocation, adminsAllocation};
+      map(([data]) => {
+        return {data};
       })
     );
-    // from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'})).subscribe(resp => {
-    //   this.parseRolesData(atob(resp['data']['content'])).subscribe(
-    //     output => console.log(output)
-    //   );
-    // });
-    // return from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
-    //   return JSON.parse(atob(resp['data']['content']));
-    // }));
   }
 
   private getNumberOfIssuePages(filter?: {}): Observable<number> {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import {map, mergeMap} from 'rxjs/operators';
-import {forkJoin, from, Observable } from 'rxjs';
+import {forkJoin, from, Observable} from 'rxjs';
 import {githubPaginatorParser} from '../../shared/lib/github-paginator-parser';
 import {IssueComment} from '../models/comment.model';
 const Octokit = require('@octokit/rest');
@@ -145,6 +145,9 @@ export class GithubService {
   }
 
   fetchDataFile(): Observable<{}> {
+    from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'roles.csv'})).subscribe(resp => {
+      console.log(atob(resp['data']['content']));
+    });
     return from(octokit.repos.getContents({owner: ORG_NAME, repo: DATA_REPO, path: 'data.json'})).pipe(map((resp) => {
       return JSON.parse(atob(resp['data']['content']));
     }));

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import {map, mergeMap} from 'rxjs/operators';
-import {forkJoin, from, Observable} from 'rxjs';
-import {githubPaginatorParser} from '../../shared/lib/github-paginator-parser';
-import {IssueComment} from '../models/comment.model';
+import { map, mergeMap } from 'rxjs/operators';
+import { forkJoin, from, Observable } from 'rxjs';
+import { githubPaginatorParser } from '../../shared/lib/github-paginator-parser';
+import { IssueComment } from '../models/comment.model';
 const Octokit = require('@octokit/rest');
 
 


### PR DESCRIPTION
Fixes #39 .

Application no longer imports the `data.json` file from the `public_data` repository.
It now looks for 4 `.csv` files which are:
- [roles.csv](https://github.com/CATcher-org/public_data/blob/master/roles.csv)
- [teamstructure.csv](https://github.com/CATcher-org/public_data/blob/master/teamstructure.csv)
- [tutorsallocation.csv](https://github.com/CATcher-org/public_data/blob/master/tutorsallocation.csv)
- [adminsallocation.csv](https://github.com/CATcher-org/public_data/blob/master/adminsallocation.csv)

The **`headers`** **_must_** follow the above templates, mainly using `name`, `team` & `role` for the parsing to work correctly. Internally the `.csv` files are retrieved, converted to an app readable `JSON` format and then passed along as normal.