### PR TITLE
Align commentor name in headers

### DIFF
--- a/src/app/phase2/new-team-respond/new-team-response.component.html
+++ b/src/app/phase2/new-team-respond/new-team-response.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="newTeamResponseForm" #myForm="ngForm" (ngSubmit)="submitNewTeamResponse(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span style="vertical-align: middle; margin-left: 10px"> Post your team's response here. </span>
+      <span style="vertical-align: middle; margin-left: 5px"> Post your team's response here. </span>
 
       <div style="float: right;">
         <button type="submit" style="margin-left: 10px" [disabled]="newTeamResponseForm.invalid || isFormPending" mat-button color="primary">Submit</button>

--- a/src/app/phase3/tutor-response/tutor-response.component.html
+++ b/src/app/phase3/tutor-response/tutor-response.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="tutorResponseForm" #myForm="ngForm" (ngSubmit)="submitNewTutorResponseForm(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span style="vertical-align: middle; margin-left: 10px"> Post your response here. </span>
+      <span style="vertical-align: middle; margin-left: 5px"> Post your response here. </span>
 
       <div style="float: right;">
         <button type="submit" style="margin-left: 10px" [disabled]="tutorResponseForm.invalid || isFormPending" mat-button color="primary">Submit</button>

--- a/src/app/shared/issue/description/description.component.html
+++ b/src/app/shared/issue/description/description.component.html
@@ -2,7 +2,7 @@
 <form [formGroup]="issueDescriptionForm" #myForm="ngForm" (ngSubmit)="updateDescription(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span> <span class="bold-name"> Tester </span> posted on {{issue.created_at}}. </span>
+      <span> <strong> Tester </strong> posted on {{issue.created_at}}. </span>
       <button mat-button *ngIf="permissions.canEditIssueDescription() && !isEditing" (click)="changeToEditMode()">
         Edit
       </button>

--- a/src/app/shared/issue/response/response.component.html
+++ b/src/app/shared/issue/response/response.component.html
@@ -2,7 +2,7 @@
 <form [formGroup]="responseForm" #myForm="ngForm" (ngSubmit)="updateResponse(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span> <span class="bold-name"> {{POSTER[attributeName]}} </span> {{ACTION[attributeName]}}. </span>
+      <span> <strong> {{POSTER[attributeName]}} </strong> {{ACTION[attributeName]}}. </span>
       <button mat-button *ngIf="canEditIssue() && !isEditing" (click)="changeToEditMode()">
         Edit
       </button>


### PR DESCRIPTION
Fixes #112 

Change `span` to `strong` instead, as having two span causes the text to mis-align.

![image](https://user-images.githubusercontent.com/6972112/60571494-4b010200-9da6-11e9-9783-34571ffdc301.png)
![image](https://user-images.githubusercontent.com/6972112/60571460-40466d00-9da6-11e9-9e67-df2ba1c00f31.png)
![image](https://user-images.githubusercontent.com/6972112/60571515-594f1e00-9da6-11e9-810c-2c2ab802b06d.png)
![image](https://user-images.githubusercontent.com/6972112/60571568-77b51980-9da6-11e9-974d-933506c0ae30.png)

