### PR TITLE
Image upload detection fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "core-js": "2.6.1",
     "csv-parse": "^4.4.3",
     "moment": "^2.24.0",
-    "ngx-markdown": "^7.1.1",
+    "ngx-markdown": "^8.1.1",
     "node-fetch": "^2.6.0",
     "rxjs": "6.4.0",
     "tslib": "^1.9.0",
@@ -62,7 +62,7 @@
     "jasmine-core": "3.3.0",
     "jasmine-spec-reporter": "4.2.1",
     "jasmine-ts": "^0.3.0",
-    "karma": "3.1.1",
+    "karma": "^4.3.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage-istanbul-reporter": "2.0.4",
     "karma-jasmine": "2.0.1",
@@ -72,7 +72,7 @@
     "protractor": "5.4.1",
     "ts-node": "^7.0.1",
     "tslint": "5.11.0",
-    "typescript": "^3.1.6",
+    "typescript": "^3.1.1",
     "wait-on": "3.2.0",
     "webdriver-manager": "12.1.0"
   }

--- a/src/app/shared/tester-response/tester-response.component.html
+++ b/src/app/shared/tester-response/tester-response.component.html
@@ -30,7 +30,7 @@
         </div>
         <div *ngIf="isEditing">
           <app-comment-editor [commentField]="testerResponseForm.get(i.toString())" [commentForm]="testerResponseForm"
-            (change)="handleChangeOfText($event, response.reasonForDiagreement, i)" [id]="i.toString()"></app-comment-editor>
+            (change)="handleChangeOfText($event, response.reasonForDiagreement, i)" [id]="i.toString()" (focusout)="handleChangeOfText($event, response.reasonForDiagreement, i)"></app-comment-editor>
         </div>
         <br> <markdown data="-------------------"></markdown> <br>
       </div>


### PR DESCRIPTION
Resolves #220 

The issue was that when the image was uploaded and the markdown text was inserted into the textbox, the angular component did not register that the internal text was changed. I tried several methods to try and force the change event but it did not work.

A workaround was I called the "updateOnTextChange" method when the user focused out of the comment box. This way when the user clicks submit, all the testerResponses will be updated prior to submission to the github api.