### PR TITLE
Dynamic label text color depending on background color

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -6,7 +6,12 @@ import { Observable } from 'rxjs';
 import { SEVERITY_ORDER } from '../../core/models/issue.model';
 import { User } from '../models/user.model';
 
-const COLOR_DARKNESS_THRESHOLD = 0.199; // The threshold to decide if color is dark or light
+/* The threshold to decide if color is dark or light.
+A higher threshold value will result in more colors determined to be "dark".
+W3C recommendation is 0.179, but 0.184 is chosen so that some colors (like bright red)
+have white text instead of black. Github labels are also red/white instead of red/black */
+const COLOR_DARKNESS_THRESHOLD = 0.184;
+
 const LIGHT_COLOR = 'FFFFFF'; // Light color for text with dark background
 const DARK_COLOR = '000000'; // Dark color for text with light background
 
@@ -123,8 +128,8 @@ export class LabelService {
     const r = parseInt(color.substring(0, 2), 16);
     const g = parseInt(color.substring(2, 4), 16);
     const b = parseInt(color.substring(4, 6), 16);
-    const uiColors = [r / 255, g / 255, b / 255];
-    const c = uiColors.map((col) => {
+    const rgb = [r / 255, g / 255, b / 255];
+    const c = rgb.map((col) => {
       if (col <= 0.03928) {
         return col / 12.92;
       }
@@ -132,7 +137,7 @@ export class LabelService {
     });
     // Calculate the luminance of the color
     const L = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
-    // A higher threshold value will result in more colors determined to be "dark"
+    // The color is "dark" if the luminance is lower than the threshold
     return (L < COLOR_DARKNESS_THRESHOLD);
   }
 

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -110,16 +110,26 @@ export class LabelService {
   }
 
   /**
-   * Converts the (color) hex value into RGB format
-   * @param hex: the hex value
+   * Choose black or white text color depending on background color
+   * @param bgColor: the color code of the background
    */
-  hexToRgb(hex: string) {
-    const rgbResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return rgbResult ? {
-      r: parseInt(rgbResult[1], 16),
-      g: parseInt(rgbResult[2], 16),
-      b: parseInt(rgbResult[3], 16)
-    } : null;
+  pickTextColorBasedOnBgColorAdvanced(bgColor: string) {
+    const lightColor = 'FFFFFF';
+    const darkColor = '000000';
+    const color = (bgColor.charAt(0) === '#') ? bgColor.substring(1, 7) : bgColor;
+    const r = parseInt(color.substring(0, 2), 16);
+    const g = parseInt(color.substring(2, 4), 16);
+    const b = parseInt(color.substring(4, 6), 16);
+    const uicolors = [r / 255, g / 255, b / 255];
+    const c = uicolors.map((col) => {
+      if (col <= 0.03928) {
+        return col / 12.92;
+      }
+      return Math.pow((col + 0.055) / 1.055, 2.4);
+    });
+    // Threshold for the color
+    const L = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
+    return (L > 0.199) ? darkColor : lightColor;
   }
 
   /**
@@ -129,26 +139,14 @@ export class LabelService {
    * @throws exception if input is an invalid color code
    */
   setLabelStyle(color: string) {
-    let r: string;
-    let g: string;
-    let b: string;
-    const white = '255';
-
-    try {
-      r = this.hexToRgb('#'.concat(color)).r.toString();
-      g = this.hexToRgb('#'.concat(color)).g.toString();
-      b = this.hexToRgb('#'.concat(color)).b.toString();
-    } catch (e) {
-      // Set rgb to white color if hexToRgb returns null
-      r = white;
-      g = white;
-      b = white;
-    }
+    const textColor = this.pickTextColorBasedOnBgColorAdvanced(color);
 
     const styles = {
-      'background-color' : `rgb(${r}, ${g}, ${b}, 0.55)`,
+      'background-color' : `#${color}`,
       'border-radius' : '3px',
       'padding' : '3px',
+      'color' : `#${textColor}`,
+      'font-weight' : '410',
     };
 
     return styles;

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -6,6 +6,8 @@ import { Observable } from 'rxjs';
 import { SEVERITY_ORDER } from '../../core/models/issue.model';
 import { User } from '../models/user.model';
 
+const BGCOLOR_THRESHOLD = 0.199; // The threshold to decide if text color will be black or white
+
 @Injectable({
   providedIn: 'root'
 })
@@ -113,23 +115,24 @@ export class LabelService {
    * Choose black or white text color depending on background color
    * @param bgColor: the color code of the background
    */
-  pickTextColorBasedOnBgColorAdvanced(bgColor: string) {
-    const lightColor = 'FFFFFF';
-    const darkColor = '000000';
+  pickTextColorBasedOnBgColor(bgColor: string) {
+    const lightColor = 'FFFFFF'; // Light text color (white)
+    const darkColor = '000000'; // Dark text color (black)
     const color = (bgColor.charAt(0) === '#') ? bgColor.substring(1, 7) : bgColor;
     const r = parseInt(color.substring(0, 2), 16);
     const g = parseInt(color.substring(2, 4), 16);
     const b = parseInt(color.substring(4, 6), 16);
-    const uicolors = [r / 255, g / 255, b / 255];
-    const c = uicolors.map((col) => {
+    const uiColors = [r / 255, g / 255, b / 255];
+    const c = uiColors.map((col) => {
       if (col <= 0.03928) {
         return col / 12.92;
       }
       return Math.pow((col + 0.055) / 1.055, 2.4);
     });
-    // Threshold for the color
+    // Calculate the luminance of the background color
     const L = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
-    return (L > 0.199) ? darkColor : lightColor;
+    // Higher threshold will result in more labels with light color text
+    return (L > BGCOLOR_THRESHOLD) ? darkColor : lightColor;
   }
 
   /**
@@ -139,7 +142,7 @@ export class LabelService {
    * @throws exception if input is an invalid color code
    */
   setLabelStyle(color: string) {
-    const textColor = this.pickTextColorBasedOnBgColorAdvanced(color);
+    const textColor = this.pickTextColorBasedOnBgColor(color);
 
     const styles = {
       'background-color' : `#${color}`,

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -115,7 +115,7 @@ export class LabelService {
 
    /**
    * Returns true if the given color is considered "dark"
-   * The color is considered "dark" if its luminance is less than BGCOLOR_THRESHOLD
+   * The color is considered "dark" if its luminance is less than COLOR_DARKNESS_THRESHOLD
    * @param inputColor: the color
    */
   isDarkColor(inputColor: string): boolean {

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import { SEVERITY_ORDER } from '../../core/models/issue.model';
 import { User } from '../models/user.model';
 
-const BGCOLOR_THRESHOLD = 0.199; // The threshold to decide if color is dark or light
+const COLOR_DARKNESS_THRESHOLD = 0.199; // The threshold to decide if color is dark or light
 const LIGHT_COLOR = 'FFFFFF'; // Light color for text with dark background
 const DARK_COLOR = '000000'; // Dark color for text with light background
 
@@ -113,13 +113,12 @@ export class LabelService {
     this.labelColorMap.clear();
   }
 
-  /**
-   * Determines if the color code provided is "dark" by calculating its luminance and
-   * comparing it with a constant threshold value
-   * @param inputColor: the color code input
-   * @return true if the luminance is less than the threshold (darker), false otherwise
+   /**
+   * Returns true if the given color is considered "dark"
+   * The color is considered "dark" if its luminance is less than BGCOLOR_THRESHOLD
+   * @param inputColor: the color
    */
-  isDarkColor(inputColor: string) {
+  isDarkColor(inputColor: string): boolean {
     const color = (inputColor.charAt(0) === '#') ? inputColor.substring(1, 7) : inputColor;
     const r = parseInt(color.substring(0, 2), 16);
     const g = parseInt(color.substring(2, 4), 16);
@@ -134,7 +133,7 @@ export class LabelService {
     // Calculate the luminance of the color
     const L = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
     // A higher threshold value will result in more colors determined to be "dark"
-    return (L < BGCOLOR_THRESHOLD);
+    return (L < COLOR_DARKNESS_THRESHOLD);
   }
 
   /**
@@ -146,11 +145,7 @@ export class LabelService {
   setLabelStyle(color: string) {
     let textColor: string;
 
-    if (this.isDarkColor(color)) {
-      textColor = LIGHT_COLOR;
-    } else {
-      textColor = DARK_COLOR;
-    }
+    textColor = (this.isDarkColor(color)) ? LIGHT_COLOR : DARK_COLOR;
 
     const styles = {
       'background-color' : `#${color}`,

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -9,11 +9,11 @@ import { User } from '../models/user.model';
 /* The threshold to decide if color is dark or light.
 A higher threshold value will result in more colors determined to be "dark".
 W3C recommendation is 0.179, but 0.184 is chosen so that some colors (like bright red)
-have white text instead of black. Github labels are also red/white instead of red/black */
+are considered dark (Github too consider them dark) */
 const COLOR_DARKNESS_THRESHOLD = 0.184;
 
-const LIGHT_COLOR = 'FFFFFF'; // Light color for text with dark background
-const DARK_COLOR = '000000'; // Dark color for text with light background
+const COLOR_DARK_TEXT  = '000000'; // Dark color for text with light background
+const COLOR_LIGHT_TEXT  = 'FFFFFF'; // Light color for text with dark background
 
 @Injectable({
   providedIn: 'root'
@@ -124,21 +124,21 @@ export class LabelService {
    * @param inputColor: the color
    */
   isDarkColor(inputColor: string): boolean {
-    const color = (inputColor.charAt(0) === '#') ? inputColor.substring(1, 7) : inputColor;
-    const r = parseInt(color.substring(0, 2), 16);
-    const g = parseInt(color.substring(2, 4), 16);
-    const b = parseInt(color.substring(4, 6), 16);
-    const rgb = [r / 255, g / 255, b / 255];
-    const c = rgb.map((col) => {
+    const COLOR = (inputColor.charAt(0) === '#') ? inputColor.substring(1, 7) : inputColor;
+    const R = parseInt(COLOR.substring(0, 2), 16);
+    const G = parseInt(COLOR.substring(2, 4), 16);
+    const B = parseInt(COLOR.substring(4, 6), 16);
+    const RGB = [R / 255, G / 255, B / 255];
+    const LINEAR_RGB = RGB.map((col) => {
       if (col <= 0.03928) {
         return col / 12.92;
       }
       return Math.pow((col + 0.055) / 1.055, 2.4);
     });
     // Calculate the luminance of the color
-    const L = (0.2126 * c[0]) + (0.7152 * c[1]) + (0.0722 * c[2]);
+    const LUMINANCE = (0.2126 * LINEAR_RGB[0]) + (0.7152 * LINEAR_RGB[1]) + (0.0722 * LINEAR_RGB[2]);
     // The color is "dark" if the luminance is lower than the threshold
-    return (L < COLOR_DARKNESS_THRESHOLD);
+    return (LUMINANCE < COLOR_DARKNESS_THRESHOLD);
   }
 
   /**
@@ -150,7 +150,7 @@ export class LabelService {
   setLabelStyle(color: string) {
     let textColor: string;
 
-    textColor = (this.isDarkColor(color)) ? LIGHT_COLOR : DARK_COLOR;
+    textColor = (this.isDarkColor(color)) ? COLOR_LIGHT_TEXT : COLOR_DARK_TEXT;
 
     const styles = {
       'background-color' : `#${color}`,

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -112,8 +112,9 @@ export class LabelService {
   }
 
   /**
-   * Choose black or white text color depending on background color
+   * Chooses light or dark text color depending on background color
    * @param bgColor: the color code of the background
+   * @return a string with light or dark color code
    */
   pickTextColorBasedOnBgColor(bgColor: string) {
     const lightColor = 'FFFFFF'; // Light text color (white)

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -138,7 +138,7 @@ export class LabelService {
     // Calculate the luminance of the color
     const LUMINANCE = (0.2126 * LINEAR_RGB[0]) + (0.7152 * LINEAR_RGB[1]) + (0.0722 * LINEAR_RGB[2]);
     // The color is "dark" if the luminance is lower than the threshold
-    return (LUMINANCE < COLOR_DARKNESS_THRESHOLD);
+    return LUMINANCE < COLOR_DARKNESS_THRESHOLD;
   }
 
   /**
@@ -150,7 +150,7 @@ export class LabelService {
   setLabelStyle(color: string) {
     let textColor: string;
 
-    textColor = (this.isDarkColor(color)) ? COLOR_LIGHT_TEXT : COLOR_DARK_TEXT;
+    textColor = this.isDarkColor(color) ? COLOR_LIGHT_TEXT : COLOR_DARK_TEXT;
 
     const styles = {
       'background-color' : `#${color}`,


### PR DESCRIPTION
Similar to how GitHub handles label color.

Removed the `hexToRgb()` function as it was only used in `setLabelStyle()`

![image](https://user-images.githubusercontent.com/6972112/59661070-98914280-91dc-11e9-9f56-d043b6bfb96a.png)
