### PR TITLE
DataService tests: Add integration test, improve spec description

### DIFF
--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -16,9 +16,8 @@ tutor,q     ,CS2103T-W12-4
 student,003-samuel,CS2103T-W12-3
 student,damithc,CS2103T-W12-3
 student,RonakLakhotia,CS2103T-W12-4
-student,ptvrajsk,CS2103T-W12-3
-               
-`;
+student,ptvrajsk,CS2103T-W12-3` +
+`                       `;
 
 // jsonData is a json representation of csvString
 export const jsonData = {

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -8,14 +8,16 @@ student,JunWei96,CS2103T-W12-3
 admin,damithc,
 tutor,anubh-v,CS2103T-W12-3
 admin,geshuming,
+
 tutor,jj-lim,CS2103T-W12-3
 tutor,jj-lim,CS2103T-W12-3
 tutor,jj-lim,CS2103T-W12-4
-tutor,q,CS2103T-W12-4
+tutor,q     ,CS2103T-W12-4
 student,003-samuel,CS2103T-W12-3
 student,damithc,CS2103T-W12-3
 student,RonakLakhotia,CS2103T-W12-4
 student,ptvrajsk,CS2103T-W12-3
+               
 `;
 
 // jsonData is a json representation of csvString

--- a/tests/services/data.service.spec.ts
+++ b/tests/services/data.service.spec.ts
@@ -5,8 +5,8 @@ import { autoSpy } from '../auto-spy';
 import { csvString, jsonData, dataFileTeamStructure } from '../constants/data.constants';
 
 describe('DataService', () => {
-  describe('getDataFile', () => {
-    it('should return the correct data', done => {
+  describe('.getDataFile()', () => {
+    it('returns a json representation of the repo\'s data csv', done => {
       const { build, githubService } = setup();
       const dataService = build();
       githubService.fetchDataFile.and.returnValue(of({'data': csvString}));
@@ -17,7 +17,7 @@ describe('DataService', () => {
       });
     });
 
-    it('should set dataFile with correct data', done => {
+    it('initializes an internal data structure that maps teamIds to Team objects', done => {
       const { build, githubService } = setup();
       const dataService = build();
       githubService.fetchDataFile.and.returnValue(of({'data': csvString}));
@@ -29,8 +29,8 @@ describe('DataService', () => {
     });
   });
 
-  describe('getTeam', () => {
-    it('should return the correct data', () => {
+  describe('.getTeam(teamId)', () => {
+    it('returns the Team object corresponding to the given teamId', () => {
       // arrange
       const { build } = setup();
       const dataService = build();
@@ -48,8 +48,8 @@ describe('DataService', () => {
     });
   });
 
-  describe('getTeams', () => {
-    it('should return the correct data', () => {
+  describe('.getTeams()', () => {
+    it('returns an array containing ids of the teams in the repo\'s data csv', () => {
       // arrange
       const { build } = setup();
       const dataService = build();
@@ -69,8 +69,8 @@ describe('DataService', () => {
     });
   });
 
-  describe('reset', () => {
-      it('should set dataFile to undefined', () => {
+  describe('.reset()', () => {
+      it('clears the internal state of the DataService', () => {
       // arrange
       const { build } = setup();
       const dataService = build();


### PR DESCRIPTION
Fixes #397 
Fixes #417

This PR re-phrases the DataService spec descriptions, to be in line with the convention discussed
in #390. It also adds an empty line, blank line and some trailing spaces into the test data csv. This allows us to test the behaviour added in #406 