### PR TITLE
Issue model: test whether bug reports with empty descriptions and issues with empty team responses are correctly created

### DIFF
--- a/tests/constants/githubcomment.constants.ts
+++ b/tests/constants/githubcomment.constants.ts
@@ -1,6 +1,6 @@
 import { GithubComment } from "../../src/app/core/models/github/github-comment.model";
 
-export const TEAM_RESPONSE : GithubComment = {
+export const EMPTY_TEAM_RESPONSE : GithubComment = {
     author_association: 'CONTRIBUTOR',
     body: "# Team's Response\n" +
     '\n' +

--- a/tests/constants/githubcomment.constants.ts
+++ b/tests/constants/githubcomment.constants.ts
@@ -1,0 +1,21 @@
+import { GithubComment } from "../../src/app/core/models/github/github-comment.model";
+
+export const TEAM_RESPONSE : GithubComment = {
+    author_association: 'CONTRIBUTOR',
+    body: "# Team's Response\n" +
+    '\n' +
+    ' ## Duplicate status (if any):\n' +
+    '--',
+    created_at: '2020-02-16T18:31:38Z',
+    html_url: 'https://github.com/CATcher-org/pe-results/issues/91#issuecomment-586737495',
+    id: 586737495,
+    issue_url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/91',
+    updated_at: '2020-03-02T12:50:02Z',
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/comments/586737495',
+    user: {
+      login: 'testathorStudent',
+      id: 46639862,
+      avatar_url: 'https://avatars3.githubusercontent.com/u/46639862?v=4',
+      url: 'https://api.github.com/users/testathorStudent',
+    },
+  }

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -1,0 +1,24 @@
+import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
+import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+         GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY } from '../constants/githublabel.constants';
+
+export const ISSUE_EMPTY_DESCRIPTION = new GithubIssue({
+    id: 574085971,
+    number: 92,
+    assignees: [],
+    body: '',
+    created_at: '2020-03-02T16:19:02Z',
+    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+             GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY
+            ],
+    state: 'open',
+    title: 'App starts to lag when given large amount of input',
+    updated_at: '2020-03-13T13:37:32Z',
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/92',
+    user: {
+        login: 'anubh-v',
+        id: 35621759,
+        avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
+        url: 'https://api.github.com/users/anubh-v',
+    }
+} as GithubIssue);

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -2,7 +2,7 @@ import { GithubIssue } from '../../src/app/core/models/github/github-issue.model
 import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
          GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY } from '../constants/githublabel.constants';
 
-export const ISSUE_EMPTY_DESCRIPTION = new GithubIssue({
+export const ISSUE_WITH_EMPTY_DESCRIPTION = new GithubIssue({
     id: 574085971,
     number: 92,
     assignees: [],
@@ -15,6 +15,33 @@ export const ISSUE_EMPTY_DESCRIPTION = new GithubIssue({
     title: 'App starts to lag when given large amount of input',
     updated_at: '2020-03-13T13:37:32Z',
     url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/92',
+    user: {
+        login: 'anubh-v',
+        id: 35621759,
+        avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
+        url: 'https://api.github.com/users/anubh-v',
+    }
+} as GithubIssue);
+
+export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
+    id: 551732011,
+    number: 91,
+    assignees: [
+        {
+          login: 'anubh-v',
+          id: 35621759,
+          url: 'https://api.github.com/users/anubh-v',
+        }
+      ],
+    body: 'Screen freezes every few minutes',
+    created_at: '2020-01-18T07:01:45Z',
+    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+        GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY
+       ],
+    state: 'open',
+    title: 'Screen freezes',
+    updated_at: '2020-03-02T12:50:02Z',
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/91',
     user: {
         login: 'anubh-v',
         id: 35621759,

--- a/tests/constants/githublabel.constants.ts
+++ b/tests/constants/githublabel.constants.ts
@@ -1,0 +1,29 @@
+import { GithubLabel } from "../../src/app/core/models/github/github-issue.model";
+
+export const GITHUB_LABEL_FUNCTIONALITY_BUG = {
+    color: '9900cc',
+    name: 'type.FunctionalityBug',
+    id: 1226647550,
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/type.FunctionalityBug',
+} as GithubLabel
+
+export const GITHUB_LABEL_MEDIUM_SEVERITY =  {
+    color: 'ff9999',
+    name: 'severity.Medium',
+    id: 1226647149,
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/severity.Medium',
+} as GithubLabel
+
+export const GITHUB_LABEL_TUTORIAL_LABEL = {
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/tutorial.CS2103T-W12',
+    name: 'tutorial.CS2103T-W12',
+    color: 'c2e0c6',
+    id: 1226649736,
+} as GithubLabel
+
+export const GITHUB_LABEL_TEAM_LABEL = {
+    id: 1226649835,
+    url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/team.3',
+    name: 'team.3',
+    color: 'd4c5f9',
+} as GithubLabel

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,30 +1,16 @@
 import { GithubService } from '../../src/app/core/services/github.service'
-import { IssueCommentService } from '../../src/app/core/services/issue-comment.service'
 import { Issue } from '../../src/app/core/models/issue.model'
+import { ISSUE_EMPTY_DESCRIPTION } from '../constants/githubissue.constants'
 
 const githubService = new GithubService(null);
 githubService.storePhaseDetails('CATcher-org', 'pe-results');
-const issueCommentService = new IssueCommentService(githubService);
 
 describe("Test whether issue instances are correctly created from GitHubIssue instances", () => {
     it('Create a bug reporting issue with an empty description', async () => {
-        const issueId = 92;
-        const ghIssue = await githubService.fetchIssue(issueId).toPromise();
-        const issue = Issue.createPhaseBugReportingIssue(ghIssue);
+        const issue = Issue.createPhaseBugReportingIssue(ISSUE_EMPTY_DESCRIPTION);
         expect(issue.title).toBe('App starts to lag when given large amount of input');
         expect(issue.description).toBe('No details provided by bug reporter.');
         expect(issue.severity).toBe('Medium');
         expect(issue.type).toBe('FunctionalityBug');
     });
-
-    it('Create a team response issue', async() => {
-        const issueId = 91;
-        const ghIssue = await githubService.fetchIssue(issueId).toPromise();
-        const ghComments = await issueCommentService.getGithubComments(issueId).toPromise();
-        const dummyTeam = null;
-        const issue = Issue.createPhaseTeamResponseIssue(ghIssue, ghComments, dummyTeam);
-        expect(issue.title).toBe('Screen freezes');
-        expect(issue.teamResponse).toBe('No details provided by team.');
-        expect(issue.assignees).toContain('anubh-v');
-    })
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,16 +1,30 @@
 import { GithubService } from '../../src/app/core/services/github.service'
+import { IssueCommentService } from '../../src/app/core/services/issue-comment.service'
 import { Issue } from '../../src/app/core/models/issue.model'
 
 const githubService = new GithubService(null);
 githubService.storePhaseDetails('CATcher-org', 'pe-results');
+const issueCommentService = new IssueCommentService(githubService);
 
 describe("Test whether issue instances are correctly created from GitHubIssue instances", () => {
-    it('Test creation of a bug reporting issue that has an empty description', async () => {
+    it('Create a bug reporting issue with an empty description', async () => {
         const issueId = 92;
         const ghIssue = await githubService.fetchIssue(issueId).toPromise();
         const issue = Issue.createPhaseBugReportingIssue(ghIssue);
         expect(issue.title).toBe('App starts to lag when given large amount of input');
         expect(issue.description).toBe('No details provided by bug reporter.');
         expect(issue.severity).toBe('Medium');
+        expect(issue.type).toBe('FunctionalityBug');
     });
+
+    it('Create a team response issue', async() => {
+        const issueId = 91;
+        const ghIssue = await githubService.fetchIssue(issueId).toPromise();
+        const ghComments = await issueCommentService.getGithubComments(issueId).toPromise();
+        const dummyTeam = null;
+        const issue = Issue.createPhaseTeamResponseIssue(ghIssue, ghComments, dummyTeam);
+        expect(issue.title).toBe('Screen freezes');
+        expect(issue.teamResponse).toBe('No details provided by team.');
+        expect(issue.assignees).toContain('anubh-v');
+    })
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,0 +1,16 @@
+import { GithubService } from '../../src/app/core/services/github.service'
+import { Issue } from '../../src/app/core/models/issue.model'
+
+const githubService = new GithubService(null);
+githubService.storePhaseDetails('CATcher-org', 'pe-results');
+
+describe("Test whether issue instances are correctly created from GitHubIssue instances", () => {
+    it('Test creation of a bug reporting issue that has an empty description', async () => {
+        const issueId = 92;
+        const ghIssue = await githubService.fetchIssue(issueId).toPromise();
+        const issue = Issue.createPhaseBugReportingIssue(ghIssue);
+        expect(issue.title).toBe('App starts to lag when given large amount of input');
+        expect(issue.description).toBe('No details provided by bug reporter.');
+        expect(issue.severity).toBe('Medium');
+    });
+});

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,16 +1,21 @@
-import { GithubService } from '../../src/app/core/services/github.service'
 import { Issue } from '../../src/app/core/models/issue.model'
-import { ISSUE_EMPTY_DESCRIPTION } from '../constants/githubissue.constants'
-
-const githubService = new GithubService(null);
-githubService.storePhaseDetails('CATcher-org', 'pe-results');
+import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants'
+import { TEAM_RESPONSE } from '../constants/githubcomment.constants';
 
 describe("Test whether issue instances are correctly created from GitHubIssue instances", () => {
     it('Create a bug reporting issue with an empty description', async () => {
-        const issue = Issue.createPhaseBugReportingIssue(ISSUE_EMPTY_DESCRIPTION);
+        const issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
         expect(issue.title).toBe('App starts to lag when given large amount of input');
         expect(issue.description).toBe('No details provided by bug reporter.');
         expect(issue.severity).toBe('Medium');
         expect(issue.type).toBe('FunctionalityBug');
     });
+
+    it('Create a team response issue that has an empty team response', async() => {
+        const dummyTeam = null;
+        const issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, [TEAM_RESPONSE], dummyTeam);
+        expect(issue.title).toBe('Screen freezes');
+        expect(issue.teamResponse).toBe('No details provided by team.');
+        expect(issue.assignees).toContain('anubh-v');
+    })
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,21 +1,26 @@
 import { Issue } from '../../src/app/core/models/issue.model'
 import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants'
-import { TEAM_RESPONSE } from '../constants/githubcomment.constants';
+import { EMPTY_TEAM_RESPONSE } from '../constants/githubcomment.constants';
 
-describe("Test whether issue instances are correctly created from GitHubIssue instances", () => {
-    it('Create a bug reporting issue with an empty description', async () => {
-        const issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-        expect(issue.title).toBe('App starts to lag when given large amount of input');
-        expect(issue.description).toBe('No details provided by bug reporter.');
-        expect(issue.severity).toBe('Medium');
-        expect(issue.type).toBe('FunctionalityBug');
+describe('Issue model class', () => {
+    describe('.createPhaseBugReportIssue(githubIssue)', () => {
+        it('correctly creates a bug reporting issue that has an empty description', async () => {
+            const issue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+            expect(issue.title).toBe('App starts to lag when given large amount of input');
+            expect(issue.description).toBe('No details provided by bug reporter.');
+            expect(issue.severity).toBe('Medium');
+            expect(issue.type).toBe('FunctionalityBug');
+        });
     });
-
-    it('Create a team response issue that has an empty team response', async() => {
-        const dummyTeam = null;
-        const issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, [TEAM_RESPONSE], dummyTeam);
-        expect(issue.title).toBe('Screen freezes');
-        expect(issue.teamResponse).toBe('No details provided by team.');
-        expect(issue.assignees).toContain('anubh-v');
-    })
+    describe('.createPhaseTeamResponseIssue(githubIssue, githubComment)', () => {
+        it('correctly creates a team response issue that has an empty team response', async() => {
+            const dummyTeam = null;
+            const issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, [EMPTY_TEAM_RESPONSE], dummyTeam);
+            expect(issue.title).toBe('Screen freezes');
+            expect(issue.teamResponse).toBe('No details provided by team.');
+            expect(issue.severity).toBe('Medium');
+            expect(issue.assignees).toContain('anubh-v');
+            expect(issue.assignees.length).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
Partially addresses #365 

I've added tests that check whether `Issue` instances are correctly created from `GithubIssue` instances when **the issues have either empty descriptions** or **empty team responses**

The `GitHubIssue` instances used in the tests are stored as constants in the test files.
