### PR TITLE
Adding Tests for Instance Methods for Issue Model

### DIFF
--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -75,7 +75,7 @@ describe('Issue', () => {
         githubComment.body = 'Sample Text';
 
         newIssueDispute = new IssueDispute('Cannot Work', 'Help Please');
-        newTesterResponse = new TesterResponse('Cannot Work', 'Help Please', 'Checkbox', 'Reason');
+        newTesterResponse = new TesterResponse('Cannot Work', 'Help Please', '- [ ] Not Done', 'Reason');
     });
 
     it('should be initialized with the correct phase and team with clone()', () => {
@@ -141,5 +141,19 @@ describe('Issue', () => {
         expect(phaseTesterResponseIssue2.createGithubTesterResponse()).toEqual(
             `# Team\'s Response\n${phaseTesterResponseIssue.teamResponse}\n ` +
         `# Items for the Tester to Verify\n${newTesterResponse.toString()}`);
+    });
+
+    it ('returns the correct number of issue disputes', () => {
+        const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
+        expect(phaseModerationIssue.numOfUnresolvedDisputes()).toEqual(0);
+
+        const phaseModerationIssue2 = dummyIssueWithTeam.clone(Phase.phaseModeration);
+        phaseModerationIssue2.issueDisputes = [newIssueDispute];
+        expect(phaseModerationIssue2.numOfUnresolvedDisputes()).toEqual(1);
+
+        const phaseModerationIssue3 = dummyIssueWithTeam.clone(Phase.phaseModeration);
+        phaseModerationIssue3.issueDisputes = [newIssueDispute];
+        newIssueDispute.todo = '- [x] Done' ;
+        expect(phaseModerationIssue3.numOfUnresolvedDisputes()).toEqual(0);
     });
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -89,7 +89,7 @@ describe('Issue', () => {
             .toEqual(`${phaseBugReportingIssueWithDescription.description}\n`);
     });
 
-    it('.clone() should be able to get the proper Team Response', () => {
+    it('.createGithubTeamResponse() should be able to get the proper Team Response', () => {
         const phaseTeamResponseIssue = dummyIssue.clone(Phase.phaseTeamResponse);
         phaseTeamResponseIssue.teamResponse = 'Sample Text';
         expect(phaseTeamResponseIssue.createGithubTeamResponse())
@@ -103,7 +103,7 @@ describe('Issue', () => {
                 + `## Duplicate status (if any):\nDuplicate of #${phaseTeamResponseIssue2.duplicateOf}`);
     });
 
-    it ('.clone() should be able to get the proper Tutor Response', () => {
+    it ('.createGithubTutorResponse() should be able to get the proper Tutor Response', () => {
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.createGithubTutorResponse()).toEqual(tutorResponseStringHeader);
 
@@ -113,7 +113,7 @@ describe('Issue', () => {
             + newIssueDispute.toTutorResponseString());
     });
 
-    it ('.clone() should be able to get the proper Tester Response', () => {
+    it ('.createGithubTesterResponse() should be able to get the proper Tester Response', () => {
         const phaseTesterResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTesterResponse);
         phaseTesterResponseIssue.teamResponse = 'Sample Text';
         phaseTesterResponseIssue.testerResponses = [];

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,4 +1,3 @@
-import { GithubComment } from '../../src/app/core/models/github/github-comment.model';
 import { IssueDispute } from '../../src/app/core/models/issue-dispute.model';
 import { Issue } from '../../src/app/core/models/issue.model';
 import { Team } from '../../src/app/core/models/team.model';
@@ -52,7 +51,7 @@ describe('Issue model class', () => {
 describe('Issue', () => {
     const dummyTeam = new Team({
         id: 'F09-2',
-        teamMembers: []
+        teamMembers: [],
     });
     const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
     const otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -50,12 +50,6 @@ describe('Issue model class', () => {
 });
 
 describe('Issue', () => {
-    let dummyTeam: Team;
-    let dummyIssue: Issue;
-    let otherDummyIssue: Issue;
-    let dummyIssueWithTeam: Issue;
-
-    let githubComment: GithubComment;
     let newIssueDispute: IssueDispute;
     let newTesterResponse: TesterResponse;
 
@@ -63,22 +57,18 @@ describe('Issue', () => {
     const tutorResponseStringHeader = '# Tutor Moderation\n\n';
 
     beforeEach(() => {
-        dummyTeam = new Team({
-            id: 'F09-2',
-            teamMembers: []
-        });
-        dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-        otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
-        dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-
-        githubComment = new GithubComment();
-        githubComment.body = 'Sample Text';
-
         newIssueDispute = new IssueDispute('Cannot Work', 'Help Please');
         newTesterResponse = new TesterResponse('Cannot Work', 'Help Please', '- [ ] Not Done', 'Reason');
     });
 
-    it('should be initialized with the correct phase and team with clone()', () => {
+    it('.clone() should intialise the cloned issue with the correct phase and team', () => {
+        const dummyTeam = new Team({
+            id: 'F09-2',
+            teamMembers: []
+        });
+        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+
         const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
         expect(phaseBugReportingIssue).toEqual(dummyIssue);
 
@@ -94,7 +84,10 @@ describe('Issue', () => {
         expect(phaseModerationIssue.teamAssigned).toEqual(dummyTeam);
     });
 
-    it('should be able to get the proper Github Issue descriptions', () => {
+    it('.createGithubIssueDescription() forms the correct GitHub Issue description for the issue', () => {
+        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+        const otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
+
         const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
         expect(phaseBugReportingIssue.createGithubIssueDescription()).toEqual(noReportedDescriptionString);
 
@@ -104,6 +97,8 @@ describe('Issue', () => {
     });
 
     it('should be able to get the proper Team Response', () => {
+        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+        
         const phaseTeamResponseIssue = dummyIssue.clone(Phase.phaseTeamResponse);
         phaseTeamResponseIssue.teamResponse = 'Sample Text';
         expect(phaseTeamResponseIssue.createGithubTeamResponse())
@@ -118,6 +113,12 @@ describe('Issue', () => {
     });
 
     it ('should be able to get the proper Tutor Response', () => {
+        const dummyTeam = new Team({
+            id: 'F09-2',
+            teamMembers: []
+        });
+        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.createGithubTutorResponse()).toEqual(tutorResponseStringHeader);
 
@@ -128,6 +129,12 @@ describe('Issue', () => {
     });
 
     it ('should be able to get the proper Tester Response', () => {
+        const dummyTeam = new Team({
+            id: 'F09-2',
+            teamMembers: []
+        });
+        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+
         const phaseTesterResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTesterResponse);
         phaseTesterResponseIssue.teamResponse = 'Sample Text';
         phaseTesterResponseIssue.testerResponses = [];
@@ -143,7 +150,13 @@ describe('Issue', () => {
         `# Items for the Tester to Verify\n${newTesterResponse.toString()}`);
     });
 
-    it ('returns the correct number of issue disputes', () => {
+    it ('.numOfUnresolvedDisputes() returns the correct number of issue disputes', () => {
+        const dummyTeam = new Team({
+            id: 'F09-2',
+            teamMembers: []
+        });
+        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.numOfUnresolvedDisputes()).toEqual(0);
 
@@ -153,7 +166,7 @@ describe('Issue', () => {
 
         const phaseModerationIssue3 = dummyIssueWithTeam.clone(Phase.phaseModeration);
         phaseModerationIssue3.issueDisputes = [newIssueDispute];
-        newIssueDispute.todo = '- [x] Done' ;
+        newIssueDispute.setIsDone(true);
         expect(phaseModerationIssue3.numOfUnresolvedDisputes()).toEqual(0);
     });
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -50,25 +50,21 @@ describe('Issue model class', () => {
 });
 
 describe('Issue', () => {
-    let newIssueDispute: IssueDispute;
-    let newTesterResponse: TesterResponse;
+    const dummyTeam = new Team({
+        id: 'F09-2',
+        teamMembers: []
+    });
+    const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+    const otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
+    const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
 
     const noReportedDescriptionString = 'No details provided by bug reporter.\n';
     const tutorResponseStringHeader = '# Tutor Moderation\n\n';
 
-    beforeEach(() => {
-        newIssueDispute = new IssueDispute('Cannot Work', 'Help Please');
-        newTesterResponse = new TesterResponse('Cannot Work', 'Help Please', '- [ ] Not Done', 'Reason');
-    });
+    const newIssueDispute = new IssueDispute('Cannot Work', 'Help Please');
+    const newTesterResponse = new TesterResponse('Cannot Work', 'Help Please', '- [ ] Not Done', 'Reason');
 
     it('.clone() should intialise the cloned issue with the correct phase and team', () => {
-        const dummyTeam = new Team({
-            id: 'F09-2',
-            teamMembers: []
-        });
-        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-
         const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
         expect(phaseBugReportingIssue).toEqual(dummyIssue);
 
@@ -85,9 +81,6 @@ describe('Issue', () => {
     });
 
     it('.createGithubIssueDescription() forms the correct GitHub Issue description for the issue', () => {
-        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-        const otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
-
         const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
         expect(phaseBugReportingIssue.createGithubIssueDescription()).toEqual(noReportedDescriptionString);
 
@@ -96,9 +89,7 @@ describe('Issue', () => {
             .toEqual(`${phaseBugReportingIssueWithDescription.description}\n`);
     });
 
-    it('should be able to get the proper Team Response', () => {
-        const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-
+    it('.clone() should be able to get the proper Team Response', () => {
         const phaseTeamResponseIssue = dummyIssue.clone(Phase.phaseTeamResponse);
         phaseTeamResponseIssue.teamResponse = 'Sample Text';
         expect(phaseTeamResponseIssue.createGithubTeamResponse())
@@ -112,13 +103,7 @@ describe('Issue', () => {
                 + `## Duplicate status (if any):\nDuplicate of #${phaseTeamResponseIssue2.duplicateOf}`);
     });
 
-    it ('should be able to get the proper Tutor Response', () => {
-        const dummyTeam = new Team({
-            id: 'F09-2',
-            teamMembers: []
-        });
-        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-
+    it ('.clone() should be able to get the proper Tutor Response', () => {
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.createGithubTutorResponse()).toEqual(tutorResponseStringHeader);
 
@@ -128,13 +113,7 @@ describe('Issue', () => {
             + newIssueDispute.toTutorResponseString());
     });
 
-    it ('should be able to get the proper Tester Response', () => {
-        const dummyTeam = new Team({
-            id: 'F09-2',
-            teamMembers: []
-        });
-        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-
+    it ('.clone() should be able to get the proper Tester Response', () => {
         const phaseTesterResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTesterResponse);
         phaseTesterResponseIssue.teamResponse = 'Sample Text';
         phaseTesterResponseIssue.testerResponses = [];
@@ -151,12 +130,6 @@ describe('Issue', () => {
     });
 
     it ('.numOfUnresolvedDisputes() returns the correct number of issue disputes', () => {
-        const dummyTeam = new Team({
-            id: 'F09-2',
-            teamMembers: []
-        });
-        const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.numOfUnresolvedDisputes()).toEqual(0);
 

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -98,7 +98,7 @@ describe('Issue', () => {
 
     it('should be able to get the proper Team Response', () => {
         const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
-        
+
         const phaseTeamResponseIssue = dummyIssue.clone(Phase.phaseTeamResponse);
         phaseTeamResponseIssue.teamResponse = 'Sample Text';
         expect(phaseTeamResponseIssue.createGithubTeamResponse())

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,4 +1,6 @@
 import { Issue } from '../../src/app/core/models/issue.model';
+import { Team } from '../../src/app/core/models/team.model';
+import { Phase } from '../../src/app/core/services/phase.service';
 
 import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants';
 
@@ -42,4 +44,38 @@ describe('Issue model class', () => {
             expect(Issue.updateTeamResponse(inputWithSpecialChars)).toBe(inputWithSpecialChars);
         });
     });
+});
+
+describe('Issue', () => {
+    let dummyTeam: Team;
+    let dummyIssue: Issue;
+    let otherDummyIssue: Issue;
+    let dummyIssueWithTeam: Issue;
+
+    beforeEach(() => {
+        dummyTeam = new Team({
+            id: 'F09-2',
+            teamMembers: []
+        });
+        dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+        otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
+        dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+    });
+
+    it('should be initialized with the correct phase and team with clone()', () => {
+        const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
+        expect(phaseBugReportingIssue).toEqual(dummyIssue);
+
+        const phaseTeamResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTeamResponse);
+        expect(phaseTeamResponseIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);
+        expect(phaseTeamResponseIssue.teamAssigned).toEqual(dummyTeam);
+
+        const phaseTesterResponseIssue = dummyIssue.clone(Phase.phaseTesterResponse);
+        expect(phaseTesterResponseIssue.githubComments).toEqual(dummyIssue.githubComments);
+
+        const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
+        expect(phaseModerationIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);
+        expect(phaseModerationIssue.teamAssigned).toEqual(dummyTeam);
+    });
+
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -70,8 +70,8 @@ describe('Issue', () => {
         expect(phaseTeamResponseIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);
         expect(phaseTeamResponseIssue.teamAssigned).toEqual(dummyTeam);
 
-        const phaseTesterResponseIssue = dummyIssue.clone(Phase.phaseTesterResponse);
-        expect(phaseTesterResponseIssue.githubComments).toEqual(dummyIssue.githubComments);
+        const phaseTesterResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTesterResponse);
+        expect(phaseTesterResponseIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);
 
         const phaseModerationIssue = dummyIssueWithTeam.clone(Phase.phaseModeration);
         expect(phaseModerationIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);


### PR DESCRIPTION
# Summary 

This fixes **the last task for** #365 where tests for the instance methods for the Issue Model need to be added. 

## Description 

So far, the methods to retrieve the strings for example `createGithubTesterResponse` and `createGithubTutorResponse` have been checked by giving an arbitary number of `testerResponses` and `issueDisputes` respectively. 

Also, `numOfUnresolvedDisputes` has been checked in the event for having resolved issue disputes. 