### PR TITLE
Fix unintuitive string value sorting method

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@angular/platform-browser-dynamic": "~7.2.7",
     "@angular/router": "~7.2.7",
     "@octokit/rest": "^16.27.0",
-    "ajv": "^6.10.2",
     "core-js": "2.6.1",
     "csv-parse": "^4.4.3",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@angular/platform-browser-dynamic": "~7.2.7",
     "@angular/router": "~7.2.7",
     "@octokit/rest": "^16.27.0",
+    "ajv": "^6.10.2",
     "core-js": "2.6.1",
     "csv-parse": "^4.4.3",
     "moment": "^2.24.0",
@@ -72,7 +73,7 @@
     "protractor": "5.4.1",
     "ts-node": "^7.0.1",
     "tslint": "5.11.0",
-    "typescript": "^3.1.1",
+    "typescript": "^3.2.4",
     "wait-on": "3.2.0",
     "webdriver-manager": "12.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "protractor": "5.4.1",
     "ts-node": "^7.0.1",
     "tslint": "5.11.0",
-    "typescript": "^3.2.4",
+    "typescript": "^3.1.1",
     "wait-on": "3.2.0",
     "webdriver-manager": "12.1.0"
   }

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -162,8 +162,8 @@ export class IssuesDataTable extends DataSource<Issue> {
   }
 
   private compareValue(valueA, valueB): number {
-    var a: string | number;
-    var b: string | number;
+    let a: string | number;
+    let b: string | number;
     if (typeof valueA === 'string') {
       a = valueA.toUpperCase();
     } else {

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -161,19 +161,9 @@ export class IssuesDataTable extends DataSource<Issue> {
     return result;
   }
 
-  private compareValue(valueA, valueB): number {
-    let a: string | number;
-    let b: string | number;
-    if (typeof valueA === 'string') {
-      a = valueA.toUpperCase();
-    } else {
-      a = valueA || '';
-    }
-    if (typeof valueB === 'string') {
-      b = valueB.toUpperCase();
-    } else {
-      b = valueB || '';
-    }
+  private compareValue(valueA: string | number, valueB: string | number): number {
+    const a = String(valueA || '').toUpperCase();
+    const b = String(valueB || '').toUpperCase();
     return (a < b ? -1 : 1) * (this.sort.direction === 'asc' ? 1 : -1);
   }
 }

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -162,8 +162,18 @@ export class IssuesDataTable extends DataSource<Issue> {
   }
 
   private compareValue(valueA, valueB): number {
-    const a = valueA || '';
-    const b = valueB || '';
+    var a: string | number;
+    var b: string | number;
+    if (typeof valueA === 'string') {
+      a = valueA.toUpperCase();
+    } else {
+      a = valueA || '';
+    }
+    if (typeof valueB === 'string') {
+      b = valueB.toUpperCase();
+    } else {
+      b = valueB || '';
+    }
     return (a < b ? -1 : 1) * (this.sort.direction === 'asc' ? 1 : -1);
   }
 }


### PR DESCRIPTION
It used to sort strings simply by comparing two strings with `<`, however `<` compares two strings according to their ASCII values, which means capital letters always come before lowercase letters (e.g. "Zoo" comes before "alpha"), which is counter-intuitive.

I changed `compareValue` function to convert strings to uppercase before comparing with `<`.