### PR TITLE
Update usage notes 

### DIFF
--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -5,6 +5,7 @@ You can download the latest release from https://github.com/CATcher-org/CATcher/
 Start the application by clicking on the executable file, no installation is required.
 
 The app will prompt you to enter the session you are participating in, using a dropdown.
+
 ![session_select](https://imgur.com/nBOy7zH.png)
 
 ## For Windows Users
@@ -12,8 +13,7 @@ For normal usage, you can run the `CATcher.exe` and the following dialog would a
 
 ![windows_warning](https://imgur.com/4p0Yn7s.png)
 
-In some cases, the "Run Anyway" button would not appear. To troubleshoot this, you can open up "Windows Security" and under "App & browser control", make sure your setting conforms to the following.
-![app_control](https://imgur.com/lFgVPSd.png=50x)
+In some cases, the "Run Anyway" button may not appear. To troubleshoot this, you can open up "Windows Security" and under "App & browser control", click on "Reputation-based protection settings" and make sure CATcher is not blocked here.
 
 ## For Mac Users
 To run CATcher on MacOS, you would need to go to "System Preferences" and in "Security & Privacy", select "Open Anyway" for CATcher, as shown below.


### PR DESCRIPTION
It seems like Windows have updated their SmartScreen Software and their user interface is now different. 

The steps to run CATcher on Mac and Linux remains unchanged when I tried to testing it.