### PR TITLE
Make isOutdatedVersion private

### DIFF
--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -40,7 +40,7 @@ export class ApplicationService {
    * @param latestVersion
    * @param currentVersion
    */
-  isOutdatedVersion(latestVersion: string, currentVersion: string): boolean {
+  private isOutdatedVersion(latestVersion: string, currentVersion: string): boolean {
     const result = this.compareVersions(latestVersion, currentVersion);
     return result === 1;
   }

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -1,38 +1,54 @@
 import { ApplicationService } from '../../src/app/core/services/application.service';
+import { GithubService } from '../../src/app/core/services/github.service';
+import { of } from 'rxjs';
 
 const currentVersion = '3.2.5';
 
 class ApplicationServiceStub extends ApplicationService {
   readonly currentVersion: string;
-  constructor(latestVersion: string, currentVersion: string) {
-    super(null);
-    this.latestVersion = latestVersion;
+  constructor(githubService: GithubService, currentVersion: string) {
+    super(githubService);
     this.currentVersion = currentVersion;
   }
 }
 
 describe('Test for ApplicationService#isApplicationOutdated', () => {
-  it('should return an Observable of false if the ApplicationService is outdated', () => {
-    const outdatedAppService1 = new ApplicationServiceStub('2.2.5', currentVersion);
+  const githubService = jasmine.createSpyObj('GithubService', ['fetchLatestRelease']);
+  it('should return the appropriate Observable if the ApplicationService is outdated', () => {
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v2.2.5'}));
+    const outdatedAppService1 = new ApplicationServiceStub(githubService, currentVersion);
     outdatedAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-    const outdatedAppService2 = new ApplicationServiceStub('3.1', currentVersion);
-    outdatedAppService2.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-    const outdatedAppService3 = new ApplicationServiceStub('3.2.4', currentVersion);
-    outdatedAppService3.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-    const longVersionedAppService = new ApplicationServiceStub('3.2.4.8.9', currentVersion);
-    longVersionedAppService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-    const latestApplicationService = new ApplicationServiceStub(currentVersion, currentVersion);
-    latestApplicationService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-  });
 
-  it('should return an Observable of true if the ApplicationService is up to date', () => {
-    const upToDateAppService1 = new ApplicationServiceStub('3.2.5.0', currentVersion);
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.1'}));
+    const outdatedAppService2 = new ApplicationServiceStub(githubService, currentVersion);
+    outdatedAppService2.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.4'}));
+    const outdatedAppService3 = new ApplicationServiceStub(githubService, currentVersion);
+    outdatedAppService3.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.4.8.9'}));
+    const longVersionedAppService = new ApplicationServiceStub(githubService, currentVersion);
+    longVersionedAppService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.5'}));
+    const latestApplicationService = new ApplicationServiceStub(githubService, currentVersion);
+    latestApplicationService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.5.0'}));
+    const upToDateAppService1 = new ApplicationServiceStub(githubService, currentVersion);
     upToDateAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
-    const upToDateAppService2 = new ApplicationServiceStub('3.2.5.5', currentVersion);
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.5.5'}));
+    const upToDateAppService2 = new ApplicationServiceStub(githubService, currentVersion);
     upToDateAppService2.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
-    const upToDateAppService3 = new ApplicationServiceStub('3.2.6', currentVersion);
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v3.2.6'}));
+    const upToDateAppService3 = new ApplicationServiceStub(githubService, currentVersion);
     upToDateAppService3.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
-    const upToDateAppService4 = new ApplicationServiceStub('3.2.6', currentVersion);
+
+    githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v10'}));
+    const upToDateAppService4 = new ApplicationServiceStub(githubService, currentVersion);
     upToDateAppService4.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
   });
 });

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -1,18 +1,37 @@
 import { ApplicationService } from '../../src/app/core/services/application.service';
 
-const applicationService = new ApplicationService(null);
+const upToDateAppService = new ApplicationService(null);
 const currentVersion = '3.2.5';
 
+class ApplicationServiceStub extends ApplicationService {
+  readonly currentVersion: string;
+  constructor(latestVersion: string, currentVersion: string) {
+    super(null);
+    this.latestVersion = latestVersion;
+    this.currentVersion = currentVersion;
+  }
+}
+
 describe('Test the ApplicationService', () => {
-    it('Test whether the ApplicationService can detect outdated versions', () => {
-        expect(applicationService.isOutdatedVersion('2.2.5', currentVersion)).toBe(false);
-        expect(applicationService.isOutdatedVersion('3.1', currentVersion)).toBe(false);
-        expect(applicationService.isOutdatedVersion('3.2.4', currentVersion)).toBe(false);
-        expect(applicationService.isOutdatedVersion('3.2.4.8.9', currentVersion)).toBe(false);
-        expect(applicationService.isOutdatedVersion(currentVersion, currentVersion)).toBe(false);
-        expect(applicationService.isOutdatedVersion('3.2.5.0', currentVersion)).toBe(true);
-        expect(applicationService.isOutdatedVersion('3.2.5.5', currentVersion)).toBe(true);
-        expect(applicationService.isOutdatedVersion('3.2.6', currentVersion)).toBe(true);
-        expect(applicationService.isOutdatedVersion('10', currentVersion)).toBe(true);
-    });
+  it('Test whether the ApplicationService can detect outdated versions', () => {
+    const outdatedAppService1 = new ApplicationServiceStub('2.2.5', currentVersion);
+    outdatedAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+    const outdatedAppService2 = new ApplicationServiceStub('3.1', currentVersion);
+    outdatedAppService2.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+    const outdatedAppService3 = new ApplicationServiceStub('3.2.4', currentVersion);
+    outdatedAppService3.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+    const longVersionedAppService = new ApplicationServiceStub('3.2.4.8.9', currentVersion);
+    longVersionedAppService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+    const latestApplicationService = new ApplicationServiceStub(currentVersion, currentVersion);
+    latestApplicationService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
+    // expect(upToDateAppService.isApplicationOutdated()).toBe(false);
+    const upToDateAppService1 = new ApplicationServiceStub('3.2.5.0', currentVersion);
+    upToDateAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
+    const upToDateAppService2 = new ApplicationServiceStub('3.2.5.5', currentVersion);
+    upToDateAppService2.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
+    const upToDateAppService3 = new ApplicationServiceStub('3.2.6', currentVersion);
+    upToDateAppService3.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
+    const upToDateAppService4 = new ApplicationServiceStub('3.2.6', currentVersion);
+    upToDateAppService4.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
+  });
 });

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -1,6 +1,5 @@
 import { ApplicationService } from '../../src/app/core/services/application.service';
 
-const upToDateAppService = new ApplicationService(null);
 const currentVersion = '3.2.5';
 
 class ApplicationServiceStub extends ApplicationService {

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -12,7 +12,7 @@ class ApplicationServiceStub extends ApplicationService {
   }
 }
 
-describe('Test for ApplicationService#isApplicationOutdated', () => {
+describe('ApplicationService#isApplicationOutdated', () => {
   const githubService = jasmine.createSpyObj('GithubService', ['fetchLatestRelease']);
   it('should return the appropriate Observable if the ApplicationService is outdated', () => {
     githubService.fetchLatestRelease.and.returnValue(of({tag_name: 'v2.2.5'}));

--- a/tests/services/application.service.spec.ts
+++ b/tests/services/application.service.spec.ts
@@ -12,8 +12,8 @@ class ApplicationServiceStub extends ApplicationService {
   }
 }
 
-describe('Test the ApplicationService', () => {
-  it('Test whether the ApplicationService can detect outdated versions', () => {
+describe('Test for ApplicationService#isApplicationOutdated', () => {
+  it('should return an Observable of false if the ApplicationService is outdated', () => {
     const outdatedAppService1 = new ApplicationServiceStub('2.2.5', currentVersion);
     outdatedAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
     const outdatedAppService2 = new ApplicationServiceStub('3.1', currentVersion);
@@ -24,7 +24,9 @@ describe('Test the ApplicationService', () => {
     longVersionedAppService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
     const latestApplicationService = new ApplicationServiceStub(currentVersion, currentVersion);
     latestApplicationService.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(false));
-    // expect(upToDateAppService.isApplicationOutdated()).toBe(false);
+  });
+
+  it('should return an Observable of true if the ApplicationService is up to date', () => {
     const upToDateAppService1 = new ApplicationServiceStub('3.2.5.0', currentVersion);
     upToDateAppService1.isApplicationOutdated().subscribe((bool) => expect(bool).toBe(true));
     const upToDateAppService2 = new ApplicationServiceStub('3.2.5.5', currentVersion);


### PR DESCRIPTION
Solves issue #396 

I've created an `ApplicatonServiceStub` class in order to pass `currentVersion` as a dependency into `ApplicationService` without modifying the existing code, and testing is done by subscribing to the returned Observable.
Not sure if this adheres to Angular/Scuri patterns.

Any feedback is welcome,
Thanks.