### PR TITLE
Enable linter on test code

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "electron:mac": "npm run build:prod && electron-builder build --mac",
     "test": "jasmine-ts --config=jasmine.json",
     "e2e": "npm run postinstall:web && ng e2e",
-    "lint": "ng lint --tslint-config"
+    "lint": "ng lint --tslint-config && tslint 'tests/**/*.ts'"
   },
   "dependencies": {
     "@angular/animations": "^7.2.16",


### PR DESCRIPTION
Fixes #367 
Our test code is currently not being checked by a linter.
Let's use TSLint to lint the `tests` directory.