### PR TITLE
Tweak the UI of label dropdowns

### DIFF
--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -5,9 +5,9 @@
 
 <mat-menu #labelList>
   <button mat-menu-item *ngFor="let value of labelValues;" (click)="updateLabel(value.labelValue)"
-          [disabled]="value.labelValue === this.issue[attributeName]"  [ngStyle]="this.labelService.setLabelStyle(value.labelColor)"
-          >
-    <span> {{value.labelValue}}</span>
+          [disabled]="value.labelValue === this.issue[attributeName]">
+        <mat-icon [ngStyle]="{'color': '#' + value.labelColor, 'font-size' : '1.8em'}">stop</mat-icon>
+        <span> {{value.labelValue}}</span>
   </button>
 </mat-menu>
 


### PR DESCRIPTION
Resolves #107 

Added a `mat-icon` to the `mat-menu-item`

![image](https://user-images.githubusercontent.com/6972112/60417159-460b4980-9c12-11e9-8783-7f6fe3573237.png)
![image](https://user-images.githubusercontent.com/6972112/60417169-4c99c100-9c12-11e9-8592-e1a88af8558e.png)
![image](https://user-images.githubusercontent.com/6972112/60417175-53283880-9c12-11e9-8158-b1b0c4bd17f3.png)


