### PR TITLE
Tester Re-responded fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "core-js": "2.6.1",
     "csv-parse": "^4.4.3",
     "moment": "^2.24.0",
-    "ngx-markdown": "^7.1.1",
+    "ngx-markdown": "^8.1.1",
     "node-fetch": "^2.6.0",
     "rxjs": "6.4.0",
     "tslib": "^1.9.0",
@@ -62,7 +62,7 @@
     "jasmine-core": "3.3.0",
     "jasmine-spec-reporter": "4.2.1",
     "jasmine-ts": "^0.3.0",
-    "karma": "3.1.1",
+    "karma": "^4.3.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage-istanbul-reporter": "2.0.4",
     "karma-jasmine": "2.0.1",
@@ -72,7 +72,7 @@
     "protractor": "5.4.1",
     "ts-node": "^7.0.1",
     "tslint": "5.11.0",
-    "typescript": "^3.1.6",
+    "typescript": "^3.1.1",
     "wait-on": "3.2.0",
     "webdriver-manager": "12.1.0"
   }

--- a/src/app/shared/tester-response/tester-response.component.ts
+++ b/src/app/shared/tester-response/tester-response.component.ts
@@ -52,10 +52,7 @@ export class TesterResponseComponent implements OnInit {
       return;
     }
     this.isFormPending = true;
-
-    if (this.isNewResponse()) {
-      this.issue.status = STATUS.Done;
-    }
+    this.issue.status = STATUS.Done;
 
     this.issueService.updateIssue(this.issue).pipe(finalize(() => {
       this.isFormPending = false;


### PR DESCRIPTION
Resolves #219 

Previously there was the requirement for the response to be a "NewResponse" (i.e. Responded for the first time) before the status done was applied. That requirement has been removed.