### PR TITLE
Use a common variable for representing 'non-supported file type upload error'

### DIFF
--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -28,7 +28,7 @@ export class UploadService {
       const onlineFilename = uuid();
       return this.githubService.uploadFile(`${onlineFilename}.${fileType}`, base64String);
     } else {
-      return throwError('We dont support that file type. Try again with GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX, ZIP.');
+      return throwError(FILE_TYPE_SUPPORT_ERROR);
     }
   }
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -183,8 +183,7 @@ export class CommentEditorComponent implements OnInit {
     const insertedText = this.insertUploadingText(filename);
 
     if (!this.uploadService.isSupportedFileType(filename)) {
-      this.handleUploadError('We dont support that file type. Try again with GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF,' +
-        ' PPTX, TXT, XLSX, ZIP.', insertedText);
+      this.handleUploadError(FILE_TYPE_SUPPORT_ERROR, insertedText);
       return;
     }
 


### PR DESCRIPTION
Let's use the same constant when handling the upload error caused by non-supported file types.