### PR TITLE
Hidden session Id for bug reports

### DIFF
--- a/src/app/core/models/hidden-data.model.ts
+++ b/src/app/core/models/hidden-data.model.ts
@@ -1,0 +1,53 @@
+/**
+ * A model to represent a hidden dataset stored in a string.
+ */
+export class HiddenData {
+  private static REGEX = /<!--(.*?)-->/gm;
+
+  readonly originalStringWithoutHiddenData: string;
+  private data = new Map<string, string>();
+
+  constructor(data: string) {
+    const matches = data.match(HiddenData.REGEX);
+    this.originalStringWithoutHiddenData = data.replace(HiddenData.REGEX, '').trim();
+    if (matches === null) {
+      return;
+    }
+
+    for (const match of data.match(HiddenData.REGEX)) {
+      let info = match.replace('<!--', '').trim();
+      info = info.replace('-->', '').trim();
+      const keyValuePair = info.split(':').map(v => v.trim());
+      if (keyValuePair.length !== 2) {
+        this.originalStringWithoutHiddenData += `\n${match}`;
+        continue;
+      }
+
+      const [key, value] = keyValuePair;
+      if (!this.data.has(key)) {
+        this.data.set(key, value);
+      }
+    }
+  }
+
+  /**
+   * @param originalString - The original string to append the hidden data into.
+   * @param hiddenData - The map of hidden data to be embedded into the string.
+   * @returns - The string with the embedded data.
+   */
+  static embedDataIntoString(originalString: string, hiddenData: Map<string, string>): string {
+    let result = originalString;
+    hiddenData.forEach((value, key) => {
+      result += `\n<!--${key}: ${value}-->`;
+    });
+    return result;
+  }
+
+  toString(): string {
+    let result = '';
+    this.data.forEach((value, key) => {
+      result += `<!--${key}: ${value}-->`;
+    });
+    return result;
+  }
+}

--- a/src/app/core/models/hidden-data.model.ts
+++ b/src/app/core/models/hidden-data.model.ts
@@ -14,7 +14,7 @@ export class HiddenData {
       return;
     }
 
-    for (const match of data.match(HiddenData.REGEX)) {
+    for (const match of matches) {
       let info = match.replace('<!--', '').trim();
       info = info.replace('-->', '').trim();
       const keyValuePair = info.split(':').map(v => v.trim());

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -11,6 +11,7 @@ import { TutorModerationIssueTemplate } from './templates/tutor-moderation-issue
 import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-template.model';
 import { Phase } from '../services/phase.service';
 import * as moment from 'moment';
+import { HiddenData } from './hidden-data.model';
 
 export class Issue {
 
@@ -22,6 +23,7 @@ export class Issue {
   githubComments: GithubComment[];
   title: string;
   description: string;
+  hiddenDataInDescription: HiddenData;
 
   /** Fields derived from Labels */
   severity: string;
@@ -76,7 +78,8 @@ export class Issue {
     this.id = +githubIssue.number;
     this.created_at = moment(githubIssue.created_at).format('lll');
     this.title = githubIssue.title;
-    this.description = Issue.updateDescription(githubIssue.body);
+    this.hiddenDataInDescription = new HiddenData(githubIssue.body);
+    this.description = Issue.updateDescription(this.hiddenDataInDescription.originalStringWithoutHiddenData);
     this.githubIssue = githubIssue;
 
     /** Fields derived from Labels */
@@ -211,6 +214,10 @@ export class Issue {
       dispute.description = this.issueDisputes[i].description;
       return dispute;
     });
+  }
+
+  createGithubIssueDescription(): string {
+    return `${this.description}\n${this.hiddenDataInDescription.toString()}`;
   }
 
   // Template url: https://github.com/CATcher-org/templates#dev-response-phase

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -13,6 +13,7 @@ import { DataService } from './data.service';
 import { LabelService } from './label.service';
 import { Title } from '@angular/platform-browser';
 import { GithubEventService } from './githubevent.service';
+import { uuid } from '../../shared/lib/uuid';
 
 export enum AuthState { 'NotAuthenticated', 'AwaitingAuthentication', 'ConfirmOAuthUser', 'Authenticated'}
 
@@ -81,6 +82,9 @@ export class AuthService {
   }
 
   changeAuthState(newAuthState: AuthState) {
+    if (newAuthState === AuthState.Authenticated) {
+      this.issueService.setSessionId(`${Date.now()}-${uuid()}`);
+    }
     this.authStateSource.next(newAuthState);
   }
 

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -95,10 +95,9 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   }
 
   markAsResponded(issue: Issue) {
-    this.issueService.updateIssue(<Issue>{
-      ...issue,
-      status: STATUS.Done
-    }).subscribe((updatedIssue) => {
+    const newIssue = issue.clone(this.phaseService.currentPhase);
+    newIssue.status = STATUS.Done;
+    this.issueService.updateIssue(newIssue).subscribe((updatedIssue) => {
       this.issueService.updateLocalStore(updatedIssue);
     }, error => {
       this.errorHandlingService.handleError(error);
@@ -111,10 +110,9 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   }
 
   markAsPending(issue: Issue) {
-    this.issueService.updateIssue(<Issue>{
-      ...issue,
-      status: STATUS.Incomplete
-    }).subscribe((updatedIssue) => {
+    const newIssue = issue.clone(this.phaseService.currentPhase);
+    newIssue.status = STATUS.Incomplete;
+    this.issueService.updateIssue(newIssue).subscribe((updatedIssue) => {
       this.issueService.updateLocalStore(updatedIssue);
     }, error => {
       this.errorHandlingService.handleError(error);

--- a/src/app/shared/issue/assignee/assignee.component.ts
+++ b/src/app/shared/issue/assignee/assignee.component.ts
@@ -5,6 +5,7 @@ import { Team } from '../../../core/models/team.model';
 import { IssueService } from '../../../core/services/issue.service';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { PermissionService } from '../../../core/services/permission.service';
+import { PhaseService } from '../../../core/services/phase.service';
 
 @Component({
   selector: 'app-assignee-component',
@@ -25,7 +26,9 @@ export class AssigneeComponent implements OnInit {
 
   @Output() issueUpdated = new EventEmitter<Issue>();
 
-  constructor(private issueService: IssueService, private errorHandlingService: ErrorHandlingService,
+  constructor(private issueService: IssueService,
+              private errorHandlingService: ErrorHandlingService,
+              private phaseService: PhaseService,
               public permissions: PermissionService) {
   }
 
@@ -46,12 +49,10 @@ export class AssigneeComponent implements OnInit {
   }
 
   updateAssignee(): void {
-    const latestIssue = <Issue>{
-      ...this.issue,
-      assignees: this.assignees
-    };
-    this.issueService.updateIssue(latestIssue).subscribe((updatedIssue: Issue) => {
-      this.issueUpdated.emit(latestIssue);
+    const newIssue = this.issue.clone(this.phaseService.currentPhase);
+    newIssue.assignees = this.assignees;
+    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
+      this.issueUpdated.emit(updatedIssue);
     }, (error) => {
       this.errorHandlingService.handleError(error);
     });

--- a/src/app/shared/issue/description/description.component.ts
+++ b/src/app/shared/issue/description/description.component.ts
@@ -33,8 +33,8 @@ export class DescriptionComponent implements OnInit {
               private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService,
               private dialog: MatDialog,
-              public permissions: PermissionService,
-              public phaseService: PhaseService) {
+              private phaseService: PhaseService,
+              public permissions: PermissionService) {
   }
 
   ngOnInit() {

--- a/src/app/shared/issue/description/description.component.ts
+++ b/src/app/shared/issue/description/description.component.ts
@@ -10,6 +10,7 @@ import { throwError } from 'rxjs';
 import { Conflict } from '../../../core/models/conflict/conflict.model';
 import { MatDialog } from '@angular/material';
 import { ConflictDialogComponent } from '../conflict-dialog/conflict-dialog.component';
+import { PhaseService } from '../../../core/services/phase.service';
 
 @Component({
   selector: 'app-issue-description',
@@ -32,7 +33,8 @@ export class DescriptionComponent implements OnInit {
               private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService,
               private dialog: MatDialog,
-              public permissions: PermissionService) {
+              public permissions: PermissionService,
+              public phaseService: PhaseService) {
   }
 
   ngOnInit() {
@@ -103,9 +105,8 @@ export class DescriptionComponent implements OnInit {
   }
 
   private getUpdatedIssue(): Issue {
-    return <Issue> {
-      ...this.issue,
-      ['description']: Issue.updateDescription(this.issueDescriptionForm.get('description').value)
-    };
+    const newIssue = this.issue.clone(this.phaseService.currentPhase);
+    newIssue.description = Issue.updateDescription(this.issueDescriptionForm.get('description').value);
+    return newIssue;
   }
 }

--- a/src/app/shared/issue/label/label.component.ts
+++ b/src/app/shared/issue/label/label.component.ts
@@ -6,6 +6,7 @@ import { ErrorHandlingService } from '../../../core/services/error-handling.serv
 import { PermissionService } from '../../../core/services/permission.service';
 import { Label } from '../../../core/models/label.model';
 import { LabelService } from '../../../core/services/label.service';
+import { PhaseService } from '../../../core/services/phase.service';
 
 @Component({
   selector: 'app-issue-label',
@@ -24,6 +25,7 @@ export class LabelComponent implements OnInit, OnChanges {
   constructor(private issueService: IssueService,
               private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService,
+              private phaseService: PhaseService,
               public labelService: LabelService,
               public permissions: PermissionService) {
   }
@@ -39,13 +41,11 @@ export class LabelComponent implements OnInit, OnChanges {
   }
 
   updateLabel(value: string) {
-    const latestIssue = <Issue>{
-    ...this.issue,
-      [this.attributeName]: value
-    };
-    this.issueService.updateIssue(latestIssue).subscribe((editedIssue: Issue) => {
-      this.issueUpdated.emit(latestIssue);
-      this.labelColor = this.labelService.getColorOfLabel(editedIssue[this.attributeName]);
+    const newIssue = this.issue.clone(this.phaseService.currentPhase);
+    newIssue[this.attributeName] = value;
+    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
+      this.issueUpdated.emit(updatedIssue);
+      this.labelColor = this.labelService.getColorOfLabel(updatedIssue[this.attributeName]);
     }, (error) => {
       this.errorHandlingService.handleError(error);
     });

--- a/src/app/shared/issue/title/title.component.ts
+++ b/src/app/shared/issue/title/title.component.ts
@@ -50,10 +50,9 @@ export class TitleComponent implements OnInit {
     }
 
     this.isSavePending = true;
-    this.issueService.updateIssue(<Issue>{
-      ...this.issue,
-      title: this.issueTitleForm.get('title').value,
-    }).pipe(finalize(() => {
+    const newIssue = this.issue.clone(this.phaseService.currentPhase);
+    newIssue.title = this.issueTitleForm.get('title').value;
+    this.issueService.updateIssue(newIssue).pipe(finalize(() => {
       this.isEditing = false;
       this.isSavePending = false;
     })).subscribe((editedIssue: Issue) => {

--- a/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.ts
+++ b/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Issue } from '../../../core/models/issue.model';
 import { IssueService } from '../../../core/services/issue.service';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
+import { PhaseService } from '../../../core/services/phase.service';
 
 @Component({
   selector: 'app-unsure-checkbox',
@@ -15,7 +16,8 @@ export class UnsureCheckboxComponent implements OnInit {
   @Output() issueUpdated = new EventEmitter<Issue>();
 
   constructor(private issueService: IssueService,
-    private errorHandlingService: ErrorHandlingService) { }
+              private errorHandlingService: ErrorHandlingService,
+              private phaseService: PhaseService) { }
 
   ngOnInit() {
   }
@@ -27,10 +29,9 @@ export class UnsureCheckboxComponent implements OnInit {
       UNSURE = true;
     }
 
-    this.issueService.updateIssue(<Issue>{
-      ...this.issue,
-      unsure: UNSURE,
-    }).subscribe((updatedIssue: Issue) => {
+    const newIssue = this.issue.clone(this.phaseService.currentPhase);
+    newIssue.unsure = UNSURE;
+    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
       this.issueUpdated.emit(updatedIssue);
     }, (error) => {
       this.errorHandlingService.handleError(error);

--- a/tests/app/shared/issue/label/label.component.spec.ts
+++ b/tests/app/shared/issue/label/label.component.spec.ts
@@ -5,19 +5,22 @@ import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { SEVERITY_LABELS, COLOR_SEVERITY_LOW, SEVERITY, COLOR_SEVERITY_HIGH, SEVERITY_HIGH } from '../../../../constants/label.constants';
 import { of } from 'rxjs';
+import { Phase, PhaseService } from '../../../../../src/app/core/services/phase.service';
 
 describe('LabelComponent', () => {
   let labelComponent: any;
   let issueService: any;
   let labelService: any;
+  let phaseService: any;
   let thisIssue: Issue;
   let issueUpdatedEmit: any;
 
   beforeEach(() => {
     labelService = jasmine.createSpyObj(LabelService, ['getLabelList', 'getColorOfLabel']);
     issueService = jasmine.createSpyObj('IssueService', ['updateIssue']);
+    phaseService = jasmine.createSpyObj(PhaseService, ['currentPhase']);
 
-    labelComponent = new LabelComponent(issueService, null, null, labelService, null);
+    labelComponent = new LabelComponent(issueService, null, null, phaseService, labelService, null);
     thisIssue =  Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
     labelComponent.issue = thisIssue;
     labelComponent.attributeName = SEVERITY;
@@ -42,6 +45,7 @@ describe('LabelComponent', () => {
     labelComponent.ngOnChanges();
 
     labelService.getColorOfLabel.and.returnValue(COLOR_SEVERITY_HIGH);
+    phaseService.currentPhase.and.returnValue(Phase.phaseBugReporting);
     issueService.updateIssue.and.callFake((x: Issue) => of(x));
     labelComponent.updateLabel(SEVERITY_HIGH);
 


### PR DESCRIPTION
A hidden session Id will be appended to bug report in following format:
```
<!--session: <epoch-time-milliseconds>-<uuid>-->
```
Behavior:
1. If the bug report is updated, the original sessionId will be retained. Even if a new logged in user update the bug report, the sessionId will still be session Id of the original creator.
2. Data of other commented out information will be retained. The position of these commented out code will be shifted below the issue description.