### PR TITLE
Fix Profiles Bug

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -50,13 +50,13 @@ export class AuthComponent implements OnInit, OnDestroy {
    * Informs user of missing profiles file.
    * @param profilesDetails - profiles file information.
    */
-  onProfilesMissing(profilesDetails: {}): void {
-    this.profileLocationPrompt = profilesDetails['visible']
+  onProfilesMissing(profilesDetails: {visible: boolean, fileName: string, fileDirectory: string}): void {
+    this.profileLocationPrompt = profilesDetails.visible
       ? 'No custom '
-        .concat(profilesDetails['fileName'])
-        .concat(' file found in ')
-        .concat(profilesDetails['fileDirectory'])
-        .concat(' .')
+          .concat(profilesDetails['fileName'])
+          .concat(' file found in ')
+          .concat(profilesDetails['fileDirectory'])
+          .concat(' .')
       : '';
   }
 

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -50,8 +50,8 @@ export class AuthComponent implements OnInit, OnDestroy {
    * Informs user of missing profiles file.
    * @param profilesDetails - profiles file information.
    */
-  onProfilesMissing(profilesDetails: {visible: boolean, fileName: string, fileDirectory: string}): void {
-    this.profileLocationPrompt = profilesDetails.visible
+  onProfilesMissing(profilesDetails: {isDirectoryMessageVisible: boolean, fileName: string, fileDirectory: string}): void {
+    this.profileLocationPrompt = profilesDetails.isDirectoryMessageVisible
       ? 'No custom '
           .concat(profilesDetails['fileName'])
           .concat(' file found in ')

--- a/src/app/auth/profiles/profiles.component.ts
+++ b/src/app/auth/profiles/profiles.component.ts
@@ -59,7 +59,7 @@ export class ProfilesComponent implements OnInit {
   @Output() profileDataEmitter: EventEmitter<{}> = new EventEmitter<{}>();
 
   profilesData = {
-    visible: false,
+    isDirectoryMessageVisible: false,
     fileName: null,
     fileDirectory: null
   };
@@ -101,16 +101,14 @@ export class ProfilesComponent implements OnInit {
    * Processes the selected profiles JSON file.
    */
   readProfiles(): void {
-
-    const fileExists: boolean = this.userProfileFileExists(this.filePath);
-
+    const isFileExists: boolean = this.userProfileFileExists(this.filePath);
     // Informing Parent Component (Auth) of file selection
     this.profilesData.fileName = this.PROFILES_FILE_NAME;
     this.profilesData.fileDirectory = this.filePath.split(this.PROFILES_FILE_NAME)[0];
-    this.profilesData.visible = !fileExists;
+    this.profilesData.isDirectoryMessageVisible = !isFileExists;
     this.profileDataEmitter.emit(this.profilesData);
 
-    if (fileExists) {
+    if (isFileExists) {
       try {
         this.profiles = JSON.parse(this.fs.readFileSync(this.filePath))['profiles'];
         this.assertProfilesValidity(this.profiles);

--- a/src/app/auth/profiles/profiles.component.ts
+++ b/src/app/auth/profiles/profiles.component.ts
@@ -59,9 +59,9 @@ export class ProfilesComponent implements OnInit {
   @Output() profileDataEmitter: EventEmitter<{}> = new EventEmitter<{}>();
 
   profilesData = {
-    'visible': false,
-    'fileName': null,
-    'fileDirectory': null
+    visible: false,
+    fileName: null,
+    fileDirectory: null
   };
 
   constructor(public errorDialog: MatDialog) { }
@@ -101,22 +101,26 @@ export class ProfilesComponent implements OnInit {
    * Processes the selected profiles JSON file.
    */
   readProfiles(): void {
+
+    const fileExists: boolean = this.userProfileFileExists(this.filePath);
+
     // Informing Parent Component (Auth) of file selection
     this.profilesData.fileName = this.PROFILES_FILE_NAME;
     this.profilesData.fileDirectory = this.filePath.split(this.PROFILES_FILE_NAME)[0];
-    this.profilesData.visible = !this.userProfileFileExists(this.filePath);
+    this.profilesData.visible = !fileExists;
     this.profileDataEmitter.emit(this.profilesData);
 
-    try {
-      this.profiles = JSON.parse(this.fs.readFileSync(this.filePath))['profiles'];
-      this.assertProfilesValidity(this.profiles);
-    } catch (e) {
-      console.log(e);
-      setTimeout(() => {
+    if (fileExists) {
+      try {
+        this.profiles = JSON.parse(this.fs.readFileSync(this.filePath))['profiles'];
+        this.assertProfilesValidity(this.profiles);
+      } catch (e) {
+        console.log(e);
+        setTimeout(() => {
           this.profiles = undefined;
           this.openErrorDialog();
-          this.selectProfile(this.blankProfile);
-      });
+        });
+      }
     }
 
     // Set default profile if exists.


### PR DESCRIPTION
Fixes #95 

- Added an `if` statement to prevent the file-read and validation if file does not exist.
- Explicitly stated the object that was being passed to the `onProfilesMissing` function so that it will be clearer to manipulate (if need be) in the future and changing the data structure on either end will cause the IDE to alert the dev that it is not the expected behaviour.