### PR TITLE
Add edit action to issue lists (all phases)

### DIFF
--- a/src/app/core/services/permission.service.ts
+++ b/src/app/core/services/permission.service.ts
@@ -163,6 +163,12 @@ export class PermissionService {
     return this.askForPermission(PermissionLevel.User, 'isTutorResponseEditable');
   }
 
+  isIssueEditable(): boolean {
+    return this.isIssueTitleEditable() || this.isIssueDescriptionEditable()
+           || this.isIssueLabelsEditable() || this.isTeamResponseEditable()
+           || this.isTutorResponseEditable();
+  }
+
   private askForPermission(permissionLevel: PermissionLevel, permissionType: string): boolean {
     switch (permissionLevel) {
       case PermissionLevel.Phase:

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -19,7 +19,8 @@ export class PhaseBugReportingComponent implements OnInit {
   ];
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.DELETE_ISSUE
+    ACTION_BUTTONS.DELETE_ISSUE,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
 
   @ViewChild(IssueTablesComponent) table: IssueTablesComponent;

--- a/src/app/phase-moderation/phase-moderation.component.ts
+++ b/src/app/phase-moderation/phase-moderation.component.ts
@@ -28,7 +28,7 @@ export class PhaseModerationComponent implements OnInit {
 
   public teamFilter = 'All Teams';
 
-  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB];
+  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.FIX_ISSUE];
 
   @ViewChild(IssueTablesComponent) table: IssueTablesComponent;
 

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -18,7 +18,7 @@ export class IssuesFaultyComponent implements OnInit, OnChanges {
 
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.FIX_ISSUE
+    ACTION_BUTTONS.FIX_ISSUE,
   ];
 
   @Input() teamFilter: string;

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -18,7 +18,7 @@ export class IssuesFaultyComponent implements OnInit, OnChanges {
 
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.FIX_ISSUE,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
 
   @Input() teamFilter: string;

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.ts
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.ts
@@ -19,7 +19,8 @@ export class IssuesPendingComponent implements OnInit, OnChanges {
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
     ACTION_BUTTONS.RESPOND_TO_ISSUE,
-    ACTION_BUTTONS.MARK_AS_RESPONDED
+    ACTION_BUTTONS.MARK_AS_RESPONDED,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
 
   @Input() teamFilter: string;

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.ts
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.ts
@@ -17,7 +17,8 @@ export class IssuesRespondedComponent implements OnInit, OnChanges {
 
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.MARK_AS_PENDING
+    ACTION_BUTTONS.MARK_AS_PENDING,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
 
   @Input() teamFilter: string;

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
@@ -21,7 +21,8 @@ export class IssuePendingComponent implements OnInit {
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
     ACTION_BUTTONS.RESPOND_TO_ISSUE,
-    ACTION_BUTTONS.MARK_AS_RESPONDED
+    ACTION_BUTTONS.MARK_AS_RESPONDED,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
   filter: (issue: Issue) => boolean;
 

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
@@ -19,7 +19,8 @@ export class IssueRespondedComponent implements OnInit {
   ];
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.MARK_AS_PENDING
+    ACTION_BUTTONS.MARK_AS_PENDING,
+    ACTION_BUTTONS.FIX_ISSUE
   ];
   filter: (issue: Issue) => boolean;
 

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -113,7 +113,7 @@
       </button>
       <ng-template #tryFixIssue>
         <button *ngIf="this.isActionVisible(action_buttons.FIX_ISSUE)"
-                [routerLink]="'/phaseTeamResponse/issues/' + issue.id" mat-button color="accent"
+                mat-button color="accent"
                 style="transform: scale(0.8)" matTooltip="Fix this Issue" >
           <mat-icon>edit</mat-icon>
         </button>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -112,7 +112,7 @@
         <mat-icon>feedback</mat-icon>
       </button>
       <ng-template #tryFixIssue>
-        <button *ngIf="this.isActionVisible(action_buttons.FIX_ISSUE)"
+        <button *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
                 mat-button color="accent"
                 style="transform: scale(0.8)" matTooltip="Fix this Issue" >
           <mat-icon>edit</mat-icon>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -106,15 +106,15 @@
         <mat-icon>link</mat-icon>
       </button>
       <button *ngIf="permissions.isTeamResponseEditable() && !issue.status
-       && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryFixIssue"
+       && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryEditIssue"
               [routerLink]="'issues/' + issue.id" mat-button color="accent"
               style="transform: scale(0.8)" matTooltip="Respond to this Issue">
         <mat-icon>feedback</mat-icon>
       </button>
-      <ng-template #tryFixIssue>
+      <ng-template #tryEditIssue>
         <button *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
                 mat-button color="accent"
-                style="transform: scale(0.8)" matTooltip="Fix this Issue" >
+                style="transform: scale(0.8)" matTooltip="Edit this Issue" >
           <mat-icon>edit</mat-icon>
         </button>
       </ng-template>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -106,11 +106,18 @@
         <mat-icon>link</mat-icon>
       </button>
       <button *ngIf="permissions.isTeamResponseEditable() && !issue.status
-       && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE)"
+       && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryFixIssue"
               [routerLink]="'issues/' + issue.id" mat-button color="accent"
               style="transform: scale(0.8)" matTooltip="Respond to this Issue">
         <mat-icon>feedback</mat-icon>
       </button>
+      <ng-template #tryFixIssue>
+        <button *ngIf="this.isActionVisible(action_buttons.FIX_ISSUE)"
+                [routerLink]="'/phaseTeamResponse/issues/' + issue.id" mat-button color="accent"
+                style="transform: scale(0.8)" matTooltip="Fix this Issue" >
+          <mat-icon>edit</mat-icon>
+        </button>
+      </ng-template>
       <button *ngIf="permissions.isTeamResponseEditable() && issue.status
       && this.isActionVisible(action_buttons.MARK_AS_RESPONDED)"
               mat-button color="primary" (click)="markAsResponded(issue)"
@@ -121,11 +128,6 @@
               style="transform: scale(0.8)" *ngIf="(userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin')
               && this.isActionVisible(action_buttons.MARK_AS_PENDING)">
         <mat-icon>cancel</mat-icon>
-      </button>
-      <button *ngIf="permissions.isTeamResponseEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
-              [routerLink]="'/phaseTeamResponse/issues/' + issue.id" mat-button color="accent"
-              style="transform: scale(0.8)" matTooltip="Fix this Issue" >
-        <mat-icon>edit</mat-icon>
       </button>
       <button mat-button color="warn" *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id]
           && this.isActionVisible(action_buttons.DELETE_ISSUE)"


### PR DESCRIPTION
Fix #106 
Let's add an edit icon, as a visual cue for users to click on the issues if they wish to edit them.

For the Team Response Phase, we already have a "Respond to Issue" icon when the issue's status is not set. I added some logic to ensure the user will only see either the "Respond to Issue" icon or the "Edit issue" icon (but not both)

Screenshot (Bug Reporting Phase):
The icon added is the red pen icon.

![image](https://user-images.githubusercontent.com/35621759/74707103-c63ef780-5253-11ea-9933-f86207f29f09.png)

Team's Response Phase:
![image](https://user-images.githubusercontent.com/35621759/74707200-0f8f4700-5254-11ea-91fe-a184b5124809.png)

![image](https://user-images.githubusercontent.com/35621759/74707679-62b5c980-5255-11ea-81e3-0e630f5f2eec.png)

Moderation Phase:
![image](https://user-images.githubusercontent.com/35621759/74707278-52e9b580-5254-11ea-83a9-16f0dfe1c378.png)

Tester's Response Phase:
![image](https://user-images.githubusercontent.com/35621759/74707330-89273500-5254-11ea-83bb-cb33957374ae.png)



