### PR TITLE
Add Newline after Input

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -10,7 +10,7 @@
           <textarea ctrlKeys (ctrlV)="onPaste()" #commentTextArea (dragover)="disableCaretMovement($event)"
                     id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20"></textarea>
+                    cdkAutosizeMaxRows="20" (change)="formatText()"></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -114,6 +114,14 @@ export class CommentEditorComponent implements OnInit {
     reader.readAsDataURL(file);
   }
 
+  /**
+   * Formats the text to create space at the end of the user input to prevent any issues with
+   * the markdown interpretation.
+   */
+  formatText() {
+    this.commentField.setValue(this.commentTextArea.nativeElement.value + '\n\r');
+  }
+
   onPaste() {
     this.uploadErrorMessage = null;
 


### PR DESCRIPTION
Resolves #210 

The issue was about how github interprets markdown text that is directly below a `<hr/>` to fix this issue I simply made it such on changes to the input a newline will be appended to the user input ensuring that the markdown is interpreted correctly.