### PR TITLE
Add Conflict Model Tests

### DIFF
--- a/src/app/core/models/conflict/conflict.model.ts
+++ b/src/app/core/models/conflict/conflict.model.ts
@@ -1,4 +1,4 @@
-import DiffMatchPatch from 'diff-match-patch';
+import { diff_match_patch } from 'diff-match-patch';
 import { escapeHTML, replaceNewlinesWithBreakLines } from '../../../shared/lib/html';
 import { Changes } from './changes.model';
 import { Removal } from './removal.model';
@@ -17,7 +17,7 @@ export class Conflict {
     this.outdatedContent = outdatedContent;
     this.updatedContent = updatedContent;
 
-    const matcher = new DiffMatchPatch();
+    const matcher = new diff_match_patch();
     const diffs = matcher.diff_main(outdatedContent, updatedContent);
     matcher.diff_cleanupSemantic(diffs);
     for (const diff of diffs) {

--- a/tests/app/core/models/conflict/conflict.model.spec.ts
+++ b/tests/app/core/models/conflict/conflict.model.spec.ts
@@ -1,0 +1,50 @@
+import { Conflict } from '../../../../../src/app/core/models/conflict/conflict.model';
+import { NoChange } from '../../../../../src/app/core/models/conflict/no-change.model';
+import { Addition } from '../../../../../src/app/core/models/conflict/addition.model';
+import { Removal } from '../../../../../src/app/core/models/conflict/removal.model';
+import { replaceNewlinesWithBreakLines } from '../../../../../src/app/shared/lib/html';
+
+
+describe('TitleComponent', () => {
+  let longerString: string;
+  let shorterString: string;
+
+  let additionalCharacters: string;
+  let conflict: Conflict;
+
+  beforeEach(() => {
+    additionalCharacters = ' Sample Text';
+    shorterString = 'Some Content that I would want to insert my java \n here';
+    longerString = shorterString + additionalCharacters;
+  });
+
+  it('should return a diff string with no conflicts with given the same string', () => {
+    conflict = new Conflict(longerString, longerString);
+    const noChangeConflict = new NoChange(longerString);
+    const noConflictString = replaceNewlinesWithBreakLines(noChangeConflict.getHtmlString());
+
+    expect(conflict.getHtmlDiffString().includes(noConflictString)).toEqual(true);
+  });
+
+  it('should return a diff string with Removal conflicts with given the same string with removed characters', () => {
+    conflict = new Conflict(longerString, shorterString);
+    const noChangeConflict = new NoChange(shorterString);
+    const noConflictString = replaceNewlinesWithBreakLines(noChangeConflict.getHtmlString());
+    const removalConflict = new Removal(additionalCharacters);
+    const removalConflictString = replaceNewlinesWithBreakLines(removalConflict.getHtmlString());
+
+    expect(conflict.getHtmlDiffString().includes(noConflictString)).toEqual(true);
+    expect(conflict.getHtmlDiffString().includes(removalConflictString)).toEqual(true);
+  });
+
+  it('should return a diff string with Addition conflicts with given the same string with additions', () => {
+    conflict = new Conflict(shorterString, longerString);
+    const noChangeConflict = new NoChange(shorterString);
+    const noConflictString = replaceNewlinesWithBreakLines(noChangeConflict.getHtmlString());
+    const additionConflict = new Addition(additionalCharacters);
+    const additionConflictString = replaceNewlinesWithBreakLines(additionConflict.getHtmlString());
+
+    expect(conflict.getHtmlDiffString().includes(noConflictString)).toEqual(true);
+    expect(conflict.getHtmlDiffString().includes(additionConflictString)).toEqual(true);
+  });
+});


### PR DESCRIPTION
# Summary 

Fixed Issue #469, which requires simple instance tests for `Conflict` model class. 

## Description 

Fixed a critical bug under `conflict.model.ts` whereby the constructor of `diff-match-patch` is actually incorrect. As a result, with the corrected constructor, now the algorithm works. 

Also, added simple tests for the following: 

1. No Change 
2. Removal
3. Additions