### PR TITLE
Tests: run using Karma, instead of jasmine-ts

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint 
-    - run: npm test
+    - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
       
   macos-setup-and-tests:
     runs-on: macos-latest
@@ -43,7 +43,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint 
-    - run: npm test
+    - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
 
   windows-setup-and-tests:
     runs-on: windows-latest
@@ -60,4 +60,4 @@ jobs:
     - run: npm update 
     - run: npm run electron:windows
     - run: npm run lint 
-    - run: npm test
+    - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"

--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,7 @@
             "main": "src/test.ts",
             "polyfills": "src/polyfills-test.ts",
             "tsConfig": "src/tsconfig.spec.json",
-            "karmaConfig": "src/karma.conf.js",
+            "karmaConfig": "tests/karma.conf.js",
             "scripts": [],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -45,6 +45,8 @@ This section shows you different commands you can run to build the application i
 |`npm run electron:mac`|  On a MAC OS, builds your application and generates a `.app` file of your application that can be run on Mac |
 |`npm run deploy:web`| Will deploy the app onto the Github's `gh-pages` branch. <br/> Prerequisites:<br/> 1. Add Environment variable of `GH_TOKEN=<Github Personal Access Token>` with the permission of `repo`. <br/>2. `build:prod:web` command's `--base-href` argument in `package.json` must have the following format `https://<OrgName or Username>.github.io/CATcher/`. <br/> 3. If you are deploying outside of CATcher-org then it would be necessary to create a new OAuth application and change the `clientId` in `environment.prod.ts` <br/> 4. If you are deploying outside of CATcher-org, you would also need to deploy your own instance of proxy server using [gatekeeper](https://github.com/CATcher-org/gatekeeper) and change the appropriate variables in `environment.prod.ts`. |
 | `npm run lint` | Runs the linter (TSLint) |
+| `npm run test` | Runs the tests           |
+| `npm run test -- "--code-coverage"` | Runs the tests and generates code coverage report under `tests/coverage` folder |
 
 # Workflow
 

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,4 +1,0 @@
-{
-    "spec_dir": "tests",
-    "spec_files": ["**/**/*.spec.ts"]
- }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "electron-log": "^4.2.4",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.0",
+    "karma-spec-reporter": "0.0.32",
     "moment": "^2.24.0",
     "ngx-markdown": "^8.2.1",
     "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "electron:linux": "npm run build:prod && electron-builder build --linux",
     "electron:windows": "npm run build:prod && electron-builder build --windows",
     "electron:mac": "npm run build:prod && electron-builder build --mac",
-    "test": "npm run codegen:gql && jasmine-ts --config=jasmine.json",
+    "test": "npm run codegen:gql && ng test",
     "e2e": "npm run codegen:gql && npm run postinstall:web && ng e2e",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "jasmine": "^3.5.0",
     "jasmine-core": "3.5.0",
     "jasmine-spec-reporter": "4.2.1",
-    "jasmine-ts": "^0.3.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "karma": "^4.4.1",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "2.1.1",
+    "karma-firefox-launcher": "^2.1.0",
     "karma-jasmine": "3.1.0",
     "karma-jasmine-html-reporter": "1.5.1",
     "npm-run-all": "4.1.5",

--- a/src/test.ts
+++ b/src/test.ts
@@ -15,6 +15,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('../tests', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -18,7 +18,7 @@
     "polyfills-test.ts"
   ],
   "include": [
-    "**/*.spec.ts",
+    "../tests/**/*.spec.ts",
     "**/*.d.ts"
   ],
   "exclude": [

--- a/tests/karma.ci.conf.js
+++ b/tests/karma.ci.conf.js
@@ -1,0 +1,13 @@
+
+let ciProperties;
+let baseConfigs = require('./karma.conf.js');
+baseConfigs({ set: function(arg) { ciProperties = arg; }});
+
+// Set CI specific settings
+// Include Firefox as a testing environment
+ciProperties.plugins.push(require('karma-firefox-launcher'));
+ciProperties.browsers.push('FirefoxHeadless');
+
+module.exports = function(config) {
+  config.set(ciProperties);
+};

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -1,0 +1,33 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: require('path').join(__dirname, './coverage/CATcher'),
+      reports: ['html', 'lcovonly', 'text-summary'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome', 'Firefox'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
-      require('karma-jasmine-html-reporter'),
+      require('karma-spec-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
@@ -21,13 +21,17 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['spec'],
+    specReporter: {
+      maxLogLines: 5, // limit number of lines per test
+      suppressErrorSummary: true,
+      suppressPassed: true,
+      showSpecTiming: false,
+    },
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
     browsers: ['ChromeHeadless', 'FirefoxHeadless'],
     singleRun: true,
-    restartOnFileChange: true
   });
 };

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -8,7 +8,6 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
-      require('karma-firefox-launcher'),
       require('karma-spec-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
@@ -31,7 +30,7 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['ChromeHeadless', 'FirefoxHeadless'],
+    browsers: ['ChromeHeadless'],
     singleRun: true,
   });
 };

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -26,8 +26,8 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome', 'Firefox'],
-    singleRun: false,
+    browsers: ['ChromeHeadless', 'FirefoxHeadless'],
+    singleRun: true,
     restartOnFileChange: true
   });
 };


### PR DESCRIPTION
Fixes #540 

Proposed commit message:
```
Our tests run in the NodeJS environment.
Let's use Karma to run the tests instead, so
that we can run them in multiple browser environments 
(as well as Electron).
```

To run the tests, run `npm run test` (this is unchanged)
(You need to run `npm install` first to install the new dependencies in this PR).
You should see the test results from Chrome.

The tests will only run on Chrome when run locally.
In the GitHub actions' workflow, they will run on both Chrome and Firefox.

