### PR TITLE
Fix Alt Tabbing Bug 

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -52,9 +52,19 @@ export class Issue {
    * Brought over from comment-editor.component.ts
    */
   static formatText(text: string): string {
+    if (text === null) {
+      return null;
+    }
+
+    if (text === undefined) {
+      return undefined;
+    }
+
     const newLinesRegex = /[\n\r]/gi;
-    if (text.split(newLinesRegex).filter(split => split.trim() !== '').length > 0) {
-      return text + '\n\r';
+    const textSplitArray = text.split(newLinesRegex);
+    console.log(textSplitArray);
+    if (textSplitArray.filter(split => split.trim() !== '').length > 0) {
+      return `${text}\n\n`;
     } else {
       return text;
     }

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -45,12 +45,27 @@ export class Issue {
   issueComment?: IssueComment; // Issue comment is used for Tutor Response and Tester Response
   issueDisputes?: IssueDispute[];
 
-    /**
+  /**
+   * Formats the text to create space at the end of the user input to prevent any issues with
+   * the markdown interpretation.
+   *
+   * Brought over from comment-editor.component.ts
+   */
+  static formatText(text: string): string {
+    const newLinesRegex = /[\n\r]/gi;
+    if (text.split(newLinesRegex).filter(split => split.trim() !== '').length > 0) {
+      return text + '\n\r';
+    } else {
+      return text;
+    }
+  }
+
+  /**
    * Processes and cleans a raw issue description obtained from user input.
    */
   static updateDescription(description: string): string {
     const defaultString = 'No details provided by bug reporter.';
-    return Issue.orDefaultString(description, defaultString);
+    return Issue.orDefaultString(Issue.formatText(description), defaultString);
   }
 
   /**
@@ -58,7 +73,7 @@ export class Issue {
    */
   static updateTeamResponse(teamResponse: string): string {
     const defaultString = 'No details provided by team.';
-    return Issue.orDefaultString(teamResponse, defaultString);
+    return Issue.orDefaultString(Issue.formatText(teamResponse), defaultString);
   }
 
   /**
@@ -217,17 +232,20 @@ export class Issue {
   }
 
   createGithubIssueDescription(): string {
+    console.log(1);
     return `${this.description}\n${this.hiddenDataInDescription.toString()}`;
   }
 
   // Template url: https://github.com/CATcher-org/templates#dev-response-phase
   createGithubTeamResponse(): string {
+    console.log(2);
     return `# Team\'s Response\n${this.teamResponse}\n ` +
       `## Duplicate status (if any):\n${this.duplicateOf ? `Duplicate of #${this.duplicateOf}` : `--`}`;
   }
 
   // Template url: https://github.com/CATcher-org/templates#tutor-moderation
   createGithubTutorResponse(): string {
+    console.log(3);
     let tutorResponseString = '# Tutor Moderation\n\n';
     for (const issueDispute of this.issueDisputes) {
       tutorResponseString += issueDispute.toTutorResponseString();
@@ -237,6 +255,7 @@ export class Issue {
 
   // Template url: https://github.com/CATcher-org/templates#teams-response-1
   createGithubTesterResponse(): string {
+    console.log(4);
     return `# Team\'s Response\n${this.teamResponse}\n ` +
       `# Items for the Tester to Verify\n${this.getTesterResponsesString(this.testerResponses)}`;
   }

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -62,7 +62,6 @@ export class Issue {
 
     const newLinesRegex = /[\n\r]/gi;
     const textSplitArray = text.split(newLinesRegex);
-    console.log(textSplitArray);
     if (textSplitArray.filter(split => split.trim() !== '').length > 0) {
       return `${text}\n\n`;
     } else {
@@ -242,20 +241,17 @@ export class Issue {
   }
 
   createGithubIssueDescription(): string {
-    console.log(1);
     return `${this.description}\n${this.hiddenDataInDescription.toString()}`;
   }
 
   // Template url: https://github.com/CATcher-org/templates#dev-response-phase
   createGithubTeamResponse(): string {
-    console.log(2);
     return `# Team\'s Response\n${this.teamResponse}\n ` +
       `## Duplicate status (if any):\n${this.duplicateOf ? `Duplicate of #${this.duplicateOf}` : `--`}`;
   }
 
   // Template url: https://github.com/CATcher-org/templates#tutor-moderation
   createGithubTutorResponse(): string {
-    console.log(3);
     let tutorResponseString = '# Tutor Moderation\n\n';
     for (const issueDispute of this.issueDisputes) {
       tutorResponseString += issueDispute.toTutorResponseString();
@@ -265,7 +261,6 @@ export class Issue {
 
   // Template url: https://github.com/CATcher-org/templates#teams-response-1
   createGithubTesterResponse(): string {
-    console.log(4);
     return `# Team\'s Response\n${this.teamResponse}\n ` +
       `# Items for the Tester to Verify\n${this.getTesterResponsesString(this.testerResponses)}`;
   }

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -10,7 +10,7 @@
           <textarea ctrlKeys (ctrlV)="onPaste()" #commentTextArea (dragover)="disableCaretMovement($event)"
                     id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20" (change)="formatText()"></textarea>
+                    cdkAutosizeMaxRows="20"></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -160,19 +160,6 @@ export class CommentEditorComponent implements OnInit {
     reader.readAsDataURL(file);
   }
 
-  /**
-   * Formats the text to create space at the end of the user input to prevent any issues with
-   * the markdown interpretation.
-   */
-  formatText() {
-    const newLinesRegex = /[\n\r]/gi;
-    if (this.commentTextArea.nativeElement.value.split(newLinesRegex).filter(split => split.trim() !== '').length > 0) {
-      this.commentField.setValue(this.commentTextArea.nativeElement.value + '\n\r');
-    } else {
-      this.commentField.setValue('');
-    }
-  }
-
   onPaste() {
     this.uploadErrorMessage = null;
 

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -34,12 +34,12 @@ describe('Issue model class', () => {
 
             const typicalDescription = 'The app crashes after parsing config files.';
             const typicalTeamResponse = 'Cannot replicate the bug.';
-            expect(Issue.updateDescription(typicalDescription)).toBe(typicalDescription);
-            expect(Issue.updateTeamResponse(typicalTeamResponse)).toBe(typicalTeamResponse);
+            expect(Issue.updateDescription(typicalDescription)).toBe(typicalDescription + '\n\n');
+            expect(Issue.updateTeamResponse(typicalTeamResponse)).toBe(typicalTeamResponse + '\n\n');
 
             const inputWithSpecialChars = '$%^!@&-_test';
-            expect(Issue.updateDescription(inputWithSpecialChars)).toBe(inputWithSpecialChars);
-            expect(Issue.updateTeamResponse(inputWithSpecialChars)).toBe(inputWithSpecialChars);
+            expect(Issue.updateDescription(inputWithSpecialChars)).toBe(inputWithSpecialChars + '\n\n');
+            expect(Issue.updateTeamResponse(inputWithSpecialChars)).toBe(inputWithSpecialChars + '\n\n');
         });
     });
 });


### PR DESCRIPTION
# Summary 

This PR Attempts to fix #492, which causes two new lines to be added every time a user **alt-tab** out of CATcher itself. 

## Description 

This bug is due to the fact that `formatText()` is being called every single time the user leaves the page. As a result, we want to reduce the number of calls made to this function and as a result, only call it when the request actually gets through, aka when the `Submit` button is pressed. 