### PR TITLE
Fix configuration so test files are linted

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -116,7 +116,8 @@
           "options": {
             "tsConfig": [
               "src/tsconfig.app.json",
-              "src/tsconfig.spec.json"
+              "src/tsconfig.spec.json",
+              "tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "electron:mac": "npm run build:prod && electron-builder build --mac",
     "test": "jasmine-ts --config=jasmine.json",
     "e2e": "npm run postinstall:web && ng e2e",
-    "lint": "ng lint --tslint-config"
+    "lint": "ng lint",
+    "lint:fix": "ng lint --fix"
   },
   "dependencies": {
     "@angular/animations": "^7.2.16",

--- a/tests/auto-spy.ts
+++ b/tests/auto-spy.ts
@@ -2,7 +2,8 @@
 export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     const res: SpyOf<T> = {} as any;
 
-    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
+    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns [].
+    // So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
     const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
     keys.forEach(key => {
         res[key] = jasmine.createSpy(key);

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -53,7 +53,7 @@ export const jsonData = {
       q: { 'CS2103T-W12-4': 'true' }
     },
     'admins-allocation': { damithc: {}, geshuming: {} }
-  }
+  };
 
   // These are objects representing some users and teams in jsonData
 const TEAM_3 = {
@@ -62,36 +62,36 @@ const TEAM_3 = {
                 {loginId: '003-samuel', role: UserRole.Student}  ,
                 {loginId: 'damithc',  role: UserRole.Student},
                 {loginId: 'ptvrajsk', role: UserRole.Student}]
-}
+};
 
 const TEAM_4 = {
   id: 'CS2103T-W12-4',
   teamMembers: [{loginId: 'ronaklakhotia', role: UserRole.Student}]
-}
+};
 
 export const USER_JUNWEI = {
   loginId: 'junwei96',
   role: UserRole.Student,
   team: TEAM_3
-}
+};
 
 export const USER_Q = {
   loginId: 'q',
   role: UserRole.Tutor,
   allocatedTeams: [TEAM_4]
-}
+};
 
 export const USER_SHUMING = {
   loginId: 'geshuming',
   role: UserRole.Admin,
   allocatedTeams: []
-}
+};
 
 export const USER_WITH_TWO_ROLES = {
   loginId: 'damithc',
   role: UserRole.Admin,
   allocatedTeams: []
-}
+};
 
 export const dataFileTeamStructure: DataFile = {
   teamStructure: new Map<string, Team>([

--- a/tests/constants/githubcomment.constants.ts
+++ b/tests/constants/githubcomment.constants.ts
@@ -1,8 +1,8 @@
-import { GithubComment } from "../../src/app/core/models/github/github-comment.model";
+import { GithubComment } from '../../src/app/core/models/github/github-comment.model';
 
-export const EMPTY_TEAM_RESPONSE : GithubComment = {
+export const EMPTY_TEAM_RESPONSE: GithubComment = {
     author_association: 'CONTRIBUTOR',
-    body: "# Team's Response\n" +
+    body: '# Team\'s Response\n' +
     '\n' +
     ' ## Duplicate status (if any):\n' +
     '--',
@@ -18,4 +18,4 @@ export const EMPTY_TEAM_RESPONSE : GithubComment = {
       avatar_url: 'https://avatars3.githubusercontent.com/u/46639862?v=4',
       url: 'https://api.github.com/users/testathorStudent',
     },
-  }
+  };

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -1,5 +1,5 @@
 import { GithubIssue } from '../../src/app/core/models/github/github-issue.model';
-import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+import { GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
          GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY } from '../constants/githublabel.constants';
 
 export const ISSUE_WITH_EMPTY_DESCRIPTION = new GithubIssue({
@@ -8,7 +8,7 @@ export const ISSUE_WITH_EMPTY_DESCRIPTION = new GithubIssue({
     assignees: [],
     body: '',
     created_at: '2020-03-02T16:19:02Z',
-    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
              GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY
             ],
     state: 'open',
@@ -35,7 +35,7 @@ export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
       ],
     body: 'Screen freezes every few minutes',
     created_at: '2020-01-18T07:01:45Z',
-    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL, 
+    labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
         GITHUB_LABEL_FUNCTIONALITY_BUG, GITHUB_LABEL_MEDIUM_SEVERITY
        ],
     state: 'open',

--- a/tests/constants/githublabel.constants.ts
+++ b/tests/constants/githublabel.constants.ts
@@ -1,29 +1,29 @@
-import { GithubLabel } from "../../src/app/core/models/github/github-issue.model";
+import { GithubLabel } from '../../src/app/core/models/github/github-issue.model';
 
 export const GITHUB_LABEL_FUNCTIONALITY_BUG = {
     color: '9900cc',
     name: 'type.FunctionalityBug',
     id: 1226647550,
     url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/type.FunctionalityBug',
-} as GithubLabel
+} as GithubLabel;
 
 export const GITHUB_LABEL_MEDIUM_SEVERITY =  {
     color: 'ff9999',
     name: 'severity.Medium',
     id: 1226647149,
     url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/severity.Medium',
-} as GithubLabel
+} as GithubLabel;
 
 export const GITHUB_LABEL_TUTORIAL_LABEL = {
     url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/tutorial.CS2103T-W12',
     name: 'tutorial.CS2103T-W12',
     color: 'c2e0c6',
     id: 1226649736,
-} as GithubLabel
+} as GithubLabel;
 
 export const GITHUB_LABEL_TEAM_LABEL = {
     id: 1226649835,
     url: 'https://api.github.com/repos/CATcher-org/pe-results/labels/team.3',
     name: 'team.3',
     color: 'd4c5f9',
-} as GithubLabel
+} as GithubLabel;

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,6 +1,6 @@
-import { Issue } from '../../src/app/core/models/issue.model'
+import { Issue } from '../../src/app/core/models/issue.model';
 
-import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants'
+import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants';
 import { EMPTY_TEAM_RESPONSE } from '../constants/githubcomment.constants';
 
 describe('Issue model class', () => {
@@ -33,8 +33,8 @@ describe('Issue model class', () => {
             expect(Issue.updateDescription(null)).toBe(noDetailsFromBugReporter);
             expect(Issue.updateTeamResponse(undefined)).toBe(noDetailsFromTeam);
 
-            const typicalDescription = 'The app crashes after parsing config files.'
-            const typicalTeamResponse = 'Cannot replicate the bug.'
+            const typicalDescription = 'The app crashes after parsing config files.';
+            const typicalTeamResponse = 'Cannot replicate the bug.';
             expect(Issue.updateDescription(typicalDescription)).toBe(typicalDescription);
             expect(Issue.updateTeamResponse(typicalTeamResponse)).toBe(typicalTeamResponse);
 

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -1,6 +1,6 @@
 import {ApplicationService} from '../../src/app/core/services/application.service';
 
-let applicationService = new ApplicationService(null);
+const applicationService = new ApplicationService(null);
 const currentVersion = '3.2.5';
 
 describe('Test the ApplicationService', () => {

--- a/tests/services/permissions.service.spec.ts
+++ b/tests/services/permissions.service.spec.ts
@@ -11,16 +11,16 @@ const testStudent = {
 const testTutor = {
     loginId: 'testTutor',
     role: UserRole.Tutor
-}
+};
 
 const testAdmin = {
     loginId: 'testAdmin',
     role: UserRole.Admin
-}
+};
 
-let mockUserService = new UserService(null, null);
-let mockPhaseService = new PhaseService(null, null, null, null, null);
-let permissionService = new PermissionService(null, mockUserService, mockPhaseService);
+const mockUserService = new UserService(null, null);
+const mockPhaseService = new PhaseService(null, null, null, null, null);
+const permissionService = new PermissionService(null, mockUserService, mockPhaseService);
 
 describe('Test a few permissions for each role in each phase', () => {
     it('Test a few permissions for UserRole.Student', () => {

--- a/tests/services/upload.service.spec.ts
+++ b/tests/services/upload.service.spec.ts
@@ -1,29 +1,29 @@
 import {UploadService, SUPPORTED_FILE_TYPES, FILE_TYPE_SUPPORT_ERROR} from '../../src/app/core/services/upload.service';
 
-const PERIOD = "."
+const PERIOD = '.';
 
 describe('UploadService', () => {
     describe('.isSupportedFileType(fileName)', () => {
         it('can distinguish valid / invalid filetypes', () => {
             const uploadService = new UploadService(null);
             for (const validFileType of SUPPORTED_FILE_TYPES) {
-                const validFileName = "testFile" + PERIOD + validFileType;
+                const validFileName = 'testFile' + PERIOD + validFileType;
                 expect(uploadService.isSupportedFileType(validFileName)).toBe(true);
             }
-            const invalidFileName = "testFile" + PERIOD + 'java';
+            const invalidFileName = 'testFile' + PERIOD + 'java';
             expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
         });
 
         it('is case insensitive', () => {
           const uploadService = new UploadService(null);
-          const invalidFileName = "TESTfile" + PERIOD + "JS";
+          const invalidFileName = 'TESTfile' + PERIOD + 'JS';
           expect(uploadService.isSupportedFileType(invalidFileName)).toBe(false);
         });
 
         it('returns false for filenames that do not have a file extension', () => {
           const uploadService = new UploadService(null);
           for (const validFileType of SUPPORTED_FILE_TYPES) {
-            const fileNameWithoutFileExtension = "testFile" + validFileType;
+            const fileNameWithoutFileExtension = 'testFile' + validFileType;
             expect(uploadService.isSupportedFileType(fileNameWithoutFileExtension)).toBe(false);
           }
         });

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -1,5 +1,5 @@
-import { jsonData, USER_JUNWEI, USER_Q, USER_SHUMING, USER_WITH_TWO_ROLES } from '../constants/data.constants'
-import { UserService } from '../../src/app/core/services/user.service'
+import { jsonData, USER_JUNWEI, USER_Q, USER_SHUMING, USER_WITH_TWO_ROLES } from '../constants/data.constants';
+import { UserService } from '../../src/app/core/services/user.service';
 import { User, UserRole } from '../../src/app/core/models/user.model';
 import { of } from 'rxjs';
 
@@ -8,7 +8,7 @@ let dataService: any;
 describe('UserService', () => {
   describe('.createUserModel(loginId)', () => {
     beforeAll(() => {
-      dataService = jasmine.createSpyObj("DataService", ['getDataFile']);
+      dataService = jasmine.createSpyObj('DataService', ['getDataFile']);
       dataService.getDataFile.and.returnValue(of(jsonData));
     });
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,8 +1,29 @@
 {
   "extends": "tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../out-tsc/spec",
+    "module": "commonjs",
+    "types": [
+      "jasmine",
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "core-js/es7/reflect": ["../node_modules/core-js/proposals/reflect-metadata"],
+      "core-js/es6/": ["../node_modules/core-js/es/"]
+    }
+  },
+  "files": [
+    "test.ts",
+    "polyfills-test.ts"
+  ],
   "include": [
-    "main.ts",
-    "src/**/*",
-    "tests/**/*"
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "dist",
+    "release",
+    "node_modules"
   ]
 }


### PR DESCRIPTION
I've configured it so that `ng lint` will use the `tsconfig.spec.json` in the root to figure out what files needs to be linted.

I've also added a `lint:fix` script so that the files can be manually linted if necessary

Resolves #367 