### PR TITLE
Move function getNumberOfPages into separate module

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { catchError, filter, flatMap, map, throwIfEmpty } from 'rxjs/operators';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
-import { githubPaginatorParser } from '../../shared/lib/github-paginator-parser';
+import { getNumberOfPages } from '../../shared/lib/github-paginator-parser';
 import { IssueComment } from '../models/comment.model';
 import { shell } from 'electron';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
@@ -105,7 +105,7 @@ export class GithubService {
     return this.getIssuesAPICall(filter, 1).pipe(
       map((response: GithubResponse<GithubIssue[]>) => {
         responseInFirstPage = response;
-        return this.getNumberOfPages(response);
+        return getNumberOfPages(response);
       }),
       flatMap((numOfPages: number) => {
         const apiCalls: Observable<GithubResponse<GithubIssue[]>>[] = [];
@@ -328,19 +328,6 @@ export class GithubService {
     this.issuesCacheManager.clear();
     this.issuesLastModifiedManager.clear();
     this.issueQueryRefs.clear();
-  }
-
-  /**
-   * Get the number of paginated pages of issues in Github.
-   * @param response
-   */
-  private getNumberOfPages<T>(response: GithubResponse<T>): number {
-    let numberOfPages = 1;
-    if (response.headers.link) {
-      const paginatedData = githubPaginatorParser(response.headers.link);
-      numberOfPages = +paginatedData['last'] || 1;
-    }
-    return numberOfPages;
   }
 
   private getIssuesAPICall(filter: RestGithubIssueFilter, pageNumber: number): Observable<GithubResponse<GithubIssue[]>> {

--- a/src/app/shared/lib/github-paginator-parser.ts
+++ b/src/app/shared/lib/github-paginator-parser.ts
@@ -1,3 +1,18 @@
+import { GithubResponse } from 'src/app/core/models/github/github-response.model';
+
+/**
+ * Get the number of paginated pages of issues specified in a GitHubResponse
+ * @param response
+ */
+export function getNumberOfPages<T>(response: GithubResponse<T>): number {
+  let numberOfPages = 1;
+  if (response.headers.link) {
+    const paginatedData = githubPaginatorParser(response.headers.link);
+    numberOfPages = +paginatedData['last'] || 1;
+  }
+  return numberOfPages;
+}
+
 /**
  * Will return in the format of { paginateAction: number }
  * Example { next: '15', last: '34', first: '1', prev: '13' }
@@ -7,7 +22,7 @@
  * @param linkStr represent the pagination string provided by github API.
  *
  */
-export function githubPaginatorParser(linkStr: string) {
+function githubPaginatorParser(linkStr: string) {
   return linkStr.split(',').map((paginateItem) => {
     return paginateItem.split(';').map((curr, idx) => {
       if (idx === 0) {

--- a/src/app/shared/lib/github-paginator-parser.ts
+++ b/src/app/shared/lib/github-paginator-parser.ts
@@ -1,4 +1,4 @@
-import { GithubResponse } from 'src/app/core/models/github/github-response.model';
+import { GithubResponse } from '../../core/models/github/github-response.model';
 
 /**
  * Get the number of paginated pages of issues specified in a GitHubResponse


### PR DESCRIPTION
There isn't a strong reason for this function to be located in GitHubService.
Let's move it into `github-paginator-parser`, as it is directly related to this module.