### PR TITLE
Fix spinner not stopping when repo has no issues

### DIFF
--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -259,7 +259,7 @@ export class IssueService {
             mappingFunctions.push(this.createIssueModel(issue));
           }
         }
-        return combineLatest(mappingFunctions);
+        return mappingFunctions.length === 0 ? of([]) : combineLatest(mappingFunctions);
       }),
       map((issueArray) => {
         let mappedResults: Issues = {};


### PR DESCRIPTION
Fix #173 

`combineLatest` on an empty array will result in Observable that completes immediately. And the datatable will not be notified of this completion. 

Ideally, `createModel` should not return `Observable`. After the code is refactored, we can remove the need of using `combineLatest`.