### PR TITLE
Use a spec reporter to print results of tests to terminal

### DIFF
--- a/jasmine.json
+++ b/jasmine.json
@@ -1,4 +1,14 @@
 {
     "spec_dir": "tests",
-    "spec_files": ["**/**/*.spec.ts"]
+    "spec_files": ["**/**/*.spec.ts"],
+    "reporters": [
+      {
+        "name": "jasmine-spec-reporter#SpecReporter",
+        "options": {
+          "spec": {
+            "displayDuration": true
+          }
+        }
+      }
+    ]
  }


### PR DESCRIPTION
Currently, when we run our tests, there is no description of the tests printed to the terminal, unless
one of the tests fails.

Example of current output:
![image](https://user-images.githubusercontent.com/35621759/79229495-afa0cf80-7e95-11ea-87ff-e7724cafcdb9.png)

It may be better to get a more descriptive report on all tests.
Benefit: we can get an overview of the components being tested, and a summary of what exactly the tests are checking.
This would be more useful as the number of tests increases.

I've tried using the [jasmine-spec-reporter module](https://github.com/bcaudan/jasmine-spec-reporter). It was already part of our dev dependencies in `package.json`.

Here is the output from running tests:
![image](https://user-images.githubusercontent.com/35621759/79230284-ec20fb00-7e96-11ea-8c11-8d1d667c8b37.png)
