### PR TITLE
CommentEditor (template): Use a constant variable to store list of accepted file types

### DIFF
--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -3,9 +3,9 @@ import {GithubService} from './github.service';
 import {uuid} from '../../shared/lib/uuid';
 import {throwError} from 'rxjs';
 
-export const FILE_TYPE_SUPPORT_ERROR = 'We dont support that file type.' +
-  ' Try again with GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX, ZIP.';
-const SUPPORTED_FILE_TYPES = ['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip'];
+export const SUPPORTED_FILE_TYPES = ['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip'];
+export const FILE_TYPE_SUPPORT_ERROR = 'We don\'t support that file type.' +
+  ' Try again with ' + SUPPORTED_FILE_TYPES.join(', ') + '.';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -19,7 +19,7 @@
             <span *ngIf="!isInErrorState"> Attach files by dragging & dropping or select them by clicking here. </span>
             <span *ngIf="isInErrorState" class="error"> {{uploadErrorMessage}} </span>
             <input #fileInput [disabled]="this.commentField.disabled"
-                   [accept]="['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip']"
+                   [accept]="SUPPORTED_FILE_TYPES"
                    type="file" class="file" (change)="onFileInputUpload($event, fileInput)">
           </div>
         </mat-form-field>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
-import {FILE_TYPE_SUPPORT_ERROR, UploadService} from '../../core/services/upload.service';
+import {FILE_TYPE_SUPPORT_ERROR, SUPPORTED_FILE_TYPES, UploadService} from '../../core/services/upload.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { clipboard } from 'electron';
 import { HttpErrorResponse } from '@angular/common/http';


### PR DESCRIPTION
We already have a variable `SUPPORTED_FILE_TYPES` that holds the list of file types accepted by the issue form. Let's reuse this variable in the template of the CommentEditor.

In future, we would only have to update this variable if we want to change the list of accepted file types.