### PR TITLE
Add .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,43 @@
+environment: # Default Set Already to Windows 
+  nodejs_version: "12"
+
+  matrix:
+    - job_name: Build
+
+    - job_name: Linter Tests
+
+    - job_name: Unit Tests
+
+branches:
+  only:
+    - master
+
+install:
+  - npm install
+
+cache:
+  - node_modules
+
+build: off # Skip Visual Studio Build
+
+for:
+-
+  matrix:
+    only: 
+      - job_name: Build 
+  build_script:
+    - npm run build 
+
+-
+  matrix:
+    only:
+      - job_name: Linter Tests
+  test_script:
+  - npm run lint
+
+-
+  matrix:
+    only:
+      - job_name: Unit Tests
+  test_script:
+  - npm run test


### PR DESCRIPTION
# Summary 

This PR addresses one of the sub-tasks in Issue #434 , which is to test build and tests for Windows using AppVeyor 

## Considerations 

1. Concurrent Jobs are not supported for Free Version of AppVeyor unless we upgrade to paid plans 😞 
2. Visual Studio build is disabled as we don't use Visual Studio for CATcher setup 


