### PR TITLE
Labels Update

### DIFF
--- a/src/app/core/models/label.model.ts
+++ b/src/app/core/models/label.model.ts
@@ -12,10 +12,13 @@ export class Label {
 
   /**
    * Returns the name of the label with the format of
-   * 'category'.'value' (e.g. severity.Low)
+   * 'category'.'value' (e.g. severity.Low) if a category exists or
+   * 'value' if the category does not exist.
    */
   public getFormattedName(): string {
-    return this.labelCategory + '.' + this.labelValue;
+    return (this.labelCategory === undefined || this.labelCategory === '')
+      ? this.labelValue
+      : (this.labelCategory.concat('.', this.labelValue));
   }
 
   public equals(label: Label) {

--- a/tests/constants/label.constants.ts
+++ b/tests/constants/label.constants.ts
@@ -20,17 +20,17 @@ export const STATUS = 'status';
 // Label color constants
 export const COLOR_BLACK  = '000000';
 export const COLOR_WHITE  = 'FFFFFF';
-export const COLOR_SEVERITY_LOW = 'ffb3b3';
-export const COLOR_SEVERITY_MEDIUM = 'ff6666';
-export const COLOR_SEVERITY_HIGH = 'b30000';
-export const COLOR_TYPE_DOCUMENTATION_BUG = 'ccb3ff';
-export const COLOR_TYPE_FUNCTIONALITY_BUG = '661aff';
-export const COLOR_RESPONSE_ACCEPTED = '80ffcc';
-export const COLOR_RESPONSE_REJECTED = 'ff80b3';
+export const COLOR_SEVERITY_LOW = 'ffcccc';
+export const COLOR_SEVERITY_MEDIUM = 'ff9999';
+export const COLOR_SEVERITY_HIGH = 'ff6666';
+export const COLOR_TYPE_DOCUMENTATION_BUG = 'd966ff';
+export const COLOR_TYPE_FUNCTIONALITY_BUG = '9900cc';
+export const COLOR_RESPONSE_ACCEPTED = '00802b';
+export const COLOR_RESPONSE_REJECTED = 'ff9900';
 export const COLOR_RESPONSE_ISSUE_UNCLEAR = 'ffcc80';
-export const COLOR_RESPONSE_CANNOT_REPRODUCE = 'bfbfbf';
-export const COLOR_STATUS_DONE = 'b3ecff';
-export const COLOR_STATUS_INCOMPLETE = '1ac6ff';
+export const COLOR_RESPONSE_CANNOT_REPRODUCE = 'ffebcc';
+export const COLOR_STATUS_DONE = 'a6a6a6';
+export const COLOR_STATUS_INCOMPLETE = '000000';
 
 // CSS style constants
 export const DARK_BG_LIGHT_TEXT = {


### PR DESCRIPTION
Fixes #91 

- New Labels Added
- Previous Labels Colours Updated
- Label Parsing Method (from API data) now accounts for labels that do not have a category (i.e. `duplicate`)
- `getFormattedName()` now accounts for labels that do not have a category.