### PR TITLE
Fixed Dashed Line Break Issue

### DIFF
--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -542,7 +542,8 @@ export class IssueService {
     let matches;
     const testerResponses: TesterResponse[] = [];
     const regex: RegExp = new RegExp('#{2} *:question: *([\\w ]+)[\\r\\n]*(Team Chose.*[\\r\\n]* *Originally.*'
-      + '|Team Chose.*[\\r\\n]*)[\\r\\n]*(- \\[x? ?\\] I disagree)[\\r\\n]*\\*\\*Reason *for *disagreement:\\*\\* *([\\s\\S]*?)-{19}',
+      + '|Team Chose.*[\\r\\n]*)[\\r\\n]*(- \\[x? ?\\] I disagree)[\\r\\n]*\\*\\*Reason *for *disagreement:\\*\\* *([\\s\\S]*?)'
+      + '[\\n\\r]-{19}[\\n\\r]{1}',
       'gi');
     while (matches = regex.exec(toParse)) {
       if (matches && matches.length > this.MINIMUM_MATCHES) {


### PR DESCRIPTION
Resolves #218 

Initially if the user keys in a set of dashes (for a line break) that is > 19 the app will not parse the tester response properly but now the appcan parse the response as long as the number of dashes is not exactly 19.