### PR TITLE
Add severity label: VeryLow

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -228,7 +228,7 @@ export interface Issues {
   [id: number]: Issue;
 }
 
-export const SEVERITY_ORDER = { '-': 0 , Low: 1, Medium: 2, High: 3 };
+export const SEVERITY_ORDER = { '-': 0 , VeryLow: 1, Low: 2, Medium: 3, High: 4 };
 
 export const ISSUE_TYPE_ORDER = { '-': 0 , DocumentationBug: 1, FeatureFlaw: 2, FunctionalityBug: 3  };
 

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -25,7 +25,7 @@ export class LabelService {
 
   private readonly REQUIRED_LABELS = {
     severity: {
-      VeryLow: new Label('severity', 'VeryLow','ffe0e0'),
+      VeryLow: new Label('severity', 'VeryLow', 'ffe0e0'),
       Low: new Label('severity', 'Low', 'ffcccc'),
       Medium: new Label('severity', 'Medium', 'ff9999'),
       High: new Label('severity', 'High', 'ff6666')

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -25,6 +25,7 @@ export class LabelService {
 
   private readonly REQUIRED_LABELS = {
     severity: {
+      VeryLow: new Label('severity', 'VeryLow','ffe0e0'),
       Low: new Label('severity', 'Low', 'ffcccc'),
       Medium: new Label('severity', 'Medium', 'ff9999'),
       High: new Label('severity', 'High', 'ff6666')


### PR DESCRIPTION
Fixes #296 

I used a light pink colour for this label.
Here are some screenshots to show how the `VeryLow` label colour contrasts with the other labels' colours.

Within CATcher:
![image](https://user-images.githubusercontent.com/35621759/75173269-93bc5f80-5769-11ea-920e-1aeaa9016d11.png)

![image](https://user-images.githubusercontent.com/35621759/75173387-c1a1a400-5769-11ea-877b-2dfe04c255d7.png)

On GitHub (CATcher synchronises the colour with the repo):
![image](https://user-images.githubusercontent.com/35621759/75173560-09c0c680-576a-11ea-87d6-5a7e7d3003fd.png)

