### PR TITLE
Enhancements to Session Fix Confirmations

### DIFF
--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -175,7 +175,7 @@ export class PhaseService {
         return this.verifySessionAvailability(sessionData);
       }),
       flatMap((isSessionAvailable: boolean) => {
-        if (!isSessionAvailable) {
+        if (!isSessionAvailable && this.currentPhase === Phase.phaseBugReporting) {
           return this.openSessionFixConfirmation();
         } else {
           return of(null);

--- a/src/app/core/services/session-fix-confirmation/session-fix-confirmation.component.html
+++ b/src/app/core/services/session-fix-confirmation/session-fix-confirmation.component.html
@@ -5,5 +5,5 @@
 </div>
 <div mat-dialog-actions>
   <button mat-button mat-raised-button color="warn" [mat-dialog-close]="false" (click)="onNoClick()">No Thanks</button>
-  <button mat-button mat-raised-button color="primary" [mat-dialog-close]="true" cdkFocusInitial>Ok</button>
+  <button mat-button mat-raised-button color="primary" [mat-dialog-close]="true" cdkFocusInitial>Yes</button>
 </div>


### PR DESCRIPTION
Resolves #202 

- Previously confirmation would be used for any phase where the
repository was detected to be unavailable but it has now been narrowed
to the BugReportingPhase
- Instead of No Thanks | Ok, changed to No Thanks | Yes to the "Would
you like ... " question.