### PR TITLE
Label Color Bug

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -75,7 +75,6 @@ export class AuthService {
     this.phaseService.reset();
     this.dataService.reset();
     this.githubEventService.reset();
-    this.labelService.reset();
     this.titleService.setTitle('CATcher');
     this.issueService.setIssueTeamFilter('All Teams');
 

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -167,12 +167,6 @@ export class LabelService {
     return labelData;
   }
 
-  reset(): void {
-    this.severityLabels.length = 0;
-    this.typeLabels.length = 0;
-    this.responseLabels.length = 0;
-  }
-
    /**
    * Returns true if the given color is considered "dark"
    * The color is considered "dark" if its luminance is less than COLOR_DARKNESS_THRESHOLD


### PR DESCRIPTION
Fixes #97 

Removed legacy code that requires a reset of some parameters in `label.service.ts` since it is no longer relevant and causes the bug mentioned in #97 .