### PR TITLE
Remove countdown for error toasters

### DIFF
--- a/src/app/shared/error-toasters/form-error/form-error.component.ts
+++ b/src/app/shared/error-toasters/form-error/form-error.component.ts
@@ -5,11 +5,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
   selector: 'app-form-error',
   templateUrl: './form-error.component.html',
 })
-export class FormErrorComponent implements OnInit {
+export class FormErrorComponent {
   constructor(
     public snackBarRef: MatSnackBarRef<FormErrorComponent>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
-
-  ngOnInit() {
-  }
 }

--- a/src/app/shared/error-toasters/form-error/form-error.component.ts
+++ b/src/app/shared/error-toasters/form-error/form-error.component.ts
@@ -11,6 +11,5 @@ export class FormErrorComponent implements OnInit {
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 
   ngOnInit() {
-    this.snackBarRef.containerInstance.snackBarConfig.duration = 5000;
   }
 }

--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
@@ -11,6 +11,5 @@ export class GeneralMessageErrorComponent implements OnInit {
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 
   ngOnInit() {
-    this.snackBarRef.containerInstance.snackBarConfig.duration = 5000;
   }
 }

--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
@@ -5,11 +5,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
   selector: 'app-general-message-error',
   templateUrl: './general-message-error.component.html',
 })
-export class GeneralMessageErrorComponent implements OnInit {
+export class GeneralMessageErrorComponent {
   constructor(
     public snackBarRef: MatSnackBarRef<GeneralMessageErrorComponent>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
-
-  ngOnInit() {
-  }
 }

--- a/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
+++ b/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
@@ -5,11 +5,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
   selector: 'app-form-error',
   templateUrl: './invalid-credentials-error.component.html',
 })
-export class InvalidCredentialsErrorComponent implements OnInit {
+export class InvalidCredentialsErrorComponent {
   constructor(
     public snackBarRef: MatSnackBarRef<InvalidCredentialsErrorComponent>,
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
-
-  ngOnInit() {
-  }
 }

--- a/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
+++ b/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
@@ -11,6 +11,5 @@ export class InvalidCredentialsErrorComponent implements OnInit {
     @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 
   ngOnInit() {
-    this.snackBarRef.containerInstance.snackBarConfig.duration = 5000;
   }
 }


### PR DESCRIPTION
Fixes #370
Let's remove the countdown duration specified for the snackbars in our application.
This will prevent error messages from being dismissed automatically.