### PR TITLE
Mock services: Implement mock polling and mock issue creation

### DIFF
--- a/src/app/core/services/mocks/mock.auth.service.ts
+++ b/src/app/core/services/mocks/mock.auth.service.ts
@@ -59,11 +59,7 @@ export class MockAuthService {
     this.phaseService.reset();
     this.dataService.reset();
     this.githubEventService.reset();
-    this.titleService.setTitle(
-      require('../../../../../package.json').name
-      .concat(' ')
-      .concat(require('../../../../../package.json').version)
-    );
+    this.setLandingPageTitle();
     this.issueService.setIssueTeamFilter('All Teams');
     this.reset();
   }
@@ -79,6 +75,18 @@ export class MockAuthService {
       this.logger.info(`Successfully authenticated with session: ${sessionId}`);
     }
     this.authStateSource.next(newAuthState);
+  }
+
+  setTitleWithPhaseDetail(): void {
+    const appSetting = require('../../../../../package.json');
+    const title = `${appSetting.name} ${appSetting.version} - ${this.phaseService.getPhaseDetail()}`;
+    this.titleService.setTitle(title);
+  }
+
+  setLandingPageTitle(): void {
+    const appSetting = require('../../../../../package.json');
+    const title = `${appSetting.name} ${appSetting.version}`;
+    this.titleService.setTitle(title);
   }
 
   /**

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -7,6 +7,8 @@ import { SessionData } from '../../models/session.model';
 import { GithubRelease } from '../../models/github/github.release';
 import { LabelService } from '../label.service';
 import { Label } from '../../models/label.model';
+import { GithubIssue } from '../../models/github/github-issue.model';
+import { GithubLabel } from '../../models/github/github-label.model';
 
 const Octokit = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
@@ -20,8 +22,11 @@ let octokit = new Octokit();
 
 @Injectable()
 export class MockGithubService {
+  numIssuesCreated: number;  // tracks the number of GithubIssues created by this mock service
 
-  constructor() {}
+  constructor() {
+    this.numIssuesCreated = 0;
+  }
 
   storeOAuthAccessToken(accessToken: string) {
     octokit = new Octokit({
@@ -48,6 +53,24 @@ export class MockGithubService {
    */
   isRepositoryPresent(owner: string, repo: string): Observable<boolean> {
     return of(true);
+  }
+
+  /**
+   * Creates a GithubIssue with the specified title / description / labels.
+   */
+  createIssue(title: string, description: string, labels: string[]): Observable<GithubIssue> {
+
+      const githubLabels: GithubLabel[] = labels.map(labelString => new GithubLabel({name: labelString}));
+
+      const githubIssueData = {
+        number: this.numIssuesCreated, // Issue's display ID
+        title: title,
+        body: description,
+        labels: githubLabels
+      };
+
+      this.numIssuesCreated++;
+      return of(new GithubIssue(githubIssueData));
   }
 
   /**

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -59,7 +59,6 @@ export class MockGithubService {
    * Creates a GithubIssue with the specified title / description / labels.
    */
   createIssue(title: string, description: string, labels: string[]): Observable<GithubIssue> {
-
       const githubLabels: GithubLabel[] = labels.map(labelString => new GithubLabel({name: labelString}));
 
       const githubIssueData = {

--- a/src/app/core/services/mocks/mock.issue.service.ts
+++ b/src/app/core/services/mocks/mock.issue.service.ts
@@ -66,9 +66,7 @@ export class MockIssueService {
   }
 
   /**
-   * Will constantly poll and update the application's state's with the updated issue.
-   *
-   * @param issueId - The issue's id to poll for.
+   * Simply returns the existing issue, to simulate polling.
    */
   pollIssue(issueId: number): Observable<Issue> {
     return of(this.issues[issueId]);

--- a/src/app/core/services/mocks/mock.issue.service.ts
+++ b/src/app/core/services/mocks/mock.issue.service.ts
@@ -71,20 +71,7 @@ export class MockIssueService {
    * @param issueId - The issue's id to poll for.
    */
   pollIssue(issueId: number): Observable<Issue> {
-    return timer(0, MockIssueService.POLL_INTERVAL).pipe(
-      exhaustMap(() => {
-        return this.githubService.fetchIssueGraphql(issueId).pipe(
-          map((response) => {
-            const issue = this.createIssueModel(response);
-            this.updateLocalStore(issue);
-            return issue;
-          }),
-          catchError((err) => {
-            return this.getIssue(issueId);
-          })
-        );
-      })
-    );
+    return of(this.issues[issueId]);
   }
 
   reloadAllIssues() {


### PR DESCRIPTION
This PR implements the `createIssue` and `pollIssue` methods of `MockGithubService` and `MockIssueService` respectively.
In these mocked methods, the actual GitHub API is not used, but simply imitated (e.g. `createIssue` simply returns a new `GithubIssue`, without using the GitHub API)

With these mocked methods, we can now create new bug reports in our end-to-end tests.

To test these changes: run `npm run ng:serve:test`.
This starts the app in "test" mode - the app will be using mocked services (hence the GitHub API will not be used).
You should be able to navigate to Bug Reporting Phase and create new bug reports.

Proposed commit message:
```
Mock services: Implement mock polling and mock issue creation

We cannot create new bug reports in our e2e tests,
as this process relies on the `createIssue` and `pollIssue` methods
of `MockGithubService` and `MockIssueService` respectively,
These methods have not been mocked yet.

Let's write mock implementations of `createIssue` and `pollIssue`,
so that we can create new bug reports in our e2e tests.
```