### PR TITLE
Migrate bug reporting phase to use the new model

### DIFF
--- a/src/app/core/models/base-issue.model.ts
+++ b/src/app/core/models/base-issue.model.ts
@@ -26,12 +26,12 @@ export class BaseIssue implements Issue {
   status?: string;
   pending?: string;
   unsure?: boolean;
-
-  /** Depending on the phase, teamAssigned attribute can be derived from Github's assignee feature OR from the Github's issue description */
   teamAssigned?: Team;
 
-  /** Fields derived from parsing of Github's issue description */
+  /** Depending on the phase, assignees attribute can be derived from Github's assignee feature OR from the Github's issue description */
   assignees?: string[];
+
+  /** Fields derived from parsing of Github's issue description */
   duplicateOf?: number;
   todoList?: string[];
   teamResponse?: string;

--- a/src/app/core/models/base-issue.model.ts
+++ b/src/app/core/models/base-issue.model.ts
@@ -7,7 +7,7 @@ import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-t
 import { Team } from './team.model';
 import { TesterResponse } from './tester-response.model';
 import { TesterResponseTemplate } from './templates/tester-response-template.model';
-import { GithubIssue } from './github-issue.model';
+import { GithubIssue, GithubLabel } from './github-issue.model';
 import * as moment from 'moment';
 import { GithubComment } from './github-comment.model';
 
@@ -49,12 +49,12 @@ export class BaseIssue implements Issue {
     this.description = githubIssue.body;
 
     /** Fields derived from Labels */
-    this.severity = githubIssue.findLabel('severity');
-    this.type = githubIssue.findLabel('type');
-    this.responseTag = githubIssue.findLabel('response');
-    this.duplicated = !!githubIssue.findLabel('duplicated', false);
-    this.status = githubIssue.findLabel('unsure', false);
-    this.pending = githubIssue.findLabel('pending');
+    this.severity = githubIssue.findLabel(GithubLabel.LABELS.severity);
+    this.type = githubIssue.findLabel(GithubLabel.LABELS.type);
+    this.responseTag = githubIssue.findLabel(GithubLabel.LABELS.response);
+    this.duplicated = !!githubIssue.findLabel(GithubLabel.LABELS.duplicated, false);
+    this.status = githubIssue.findLabel(GithubLabel.LABELS.unsure, false);
+    this.pending = githubIssue.findLabel(GithubLabel.LABELS.pending);
   }
 
   public static createPhaseBugReportingIssue(githubIssue: GithubIssue): BaseIssue {

--- a/src/app/core/models/base-issue.model.ts
+++ b/src/app/core/models/base-issue.model.ts
@@ -1,15 +1,15 @@
-import {Issue} from './issue.model';
+import { TeamResponseTemplate } from './templates/team-response-template.model';
+import { Issue } from './issue.model';
+import { IssueDispute } from './issue-dispute.model';
+import { IssueComment } from './comment.model';
+import { TutorModerationIssueTemplate } from './templates/tutor-moderation-issue-template.model';
+import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-template.model';
+import { Team } from './team.model';
+import { TesterResponse } from './tester-response.model';
+import { TesterResponseTemplate } from './templates/tester-response-template.model';
+import { GithubIssue } from './github-issue.model';
 import * as moment from 'moment';
-import {GithubIssue} from './github-issue.model';
-import {Team} from './team.model';
-import {TesterResponse} from './tester-response.model';
-import {IssueComment} from './comment.model';
-import {IssueDispute} from './issue-dispute.model';
-import {TeamResponseTemplate} from './templates/team-response-template.model';
-import {GithubComment} from './github-comment.model';
-import {TesterResponseTemplate} from './templates/tester-response-template.model';
-import {TutorModerationIssueTemplate} from './templates/tutor-moderation-issue-template.model';
-import {TutorModerationTodoTemplate} from './templates/tutor-moderation-todo-template.model';
+import { GithubComment } from './github-comment.model';
 
 export class BaseIssue implements Issue {
   /** Basic Fields */
@@ -42,11 +42,13 @@ export class BaseIssue implements Issue {
 
 
   protected constructor(githubIssue: GithubIssue) {
+    /** Basic Fields */
     this.id = +githubIssue.number;
     this.created_at = moment(githubIssue.created_at).format('lll');
     this.title = githubIssue.title;
     this.description = githubIssue.body;
 
+    /** Fields derived from Labels */
     this.severity = githubIssue.findLabel('severity');
     this.type = githubIssue.findLabel('type');
     this.responseTag = githubIssue.findLabel('response');

--- a/src/app/core/models/base-issue.model.ts
+++ b/src/app/core/models/base-issue.model.ts
@@ -1,6 +1,6 @@
-import {Issue, labelsToAttributeMapping} from './issue.model';
+import {Issue} from './issue.model';
 import * as moment from 'moment';
-import {GithubIssue, GithubLabel} from './github-issue.model';
+import {GithubIssue} from './github-issue.model';
 import {Team} from './team.model';
 import {TesterResponse} from './tester-response.model';
 import {IssueComment} from './comment.model';

--- a/src/app/core/models/github-issue.model.ts
+++ b/src/app/core/models/github-issue.model.ts
@@ -36,7 +36,7 @@ export class GithubIssue {
   findLabel(name: string, isCategorical: boolean = true): string {
     if (!isCategorical) {
       const label = this.labels.find(l => (!l.isCategorical() && l.name === name));
-      return label ? label.getCategoryValue() : undefined;
+      return label ? label.getValue() : undefined;
     }
 
     // Find labels with the same category name as what is specified in the parameter.
@@ -44,17 +44,17 @@ export class GithubIssue {
     if (labels.length === 0) {
       return undefined;
     } else if (labels.length === 1) {
-      return labels[0].getCategoryValue();
+      return labels[0].getValue();
     } else {
       // If Label order is not specified, return the first label value else
       // If Label order is specified, return the highest ranking label value
       if (!GithubLabel.LABEL_ORDER[name]) {
-        return labels[0].getCategoryValue();
+        return labels[0].getValue();
       } else {
         const order = GithubLabel.LABEL_ORDER[name];
         return labels.reduce((result, currLabel) => {
-          return order[currLabel.getCategoryValue()] > order[result.getCategoryValue()] ? currLabel : result;
-        }).getCategoryValue();
+          return order[currLabel.getValue()] > order[result.getValue()] ? currLabel : result;
+        }).getValue();
       }
     }
   }
@@ -95,7 +95,7 @@ export class GithubLabel {
     }
   }
 
-  getCategoryValue(): string {
+  getValue(): string {
     if (this.isCategorical()) {
       return this.name.split('.')[1];
     } else {

--- a/src/app/core/models/github-issue.model.ts
+++ b/src/app/core/models/github-issue.model.ts
@@ -1,4 +1,4 @@
-export interface GithubIssue {
+export class GithubIssue {
   id: number; // Github's backend's id
   number: number; // Issue's display id
   assignees: Array<{
@@ -8,13 +8,7 @@ export interface GithubIssue {
   }>;
   body: string;
   created_at: string;
-  html_url: string;
-  labels: Array<{
-    color: string,
-    id: number,
-    name: string,
-    url: string,
-  }>;
+  labels: Array<GithubLabel>;
   state: string;
   title: string;
   updated_at: string;
@@ -25,4 +19,54 @@ export interface GithubIssue {
     avatar_url: string,
     url: string,
   };
+
+  constructor(githubIssue: {}) {
+    Object.assign(this, githubIssue);
+    this.labels = [];
+    for (const label of githubIssue['labels']) {
+      this.labels.push(new GithubLabel(label));
+    }
+  }
+
+  /**
+   *
+   * @param name Depending on the isCategorical flag, this name either refers to the category name of label or the exact name of label.
+   * @param isCategorical Whether the label is categorical.
+   */
+  findLabel(name: string, isCategorical: boolean = true) {
+    const label = this.labels.find(l => (l.isCategorical() === isCategorical && l.getCategory() === name));
+    return label ? label.getCategoryValue() : undefined;
+  }
+}
+
+export class GithubLabel {
+  color: string;
+  id: number;
+  name: string;
+  url: string;
+
+  constructor(githubLabels: {}) {
+    Object.assign(this, githubLabels);
+  }
+
+  getCategory(): string {
+    if (this.isCategorical()) {
+      return this.name.split('.')[0];
+    } else {
+      return '';
+    }
+  }
+
+  getCategoryValue(): string {
+    if (this.isCategorical()) {
+      return this.name.split('.')[1];
+    } else {
+      return this.name;
+    }
+  }
+
+  isCategorical(): boolean {
+    const regex = /^\S+.\S+$/;
+    return regex.test(this.name);
+  }
 }

--- a/src/app/core/models/github-issue.model.ts
+++ b/src/app/core/models/github-issue.model.ts
@@ -37,6 +37,10 @@ export class GithubIssue {
     const label = this.labels.find(l => (l.isCategorical() === isCategorical && l.getCategory() === name));
     return label ? label.getCategoryValue() : undefined;
   }
+
+  findTeamId(): string {
+    return `${this.findLabel('team')}.${this.findLabel('tutorial')}`;
+  }
 }
 
 export class GithubLabel {

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -1,6 +1,6 @@
-import {Team} from './team.model';
+import { Team } from './team.model';
 import { TesterResponse } from './tester-response.model';
-import { IssueComment, IssueComments } from './comment.model';
+import { IssueComment } from './comment.model';
 import { IssueDispute } from './issue-dispute.model';
 
 export interface Issue {

--- a/src/app/core/models/team.model.ts
+++ b/src/app/core/models/team.model.ts
@@ -1,4 +1,4 @@
-import {User} from './user.model';
+import { User } from './user.model';
 
 export interface Team {
   id: string;

--- a/src/app/core/models/templates/sections/duplicate-of-section.model.ts
+++ b/src/app/core/models/templates/sections/duplicate-of-section.model.ts
@@ -1,4 +1,4 @@
-import {Section, SectionalDependency} from './section.model';
+import { Section, SectionalDependency } from './section.model';
 
 export class DuplicateOfSection extends Section {
   private readonly duplicateOfRegex = /duplicate of\s*#(\d+)/i;

--- a/src/app/core/models/templates/sections/issue-dispute-section.model.ts
+++ b/src/app/core/models/templates/sections/issue-dispute-section.model.ts
@@ -1,5 +1,5 @@
-import {Section, SectionalDependency} from './section.model';
-import {IssueDispute} from '../../issue-dispute.model';
+import { IssueDispute } from '../../issue-dispute.model';
+import { Section, SectionalDependency } from './section.model';
 
 export class IssueDisputeSection extends Section {
   disputes: IssueDispute[];

--- a/src/app/core/models/templates/sections/moderation-section.model.ts
+++ b/src/app/core/models/templates/sections/moderation-section.model.ts
@@ -1,5 +1,5 @@
-import {Section, SectionalDependency} from './section.model';
-import {IssueDispute} from '../../issue-dispute.model';
+import { IssueDispute } from '../../issue-dispute.model';
+import { Section, SectionalDependency } from './section.model';
 
 export class ModerationSection extends Section {
   disputesToResolve: IssueDispute[];

--- a/src/app/core/models/templates/sections/section.model.ts
+++ b/src/app/core/models/templates/sections/section.model.ts
@@ -5,7 +5,7 @@
  * Reason for the dependencies on other headers: We need them to create a regex expression that is capable of parsing the current
  *                                               section out of the string.
  */
-import {Header} from '../template.model';
+import { Header } from '../template.model';
 
 export interface SectionalDependency {
   sectionHeader: Header;

--- a/src/app/core/models/templates/sections/test-response-section.model.ts
+++ b/src/app/core/models/templates/sections/test-response-section.model.ts
@@ -1,5 +1,5 @@
-import {Section, SectionalDependency} from './section.model';
-import {TesterResponse} from '../../tester-response.model';
+import { TesterResponse } from '../../tester-response.model';
+import { Section, SectionalDependency } from './section.model';
 
 export class TesterResponseSection extends Section {
   testerResponses: TesterResponse[] = [];

--- a/src/app/core/models/templates/team-response-template.model.ts
+++ b/src/app/core/models/templates/team-response-template.model.ts
@@ -1,7 +1,7 @@
-import {GithubIssue} from '../github-issue.model';
-import {Header, Template} from './template.model';
-import {Section} from './sections/section.model';
-import {DuplicateOfSection} from './sections/duplicate-of-section.model';
+import { DuplicateOfSection } from './sections/duplicate-of-section.model';
+import { Header, Template } from './template.model';
+import { Section } from './sections/section.model';
+import { GithubIssue } from '../github-issue.model';
 
 const teamResponseHeaders = {
   description: new Header('Description', 1),

--- a/src/app/core/models/templates/template.model.ts
+++ b/src/app/core/models/templates/template.model.ts
@@ -1,4 +1,4 @@
-import {SectionalDependency} from './sections/section.model';
+import { SectionalDependency } from './sections/section.model';
 
 export abstract class Template {
   headers: Header[];

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -1,7 +1,8 @@
-import {Header, Template} from './template.model';
-import {Section} from './sections/section.model';
-import {GithubComment} from '../github-comment.model';
-import {TesterResponseSection} from './sections/test-response-section.model';
+import { Header, Template } from './template.model';
+import { TesterResponseSection } from './sections/test-response-section.model';
+import { Section } from './sections/section.model';
+import { GithubComment } from '../github-comment.model';
+
 
 const testerResponseHeaders = {
   teamResponse: new Header('Team\'s Response', 1),

--- a/src/app/core/models/templates/tutor-moderation-issue-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-issue-template.model.ts
@@ -1,7 +1,8 @@
-import {Header, Template} from './template.model';
-import {Section} from './sections/section.model';
-import {GithubIssue} from '../github-issue.model';
-import {IssueDisputeSection} from './sections/issue-dispute-section.model';
+import { Header, Template } from './template.model';
+import { IssueDisputeSection } from './sections/issue-dispute-section.model';
+import { Section } from './sections/section.model';
+import { GithubIssue } from '../github-issue.model';
+
 
 const tutorModerationIssueDescriptionHeaders = {
   description: new Header('Description', 1),

--- a/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
@@ -1,6 +1,7 @@
-import {Header, Template} from './template.model';
-import {GithubComment} from '../github-comment.model';
-import {ModerationSection} from './sections/moderation-section.model';
+import { Header, Template } from './template.model';
+import { ModerationSection } from './sections/moderation-section.model';
+import { GithubComment } from '../github-comment.model';
+
 
 const tutorModerationTodoHeaders = {
   todo: new Header('Tutor Moderation', 1),

--- a/src/app/core/models/user.model.ts
+++ b/src/app/core/models/user.model.ts
@@ -1,4 +1,4 @@
-import {Team} from './team.model';
+import { Team } from './team.model';
 
 export interface User {
   loginId: string;

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -5,7 +5,7 @@ import { githubPaginatorParser } from '../../shared/lib/github-paginator-parser'
 import { IssueComment } from '../models/comment.model';
 import { shell } from 'electron';
 import { ErrorHandlingService } from './error-handling.service';
-import {GithubIssue} from '../models/github-issue.model';
+import { GithubIssue } from '../models/github-issue.model';
 const Octokit = require('@octokit/rest');
 
 

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -56,12 +56,11 @@ export class GithubService {
         return forkJoin(apiCalls);
       }),
       map((resultArray) => {
-        let collatedData = [];
+        const collatedData = [];
         for (const response of resultArray) {
-          collatedData = [
-            ...collatedData,
-            ...response['data'],
-          ];
+          for (const issue of response['data']) {
+            collatedData.push(new GithubIssue(issue));
+          }
         }
         return collatedData;
       })
@@ -71,7 +70,7 @@ export class GithubService {
   fetchIssue(id: number): Observable<GithubIssue> {
     return from(octokit.issues.get({owner: ORG_NAME, repo: REPO, number: id})).pipe(
       map((response) => {
-        return response['data'];
+        return new GithubIssue(response['data']);
       })
     );
   }
@@ -124,18 +123,18 @@ export class GithubService {
     octokit.issues.updateLabel({owner: ORG_NAME, repo: REPO, current_name: labelName, color: labelColor});
   }
 
-  closeIssue(id: number): Observable<{}> {
+  closeIssue(id: number): Observable<GithubIssue> {
     return from(octokit.issues.update({owner: ORG_NAME, repo: REPO, number: id, state: 'closed'})).pipe(
       map(response => {
-        return response['data'];
+        return new GithubIssue(response['data']);
       })
     );
   }
 
-  createIssue(title: string, description: string, labels: string[]): Observable<{}> {
+  createIssue(title: string, description: string, labels: string[]): Observable<GithubIssue> {
     return from(octokit.issues.create({owner: ORG_NAME, repo: REPO, title: title, body: description, labels: labels})).pipe(
       map(response => {
-        return response['data'];
+        return new GithubIssue(response['data']);
       })
     );
   }
@@ -149,11 +148,11 @@ export class GithubService {
     );
   }
 
-  updateIssue(id: number, title: string, description: string, labels: string[], assignees?: string[]): Observable<{}> {
+  updateIssue(id: number, title: string, description: string, labels: string[], assignees?: string[]): Observable<GithubIssue> {
     return from(octokit.issues.update({owner: ORG_NAME, repo: REPO, number: id, title: title, body: description, labels: labels,
       assignees: assignees})).pipe(
       map(response => {
-        return response['data'];
+        return new GithubIssue(response['data']);
       })
     );
   }

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -25,8 +25,8 @@ import { TesterResponse } from '../models/tester-response.model';
 import { IssueComments, IssueComment } from '../models/comment.model';
 import { IssueDispute } from '../models/issue-dispute.model';
 import { UserRole } from '../../core/models/user.model';
-import {BaseIssue} from '../models/base-issue.model';
-import {GithubIssue} from '../models/github-issue.model';
+import { BaseIssue } from '../models/base-issue.model';
+import { GithubIssue } from '../models/github-issue.model';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -25,6 +25,8 @@ import { TesterResponse } from '../models/tester-response.model';
 import { IssueComments, IssueComment } from '../models/comment.model';
 import { IssueDispute } from '../models/issue-dispute.model';
 import { UserRole } from '../../core/models/user.model';
+import {BaseIssue} from '../models/base-issue.model';
+import {GithubIssue} from '../models/github-issue.model';
 
 @Injectable({
   providedIn: 'root',
@@ -82,7 +84,7 @@ export class IssueService {
   createIssue(title: string, description: string, severity: string, type: string): Observable<Issue> {
     const labelsArray = [this.createLabel('severity', severity), this.createLabel('type', type)];
     return this.githubService.createIssue(title, description, labelsArray).pipe(
-      flatMap((response) => {
+      flatMap((response: GithubIssue) => {
         return this.createIssueModel(response);
       })
     );
@@ -92,7 +94,7 @@ export class IssueService {
     const assignees = this.phaseService.currentPhase === Phase.phaseModeration ? [] : issue.assignees;
     return this.githubService.updateIssue(issue.id, issue.title, this.createGithubIssueDescription(issue),
       this.createLabelsForIssue(issue), assignees).pipe(
-        flatMap((response) => {
+        flatMap((response: GithubIssue) => {
           return this.createIssueModel(response);
         })
     );
@@ -135,7 +137,7 @@ export class IssueService {
 
   deleteIssue(id: number): Observable<Issue> {
     return this.githubService.closeIssue(id).pipe(
-      flatMap((response) => {
+      flatMap((response: GithubIssue) => {
         return this.createIssueModel(response).pipe(
           map(deletedIssue => {
             this.deleteFromLocalStore(deletedIssue);
@@ -424,7 +426,13 @@ export class IssueService {
     return `${prepend}.${value}`;
   }
 
-  private createIssueModel(issueInJson: {}): Observable<Issue> {
+  private createIssueModel(githubIssue: GithubIssue): Observable<Issue> {
+    if (this.phaseService.currentPhase === Phase.phaseBugReporting) {
+      return of(BaseIssue.createPhaseBugReportingIssue(githubIssue));
+    }
+
+    // A temp fix due to the refactoring process. After refactoring is complete, we can remove this whole chunk of code below.
+    let issueInJson = { ...githubIssue };
     this.getParsedBody(issueInJson);
     const issueId = +issueInJson['number'];
     return this.issueCommentService.getIssueComments(issueId, this.isIssueReloaded).pipe(


### PR DESCRIPTION
- Bug reporting phase now uses the new template.
- Changed the GithubIssue Model from interface to a class.
- Add label parsing capability to the new issue model.