### PR TITLE
LabelDropdownComponent: Set required attribute on select control

### DIFF
--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="dropdownForm">
   <mat-form-field style="width: 100%;">
     <mat-select [ngClass]="dropdownTextColor" formControlName="{{attributeName}}" placeholder="{{this.labelService.getLabelTitle(attributeName)}}"
-      (selectionChange)="setSelectedLabelColor($event.value)" [ngStyle]="this.labelService.setLabelStyle(this.selectedColor)">
+      (selectionChange)="setSelectedLabelColor($event.value)" [ngStyle]="this.labelService.setLabelStyle(this.selectedColor)" required>
       <mat-select-trigger>
         {{dropdownControl.value}}
       </mat-select-trigger>


### PR DESCRIPTION
Fixes #230 
The Severity and Bug Type fields are not marked with the `*` character in the new bug report form.
The `*` character gives users a visual cue that the field is mandatory.

Let's set the required attribute on the `mat-select` control in `LabelDropdownComponent` to fix this.

Before (new bug report form):
![image](https://user-images.githubusercontent.com/35621759/75222975-6bbc1300-57e0-11ea-84db-76a674d293f6.png)

Now (new bug report form):
![image](https://user-images.githubusercontent.com/35621759/75223224-f3098680-57e0-11ea-9956-5c99f55d335f.png)

Before (new team response form):
![image](https://user-images.githubusercontent.com/35621759/75223021-81c9d380-57e0-11ea-8242-6a88d003887c.png)

Now (new team response form):
![image](https://user-images.githubusercontent.com/35621759/75223263-06b4ed00-57e1-11ea-8adf-728dbd105413.png)

