### PR TITLE
App component specs file: Remove unused class

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,8 +26,3 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 });
-
-class TranslateServiceStub {
-  setDefaultLang(lang: string): void {
-  }
-}


### PR DESCRIPTION
This PR fixes #518.

The unused `TranslateServiceStub` class has been removed from app.component.spec.ts file.

Proposed commit message:
```
app.component.spec.ts: Remove unused class TranslateServiceStub 
```