### PR TITLE
Fix bug for view in browser button

### DIFF
--- a/src/app/phase2/phase2.component.ts
+++ b/src/app/phase2/phase2.component.ts
@@ -3,6 +3,7 @@ import {UserService} from '../core/services/user.service';
 import {IssuesFilter} from '../core/models/issue.model';
 import {Phase} from '../core/services/phase.service';
 import {DataService} from '../core/services/data.service';
+import { IssueService } from '../core/services/issue.service';
 
 @Component({
   selector: 'app-phase2',
@@ -12,9 +13,11 @@ import {DataService} from '../core/services/data.service';
 export class Phase2Component implements OnInit {
   public teamFilter = 'All Teams';
 
-  constructor(public userService: UserService, private dataService: DataService) {}
+  constructor(public userService: UserService, private dataService: DataService, private issueService: IssueService) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.issueService.setIssueTeamFilter(this.teamFilter);
+  }
 
   get teamList(): string[] {
     const teams = this.dataService.getTeams();

--- a/src/app/phase3/phase3.component.ts
+++ b/src/app/phase3/phase3.component.ts
@@ -30,6 +30,7 @@ export class Phase3Component implements OnInit {
               private dataService: DataService) { }
 
   ngOnInit() {
+    this.issueService.setIssueTeamFilter(this.teamFilter);
     this.issuesDataSource = new IssuesDataTable(this.issueService, this.errorHandlingService, this.sort,
       this.paginator, this.displayedColumns);
     this.issuesDataSource.loadIssues();

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -48,7 +48,7 @@ export class HeaderComponent implements OnInit {
   needToShowOpenUrlButton(): boolean {
     return this.phaseService.currentPhase === Phase.phase1 ||
     this.userService.currentUser.role === UserRole.Student ||
-    this.issueService.getIssueTeamFilter() !== 'All Teams';
+    (this.issueService.getIssueTeamFilter() !== 'All Teams' || this.router.url.includes('/issues'));
   }
 
   goBack() {


### PR DESCRIPTION
Fix bug where the button don't appear in individual Issues page when the team filter is "All Teams".

![image](https://user-images.githubusercontent.com/6972112/59652666-4ee72e80-91c1-11e9-8644-676cd28e5b66.png)
![image](https://user-images.githubusercontent.com/6972112/59652756-b00f0200-91c1-11e9-97f3-e908eb6bc822.png)


Also, set the `issueService.issueTeamFilter` to the default team filter when the back button is pressed from the Issues page back to the "main" page for consistency.

![image](https://user-images.githubusercontent.com/6972112/59652699-70e0b100-91c1-11e9-976e-700116223627.png)
![image](https://user-images.githubusercontent.com/6972112/59652717-83f38100-91c1-11e9-9ad3-7ba5413c87f5.png)
![image](https://user-images.githubusercontent.com/6972112/59652726-94a3f700-91c1-11e9-85a8-153e2490dfd0.png)

