### PR TITLE
Fix for Copy Pasting of MacOS 

### DIFF
--- a/src/app/core/directives/ctrl-key.directive.ts
+++ b/src/app/core/directives/ctrl-key.directive.ts
@@ -7,9 +7,9 @@ import { Directive, Output, EventEmitter, HostListener } from '@angular/core';
 export class CtrlKeysDirective  {
   @Output() ctrlV = new EventEmitter();
 
-  @HostListener('window:keydown',['$event'])
+  @HostListener('window:keydown', ['$event'])
   onKeyPress($event: KeyboardEvent) {
-      if(($event.ctrlKey || $event.metaKey) && $event.code == "KeyV") {
+      if (($event.ctrlKey || $event.metaKey) && $event.code === 'KeyV') {
         this.ctrlV.emit();
       }
   }

--- a/src/app/core/directives/ctrl-key.directive.ts
+++ b/src/app/core/directives/ctrl-key.directive.ts
@@ -6,13 +6,11 @@ import { Directive, Output, EventEmitter, HostListener } from '@angular/core';
 })
 export class CtrlKeysDirective  {
   @Output() ctrlV = new EventEmitter();
-  @Output() ctrlC = new EventEmitter();
 
-  @HostListener('keydown.control.v') onCtrlV() {
-    this.ctrlV.emit();
-  }
-
-  @HostListener('keydown.control.c') onCtrlC() {
-    this.ctrlC.emit();
+  @HostListener('window:keydown',['$event'])
+  onKeyPress($event: KeyboardEvent) {
+      if(($event.ctrlKey || $event.metaKey) && $event.code == "KeyV") {
+        this.ctrlV.emit();
+      }
   }
 }


### PR DESCRIPTION
# Summary 

This fixes #491 and #373 simultaneously, by allowing Mac Users to copy paste screenshots into the text editor

## Description 

This is mainly by allowing detection of mac command key via `event.metaKey` 