### PR TITLE
CommentEditor Toggling

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.css
+++ b/src/app/shared/comment-editor/comment-editor.component.css
@@ -8,6 +8,12 @@
   border-width: 2px;
 }
 
+.highlight-drag-box-disabled {
+  border-style: dashed;
+  border-color: #fb2a5c;
+  border-width: 2px;
+}
+
 .drag-and-drop {
   color: #586069;
   font-size: 13px;

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -18,7 +18,8 @@
           <div class="drag-and-drop">
             <span *ngIf="!isInErrorState"> Attach files by dragging & dropping or select them by clicking here. </span>
             <span *ngIf="isInErrorState" class="error"> {{uploadErrorMessage}} </span>
-            <input #fileInput [accept]="['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip']"
+            <input #fileInput [disabled]="this.commentField.disabled"
+                   [accept]="['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip']"
                    type="file" class="file" (change)="onFileInputUpload($event, fileInput)">
           </div>
         </mat-form-field>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -42,7 +42,11 @@ export class CommentEditorComponent implements OnInit {
     event.stopPropagation();
 
     this.dragActiveCounter++;
-    this.dropArea.nativeElement.classList.add('highlight-drag-box');
+    if (this.commentField.disabled) {
+      this.dropArea.nativeElement.classList.add('highlight-drag-box-disabled');
+    } else {
+      this.dropArea.nativeElement.classList.add('highlight-drag-box');
+    }
   }
 
   // Prevent cursor in textarea from moving when file is dragged over it.
@@ -58,9 +62,13 @@ export class CommentEditorComponent implements OnInit {
   onDrop(event) {
     event.preventDefault();
     event.stopPropagation();
-    const files = event.dataTransfer.files;
     this.removeHighlightBorderStyle();
 
+    if (this.commentField.disabled) {
+      return;
+    }
+
+    const files = event.dataTransfer.files;
     if (files.length > 0) {
       this.readAndUploadFile(files[0]);
       this.commentTextArea.nativeElement.focus();
@@ -189,6 +197,7 @@ export class CommentEditorComponent implements OnInit {
     this.dragActiveCounter--;
     if (this.dragActiveCounter === 0) { // To make sure when dragging over a child element, drop area is still highlight.
       this.dropArea.nativeElement.classList.remove('highlight-drag-box');
+      this.dropArea.nativeElement.classList.remove('highlight-drag-box-disabled');
     }
   }
 }

--- a/src/app/shared/tester-response/tester-response.component.html
+++ b/src/app/shared/tester-response/tester-response.component.html
@@ -26,8 +26,7 @@
         </div>
         <div *ngIf="isEditing">
           <app-comment-editor [commentField]="testerResponseForm.get(i.toString())" [commentForm]="testerResponseForm"
-            (change)="handleChangeOfText($event, response.reasonForDiagreement, i)" [id]="i.toString()"
-            [initialDescription]="response.reasonForDiagreement"></app-comment-editor>
+            (change)="handleChangeOfText($event, response.reasonForDiagreement, i)" [id]="i.toString()"></app-comment-editor>
         </div>
         <br> <markdown data="-------------------"></markdown> <br>
       </div>

--- a/src/app/shared/tester-response/tester-response.component.ts
+++ b/src/app/shared/tester-response/tester-response.component.ts
@@ -72,7 +72,8 @@ export class TesterResponseComponent implements OnInit {
   }
 
   handleChangeOfDisagreeCheckbox(event, disagree, index) {
-    this.issue.testerResponses[index].disagreeCheckbox = '- [' + event.checked ? 'x' : '' + ']' + disagree.substring(5);
+    this.issue.testerResponses[index].disagreeCheckbox = ('- [').concat((event.checked ? 'x' : ' '), '] ', disagree.substring(6));
+    console.log(this.issue.testerResponses[index].disagreeCheckbox);
     this.toggleCommentEditor(index, event.checked);
   }
 

--- a/src/app/shared/tester-response/tester-response.component.ts
+++ b/src/app/shared/tester-response/tester-response.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter, ViewChild } from '@angular/core';
-import { FormGroup, FormBuilder, Validators, NgForm, FormControl } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormControl, AbstractControl } from '@angular/forms';
 import { Issue, STATUS } from '../../core/models/issue.model';
 import { CommentEditorComponent } from '../comment-editor/comment-editor.component';
 import { IssueService } from '../../core/services/issue.service';
@@ -31,7 +31,9 @@ export class TesterResponseComponent implements OnInit {
   ngOnInit() {
     const group: any = {};
     for (let i = 0; i < this.issue.testerResponses.length; i++) {
-      group[i.toString()] = new FormControl(Validators.required);
+      const disabled: boolean = !this.isDisagreeChecked(this.issue.testerResponses[i].disagreeCheckbox);
+      const value: string = this.issue.testerResponses[i].reasonForDiagreement;
+      group[i.toString()] = new FormControl({value: value, disabled: disabled}, Validators.required);
     }
     group['testerResponse'] = [this.issue.testerResponses];
     this.testerResponseForm = this.formBuilder.group(group);
@@ -70,10 +72,17 @@ export class TesterResponseComponent implements OnInit {
   }
 
   handleChangeOfDisagreeCheckbox(event, disagree, index) {
-    if (event.checked) {
-      this.issue.testerResponses[index].disagreeCheckbox = '- [x]' + disagree.substring(5);
+    this.issue.testerResponses[index].disagreeCheckbox = '- [' + event.checked ? 'x' : '' + ']' + disagree.substring(5);
+    this.toggleCommentEditor(index, event.checked);
+  }
+
+  toggleCommentEditor(index: number, isCommentEditorEnabled: boolean) {
+    const control: AbstractControl = this.testerResponseForm.controls[index];
+    if (isCommentEditorEnabled) {
+      control.enable({onlySelf: true});
     } else {
-      this.issue.testerResponses[index].disagreeCheckbox = '- [ ]' + disagree.substring(5);
+      control.disable({onlySelf: false});
+      this.issue.testerResponses[index].reasonForDiagreement = '';
     }
   }
 


### PR DESCRIPTION
Fixes #150 

When the Disagree Checkbox is checked, comment editor behaviour is as per normal.
![image](https://user-images.githubusercontent.com/39243082/61767156-e0c40600-ae15-11e9-81ee-4100a2488622.png)

And when it is not checked, the comment editor is disabled. (User Cannot type into it)
![image](https://user-images.githubusercontent.com/39243082/61767212-1d8ffd00-ae16-11e9-8377-89ba4d755873.png)

Also, if they attempt to drag and drop file inputs, a red border appears and the upload does not take place.
![image](https://user-images.githubusercontent.com/39243082/61767303-73fd3b80-ae16-11e9-8657-9d9209312947.png)

If they key in some text after checking disagree, and then uncheck disagree, the text is temporarily left there but greyed out (should they wish to disagree again) but on submit, the text is ignored if the disagree remains unchecked.
![image](https://user-images.githubusercontent.com/39243082/61767390-ad35ab80-ae16-11e9-8108-aec7c8876e6c.png)

----
⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️ On Submit ⬇️⬇️⬇️⬇️⬇️⬇️⬇️⬇️
----

![image](https://user-images.githubusercontent.com/39243082/61767406-b9216d80-ae16-11e9-967e-932fb20adc30.png)





