### PR TITLE
Link to UserGuide

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -96,9 +96,8 @@ const mainMenuTemplate: Electron.MenuItemConstructorOptions[] = [
     role: 'help',
     submenu: [
       {
-        label: 'Learn More',
-        // TODO: Change below url to course-site / application github site.
-        click () { require('electron').shell.openExternal('https://electronjs.org'); }
+        label: 'User Guide',
+        click () { require('electron').shell.openExternal('https://catcher-org.github.io/'); }
       }
     ]
   }


### PR DESCRIPTION
Fixes #125 

Link to the [User Guide](https://catcher-org.github.io) for the CATcher App which can be accessed on the electron menu.

![image](https://user-images.githubusercontent.com/39243082/61682689-3da3bb80-ad45-11e9-955c-8b39627b2ec7.png)


Source code for the site is in this [repository](https://github.com/CATcher-org/catcher-org.github.io).