### PR TITLE
SessionData: add tests for session validation logic

### DIFF
--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -1,22 +1,27 @@
 import { pipe } from 'rxjs';
 import { throwIfFalse } from '../../shared/lib/custom-ops';
+import { Phase } from '../services/phase.service';
 
 export interface SessionData {
-  openPhases: string[];
-  phaseBugReporting: string;
-  phaseTeamResponse: string;
-  phaseTesterResponse: string;
-  phaseModeration: string;
+  openPhases: Phase[];
+  [Phase.phaseBugReporting]: string;
+  [Phase.phaseTeamResponse]: string;
+  [Phase.phaseTesterResponse]: string;
+  [Phase.phaseModeration]: string;
 }
+
+export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable'
+export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined'
+export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases'
 
 export function assertSessionDataIntegrity() {
   return pipe(
     throwIfFalse(sessionData => sessionData !== undefined,
-      () => new Error('Session Data Unavailable')),
+      () => new Error(SESSION_DATA_UNAVAILABLE)),
     throwIfFalse(isSessionDataCorrectlyDefined,
-      () => new Error('Session Data is Incorrectly Defined')),
+      () => new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
     throwIfFalse(hasOpenPhases,
-      () => new Error('There are no accessible phases.')));
+      () => new Error(NO_ACCESSIBLE_PHASES)));
 }
 
 /**

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -1,13 +1,12 @@
 import { pipe } from 'rxjs';
 import { throwIfFalse } from '../../shared/lib/custom-ops';
-import { Phase } from '../services/phase.service';
 
 export interface SessionData {
-  openPhases: Phase[];
-  [Phase.phaseBugReporting]: string;
-  [Phase.phaseTeamResponse]: string;
-  [Phase.phaseTesterResponse]: string;
-  [Phase.phaseModeration]: string;
+  openPhases: string[];
+  phaseBugReporting: string;
+  phaseTeamResponse: string;
+  phaseTesterResponse: string;
+  phaseModeration: string;
 }
 
 export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -10,9 +10,9 @@ export interface SessionData {
   [Phase.phaseModeration]: string;
 }
 
-export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable'
-export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined'
-export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases'
+export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';
+export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined';
+export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases';
 
 export function assertSessionDataIntegrity() {
   return pipe(

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -1,0 +1,59 @@
+import { assertSessionDataIntegrity } from '../../../../src/app/core/models/session.model';
+import { of } from 'rxjs';
+
+const validSessionData = {
+  openPhases: [
+    'phaseBugReporting',
+    'phaseTeamResponse',
+    'phaseTesterResponse',
+    'phaseModeration',
+  ],
+  phaseBugReporting: 'bugreporting',
+  phaseTeamResponse: 'pe-results',
+  phaseTesterResponse: 'testerresponse',
+  phaseModeration: 'pe-evaluation',
+};
+
+describe('Session Model', () => {
+  describe('Assert Session Data Integrity', () => {
+    it('should throw error on unavailable session', () => {
+      of(undefined)
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(new Error('Session Data Unavailable')),
+        });
+    });
+    it('should throw error on incorrect session data', () => {
+      of({ key: '' })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(
+              new Error('Session Data is Incorrectly Defined')
+            ),
+        });
+      of({ key: undefined })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(
+              new Error('Session Data is Incorrectly Defined')
+            ),
+        });
+    });
+    it('should throw error on session with no open phases', () => {
+      of({ openPhases: [] })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(new Error('There are no accessible phases.')),
+        });
+    });
+    it('should pass valid session data', () => {
+      of(validSessionData)
+        .pipe(assertSessionDataIntegrity())
+        .subscribe((el) => expect(el).toEqual(validSessionData));
+    });
+  });
+});

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -4,9 +4,9 @@ import {
   SESSION_DATA_INCORRECTLY_DEFINED,
   SESSION_DATA_UNAVAILABLE,
   NO_ACCESSIBLE_PHASES,
-} from "../../../../src/app/core/models/session.model";
-import { Phase } from "../../../../src/app/core/services/phase.service";
-import { of } from "rxjs";
+} from '../../../../src/app/core/models/session.model';
+import { Phase } from '../../../../src/app/core/services/phase.service';
+import { of } from 'rxjs';
 
 const validSessionData: SessionData = {
   openPhases: [
@@ -15,15 +15,15 @@ const validSessionData: SessionData = {
     Phase.phaseTesterResponse,
     Phase.phaseModeration,
   ],
-  phaseBugReporting: "bugreporting",
-  phaseTeamResponse: "pe-results",
-  phaseTesterResponse: "testerresponse",
-  phaseModeration: "pe-evaluation",
+  phaseBugReporting: 'bugreporting',
+  phaseTeamResponse: 'pe-results',
+  phaseTesterResponse: 'testerresponse',
+  phaseModeration: 'pe-evaluation',
 };
 
-describe("Session Model", () => {
-  describe("assertSessionDataIntegrity", () => {
-    it("should throw error on unavailable session", () => {
+describe('Session Model', () => {
+  describe('assertSessionDataIntegrity', () => {
+    it('should throw error on unavailable session', () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -32,8 +32,8 @@ describe("Session Model", () => {
         });
     });
 
-    it("should throw error on session data with missing values", () => {
-      of({ key: "" })
+    it('should throw error on session data with missing values', () => {
+      of({ key: '' })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
@@ -47,7 +47,7 @@ describe("Session Model", () => {
         });
     });
 
-    it("should throw error on session with no open phases", () => {
+    it('should throw error on session with no open phases', () => {
       of({ openPhases: [] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -55,7 +55,7 @@ describe("Session Model", () => {
         });
     });
 
-    it("should pass valid session data", () => {
+    it('should pass valid session data', () => {
       of(validSessionData)
         .pipe(assertSessionDataIntegrity())
         .subscribe((el) => expect(el).toEqual(validSessionData));

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -1,56 +1,61 @@
-import { assertSessionDataIntegrity } from '../../../../src/app/core/models/session.model';
-import { of } from 'rxjs';
+import {
+  assertSessionDataIntegrity,
+  SessionData,
+  SESSION_DATA_INCORRECTLY_DEFINED,
+  SESSION_DATA_UNAVAILABLE,
+  NO_ACCESSIBLE_PHASES,
+} from "../../../../src/app/core/models/session.model";
+import { Phase } from "../../../../src/app/core/services/phase.service";
+import { of } from "rxjs";
 
-const validSessionData = {
+const validSessionData: SessionData = {
   openPhases: [
-    'phaseBugReporting',
-    'phaseTeamResponse',
-    'phaseTesterResponse',
-    'phaseModeration',
+    Phase.phaseBugReporting,
+    Phase.phaseTeamResponse,
+    Phase.phaseTesterResponse,
+    Phase.phaseModeration,
   ],
-  phaseBugReporting: 'bugreporting',
-  phaseTeamResponse: 'pe-results',
-  phaseTesterResponse: 'testerresponse',
-  phaseModeration: 'pe-evaluation',
+  phaseBugReporting: "bugreporting",
+  phaseTeamResponse: "pe-results",
+  phaseTesterResponse: "testerresponse",
+  phaseModeration: "pe-evaluation",
 };
 
-describe('Session Model', () => {
-  describe('Assert Session Data Integrity', () => {
-    it('should throw error on unavailable session', () => {
+describe("Session Model", () => {
+  describe("assertSessionDataIntegrity", () => {
+    it("should throw error on unavailable session", () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(new Error('Session Data Unavailable')),
+            expect(err).toEqual(new Error(SESSION_DATA_UNAVAILABLE)),
         });
     });
-    it('should throw error on incorrect session data', () => {
-      of({ key: '' })
+
+    it("should throw error on session data with missing values", () => {
+      of({ key: "" })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(
-              new Error('Session Data is Incorrectly Defined')
-            ),
+            expect(err).toEqual(new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
         });
       of({ key: undefined })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(
-              new Error('Session Data is Incorrectly Defined')
-            ),
+            expect(err).toEqual(new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
         });
     });
-    it('should throw error on session with no open phases', () => {
+
+    it("should throw error on session with no open phases", () => {
       of({ openPhases: [] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
-          error: (err) =>
-            expect(err).toEqual(new Error('There are no accessible phases.')),
+          error: (err) => expect(err).toEqual(new Error(NO_ACCESSIBLE_PHASES)),
         });
     });
-    it('should pass valid session data', () => {
+
+    it("should pass valid session data", () => {
       of(validSessionData)
         .pipe(assertSessionDataIntegrity())
         .subscribe((el) => expect(el).toEqual(validSessionData));

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -22,7 +22,7 @@ const validSessionData: SessionData = {
 };
 
 describe('Session Model', () => {
-  describe('assertSessionDataIntegrity', () => {
+  describe('assertSessionDataIntegrity()', () => {
     it('should throw error on unavailable session', () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())


### PR DESCRIPTION
# Summary 

This issue fixes #533 , which adds tests for the testing of the logic within `session.model.ts`