### PR TITLE
Issue model: Test methods used to clean strings obtained from user

### DIFF
--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -3,17 +3,19 @@ import { Issue } from '../../src/app/core/models/issue.model'
 describe('Issue model class', () => {
     describe('.updateDescription(description) and .updateTeamResponse(teamResponse)', () => {
         it('correctly clean strings obtained from users', () => {
-            expect(Issue.updateDescription('')).toBe('No details provided by bug reporter.');
-            expect(Issue.updateTeamResponse('')).toBe('No details provided by team.');
-            expect(Issue.updateDescription(null)).toBe('No details provided by bug reporter.');
-            expect(Issue.updateTeamResponse(undefined)).toBe('No details provided by team.');
+            const noDetailsFromBugReporter = 'No details provided by bug reporter.';
+            const noDetailsFromTeam = 'No details provided by team.';
+            expect(Issue.updateDescription('')).toBe(noDetailsFromBugReporter);
+            expect(Issue.updateTeamResponse('')).toBe(noDetailsFromTeam);
+            expect(Issue.updateDescription(null)).toBe(noDetailsFromBugReporter);
+            expect(Issue.updateTeamResponse(undefined)).toBe(noDetailsFromTeam);
 
-            const typicalDescription = 'The app crashes after parsing config file.s'
+            const typicalDescription = 'The app crashes after parsing config files.'
             const typicalTeamResponse = 'Cannot replicate the bug.'
             expect(Issue.updateDescription(typicalDescription)).toBe(typicalDescription);
             expect(Issue.updateTeamResponse(typicalTeamResponse)).toBe(typicalTeamResponse);
 
-            const inputWithSpecialChars = '$%^!@&&_0_99';
+            const inputWithSpecialChars = '$%^!@&-_test';
             expect(Issue.updateDescription(inputWithSpecialChars)).toBe(inputWithSpecialChars);
             expect(Issue.updateTeamResponse(inputWithSpecialChars)).toBe(inputWithSpecialChars);
         });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,0 +1,21 @@
+import { Issue } from '../../src/app/core/models/issue.model'
+
+describe('Issue model class', () => {
+    describe('.updateDescription(description) and .updateTeamResponse(teamResponse)', () => {
+        it('correctly clean strings obtained from users', () => {
+            expect(Issue.updateDescription('')).toBe('No details provided by bug reporter.');
+            expect(Issue.updateTeamResponse('')).toBe('No details provided by team.');
+            expect(Issue.updateDescription(null)).toBe('No details provided by bug reporter.');
+            expect(Issue.updateTeamResponse(undefined)).toBe('No details provided by team.');
+
+            const typicalDescription = 'The app crashes after parsing config file.s'
+            const typicalTeamResponse = 'Cannot replicate the bug.'
+            expect(Issue.updateDescription(typicalDescription)).toBe(typicalDescription);
+            expect(Issue.updateTeamResponse(typicalTeamResponse)).toBe(typicalTeamResponse);
+
+            const inputWithSpecialChars = '$%^!@&&_0_99';
+            expect(Issue.updateDescription(inputWithSpecialChars)).toBe(inputWithSpecialChars);
+            expect(Issue.updateTeamResponse(inputWithSpecialChars)).toBe(inputWithSpecialChars);
+        });
+    });
+});


### PR DESCRIPTION
Partially addresses #365 

Let's test the `updateDescription` and `updateTeamResponse` methods in the Issue class.
These methods are used to clean input obtained from the user.
For example, if no description is provided in the bug report, the `updateDescription` method changes the input string to `'No details provided by bug reporter.`