### PR TITLE
UploadService: Test 'isSupportedFileType' method

### DIFF
--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -1,4 +1,4 @@
-import {UploadService, SUPPORTED_FILE_TYPES} from '../../src/app/core/services/upload.service';
+import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../../src/app/core/services/upload.service';
 
 describe('Test the UploadService', () => {
     it('Test whether the UploadService can detect valid / invalid filetypes', () => {
@@ -9,6 +9,20 @@ describe('Test the UploadService', () => {
         const invalidFileName = "testFile." + 'java';
         expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
         expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+    });
+
+    it('UploadService should throw an error if an invalid filetype is uploaded', done => {
+      const uploadService = new UploadService(null);
+      uploadService.uploadFile('testdata', 'testFile.java').subscribe(
+        val => {
+          fail('This test case should fail.');
+          done();
+        },
+        error => {
+          expect(error).toBe(FILE_TYPE_SUPPORT_ERROR);
+          done();
+        }
+      );
     });
 });
 

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -1,14 +1,30 @@
 import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../../src/app/core/services/upload.service';
 
+const PERIOD = "."
+
 describe('UploadService', () => {
-    it('can detect valid / invalid filetypes', () => {
+    it('can distinguish valid / invalid filetypes', () => {
         const uploadService = new UploadService(null);
         for (const validFileType of SUPPORTED_FILE_TYPES) {
-            const validFileName = "testFile." + validFileType;
+            const validFileName = "testFile" + PERIOD + validFileType;
             expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
         }
-        const invalidFileName = "testFile." + 'java';
+        const invalidFileName = "testFile" + PERIOD + 'java';
         expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+    });
+
+    it('is case insensitive', () => {
+      const uploadService = new UploadService(null);
+      const invalidFileName = "TESTfile" + PERIOD + "JS";
+      expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+    });
+
+    it('rejects filenames that do not have a file extension', () => {
+      const uploadService = new UploadService(null);
+      for (const validFileType of SUPPORTED_FILE_TYPES) {
+        const fileNameWithoutFileExtension = "testFile" + validFileType;
+        expect(uploadService.isSupportedFileType(fileNameWithoutFileExtension)).toBe(false);
+      }
     });
 
     it('throws an error if an invalid filetype is uploaded', done => {

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -3,41 +3,45 @@ import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../.
 const PERIOD = "."
 
 describe('UploadService', () => {
-    it('can distinguish valid / invalid filetypes', () => {
-        const uploadService = new UploadService(null);
-        for (const validFileType of SUPPORTED_FILE_TYPES) {
-            const validFileName = "testFile" + PERIOD + validFileType;
-            expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
-        }
-        const invalidFileName = "testFile" + PERIOD + 'java';
-        expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+    describe('.isSupportedFileType(fileName)', () => {
+        it('can distinguish valid / invalid filetypes', () => {
+            const uploadService = new UploadService(null);
+            for (const validFileType of SUPPORTED_FILE_TYPES) {
+                const validFileName = "testFile" + PERIOD + validFileType;
+                expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
+            }
+            const invalidFileName = "testFile" + PERIOD + 'java';
+            expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+        });
+
+        it('is case insensitive', () => {
+          const uploadService = new UploadService(null);
+          const invalidFileName = "TESTfile" + PERIOD + "JS";
+          expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+        });
+
+        it('returns false for filenames that do not have a file extension', () => {
+          const uploadService = new UploadService(null);
+          for (const validFileType of SUPPORTED_FILE_TYPES) {
+            const fileNameWithoutFileExtension = "testFile" + validFileType;
+            expect(uploadService.isSupportedFileType(fileNameWithoutFileExtension)).toBe(false);
+          }
+        });
     });
 
-    it('is case insensitive', () => {
-      const uploadService = new UploadService(null);
-      const invalidFileName = "TESTfile" + PERIOD + "JS";
-      expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
-    });
-
-    it('rejects filenames that do not have a file extension', () => {
-      const uploadService = new UploadService(null);
-      for (const validFileType of SUPPORTED_FILE_TYPES) {
-        const fileNameWithoutFileExtension = "testFile" + validFileType;
-        expect(uploadService.isSupportedFileType(fileNameWithoutFileExtension)).toBe(false);
-      }
-    });
-
-    it('throws an error if an invalid filetype is uploaded', done => {
-      const uploadService = new UploadService(null);
-      uploadService.uploadFile('testdata', 'testFile.java').subscribe(
-        val => {
-          fail('This test case should fail.');
-          done();
-        },
-        error => {
-          expect(error).toBe(FILE_TYPE_SUPPORT_ERROR);
-          done();
-        }
-      );
+    describe('.uploadFile(fileData, fileName)', () => {
+        it('throws an error if an invalid filetype is uploaded', done => {
+          const uploadService = new UploadService(null);
+          uploadService.uploadFile('testdata', 'testFile.java').subscribe(
+            val => {
+              fail('This test case should fail.');
+              done();
+            },
+            error => {
+              expect(error).toBe(FILE_TYPE_SUPPORT_ERROR);
+              done();
+            }
+          );
+        });
     });
 });

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -1,7 +1,7 @@
 import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../../src/app/core/services/upload.service';
 
-describe('Test the UploadService', () => {
-    it('Test whether the UploadService can detect valid / invalid filetypes', () => {
+describe('UploadService', () => {
+    it('can detect valid / invalid filetypes', () => {
         const uploadService = new UploadService(null);
         for (const validFileType of SUPPORTED_FILE_TYPES) {
             const validFileName = "testFile." + validFileType;
@@ -11,7 +11,7 @@ describe('Test the UploadService', () => {
         expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
     });
 
-    it('UploadService should throw an error if an invalid filetype is uploaded', done => {
+    it('throws an error if an invalid filetype is uploaded', done => {
       const uploadService = new UploadService(null);
       uploadService.uploadFile('testdata', 'testFile.java').subscribe(
         val => {

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -1,0 +1,17 @@
+import {UploadService, SUPPORTED_FILE_TYPES} from '../../src/app/core/services/upload.service';
+
+describe('Test the UploadService', () => {
+    it('Test whether the UploadService can detect valid / invalid filetypes', () => {
+        const uploadService = new UploadService(null);
+        const numOfAcceptedFileTypes = SUPPORTED_FILE_TYPES.length;
+        const randomValidFileType = SUPPORTED_FILE_TYPES[randomIntBetween(0, numOfAcceptedFileTypes)];
+        const validFileName = "testFile." + randomValidFileType;
+        const invalidFileName = "testFile." + 'java';
+        expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
+        expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
+    });
+});
+
+function randomIntBetween(smallerInt : number, largerInt : number) {
+  return Math.floor(Math.random() * (largerInt - smallerInt)) + smallerInt;
+}

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -3,11 +3,11 @@ import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../.
 describe('Test the UploadService', () => {
     it('Test whether the UploadService can detect valid / invalid filetypes', () => {
         const uploadService = new UploadService(null);
-        const numOfAcceptedFileTypes = SUPPORTED_FILE_TYPES.length;
-        const randomValidFileType = SUPPORTED_FILE_TYPES[randomIntBetween(0, numOfAcceptedFileTypes)];
-        const validFileName = "testFile." + randomValidFileType;
+        for (const validFileType of SUPPORTED_FILE_TYPES) {
+            const validFileName = "testFile." + validFileType;
+            expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
+        }
         const invalidFileName = "testFile." + 'java';
-        expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
         expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
     });
 
@@ -25,7 +25,3 @@ describe('Test the UploadService', () => {
       );
     });
 });
-
-function randomIntBetween(smallerInt : number, largerInt : number) {
-  return Math.floor(Math.random() * (largerInt - smallerInt)) + smallerInt;
-}


### PR DESCRIPTION
The `isSupportedFileType` method of UploadService is used to check if a particular file can be uploaded via the form.

Let's add a test for this so we can check correctness of future implementation changes