### PR TITLE
Add Pre-Push Check for Git Hooks using Husky 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "lint": "ng lint",
     "lint:fix": "ng lint --fix"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint && npm run test"
+    }
+  },
   "dependencies": {
     "@angular/animations": "^7.2.16",
     "@angular/cdk": "^7.3.7",
@@ -59,6 +64,7 @@
     "electron": "7.1.9",
     "electron-builder": "22.2.0",
     "electron-reload": "1.5.0",
+    "husky": "^4.2.5",
     "jasmine": "^3.5.0",
     "jasmine-core": "3.5.0",
     "jasmine-spec-reporter": "4.2.1",


### PR DESCRIPTION
# Summary 
This PR Addresses #391 where a pre-push hook is supposed to be added for linting and testing 

## Description 
By Defining the command in `husky` under `package.json`, you can define what needs to be passed before the push is enabled. 