### PR TITLE
Move Phase enum into its own file

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -9,7 +9,7 @@ import { TeamResponseTemplate } from './templates/team-response-template.model';
 import { TesterResponseTemplate } from './templates/tester-response-template.model';
 import { TutorModerationIssueTemplate } from './templates/tutor-moderation-issue-template.model';
 import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-template.model';
-import { Phase } from '../services/phase.service';
+import { Phase } from '../models/phase.model';
 import * as moment from 'moment';
 import { HiddenData } from './hidden-data.model';
 

--- a/src/app/core/models/phase.model.ts
+++ b/src/app/core/models/phase.model.ts
@@ -1,0 +1,6 @@
+export enum Phase {
+  phaseBugReporting = 'phaseBugReporting',
+  phaseTeamResponse = 'phaseTeamResponse',
+  phaseTesterResponse = 'phaseTesterResponse',
+  phaseModeration = 'phaseModeration'
+}

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -1,22 +1,27 @@
 import { pipe } from 'rxjs';
 import { throwIfFalse } from '../../shared/lib/custom-ops';
+import { Phase } from '../services/phase.service';
 
 export interface SessionData {
-  openPhases: string[];
-  phaseBugReporting: string;
-  phaseTeamResponse: string;
-  phaseTesterResponse: string;
-  phaseModeration: string;
+  openPhases: Phase[];
+  [Phase.phaseBugReporting]: string;
+  [Phase.phaseTeamResponse]: string;
+  [Phase.phaseTesterResponse]: string;
+  [Phase.phaseModeration]: string;
 }
+
+export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable'
+export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined'
+export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases'
 
 export function assertSessionDataIntegrity() {
   return pipe(
     throwIfFalse(sessionData => sessionData !== undefined,
-      () => new Error('Session Data Unavailable')),
+      () => new Error(SESSION_DATA_UNAVAILABLE)),
     throwIfFalse(isSessionDataCorrectlyDefined,
-      () => new Error('Session Data is Incorrectly Defined')),
+      () => new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
     throwIfFalse(hasOpenPhases,
-      () => new Error('There are no accessible phases.')));
+      () => new Error(NO_ACCESSIBLE_PHASES)));
 }
 
 /**

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -1,12 +1,13 @@
 import { pipe } from 'rxjs';
 import { throwIfFalse } from '../../shared/lib/custom-ops';
+import { Phase } from '../models/phase.model';
 
 export interface SessionData {
-  openPhases: string[];
-  phaseBugReporting: string;
-  phaseTeamResponse: string;
-  phaseTesterResponse: string;
-  phaseModeration: string;
+  openPhases: Phase[];
+  [Phase.phaseBugReporting]: string;
+  [Phase.phaseTeamResponse]: string;
+  [Phase.phaseTesterResponse]: string;
+  [Phase.phaseModeration]: string;
 }
 
 export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -1,13 +1,12 @@
 import { pipe } from 'rxjs';
 import { throwIfFalse } from '../../shared/lib/custom-ops';
-import { Phase } from '../services/phase.service';
 
 export interface SessionData {
-  openPhases: Phase[];
-  [Phase.phaseBugReporting]: string;
-  [Phase.phaseTeamResponse]: string;
-  [Phase.phaseTesterResponse]: string;
-  [Phase.phaseModeration]: string;
+  openPhases: string[];
+  phaseBugReporting: string;
+  phaseTeamResponse: string;
+  phaseTesterResponse: string;
+  phaseModeration: string;
 }
 
 export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -10,9 +10,9 @@ export interface SessionData {
   [Phase.phaseModeration]: string;
 }
 
-export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable'
-export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined'
-export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases'
+export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';
+export const SESSION_DATA_INCORRECTLY_DEFINED = 'Session Data is Incorrectly Defined';
+export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases';
 
 export function assertSessionDataIntegrity() {
   return pipe(

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -22,6 +22,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import RestGithubIssueFilter from '../models/github/github-issue-filter.model';
 import { DocumentNode } from 'graphql';
 import { ElectronService } from './electron.service';
+import { SessionData } from '../models/session.model';
 
 const Octokit = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
@@ -297,9 +298,9 @@ export class GithubService {
 
   /**
    * Fetches the data file that is regulates session information.
-   * @return Observable<{}> representing session information.
+   * @return Observable<SessionData> representing session information.
    */
-  fetchSettingsFile(): Observable<{}> {
+  fetchSettingsFile(): Observable<SessionData> {
     return from(octokit.repos.getContents({owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json',
       headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
         map(rawData => JSON.parse(atob(rawData['data']['content']))),

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -8,7 +8,8 @@ import {
   IssuesFilter, STATUS,
 } from '../models/issue.model';
 import { UserService } from './user.service';
-import { Phase, PhaseService } from './phase.service';
+import { PhaseService } from './phase.service';
+import { Phase } from '../models/phase.model';
 import { PermissionService } from './permission.service';
 import { DataService } from './data.service';
 import { ErrorHandlingService } from './error-handling.service';

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { GithubUser } from '../../models/github-user.model';
 import { AppConfig } from '../../../../environments/environment.test';
-import { Phase } from '../phase.service';
+import { Phase } from '../../models/phase.model';
 import { SessionData } from '../../models/session.model';
 import { GithubRelease } from '../../models/github/github.release';
 import { LabelService } from '../label.service';
@@ -98,7 +98,7 @@ export class MockGithubService {
    * Fabricates session data in accordance with SessionData Requirements.
    * @return Observable<{}> representing session information.
    */
-  fetchSettingsFile(): Observable<{}> {
+  fetchSettingsFile(): Observable<SessionData> {
     return of({
       openPhases : [Phase.phaseBugReporting, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration],
       [Phase.phaseBugReporting]: 'undefined',

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -96,7 +96,7 @@ export class MockGithubService {
 
   /**
    * Fabricates session data in accordance with SessionData Requirements.
-   * @return Observable<{}> representing session information.
+   * @return Observable<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
     return of({

--- a/src/app/core/services/mocks/mock.issue.service.ts
+++ b/src/app/core/services/mocks/mock.issue.service.ts
@@ -8,7 +8,8 @@ import {
   STATUS,
 } from '../../models/issue.model';
 import { UserService } from '../user.service';
-import { Phase, PhaseService } from '../phase.service';
+import { PhaseService } from '../phase.service';
+import { Phase } from '../../models/phase.model';
 import { PermissionService } from '../permission.service';
 import { DataService } from '../data.service';
 import { ErrorHandlingService } from '../error-handling.service';

--- a/src/app/core/services/permission.service.ts
+++ b/src/app/core/services/permission.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { GithubService } from './github.service';
 import { UserService } from './user.service';
-import { Phase, PhaseService } from './phase.service';
+import { PhaseService } from './phase.service';
+import { Phase } from '../models/phase.model';
 import { UserRole } from '../models/user.model';
 
 const enum PermissionLevel { Phase = 'Phase', User = 'User' }

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -9,13 +9,7 @@ import { UserRole } from '../models/user.model';
 import { SessionData, assertSessionDataIntegrity } from '../models/session.model';
 import { MatDialog } from '@angular/material';
 import { SessionFixConfirmationComponent } from './session-fix-confirmation/session-fix-confirmation.component';
-
-export enum Phase {
-  phaseBugReporting = 'phaseBugReporting',
-  phaseTeamResponse = 'phaseTeamResponse',
-  phaseTesterResponse = 'phaseTesterResponse',
-  phaseModeration = 'phaseModeration'
-}
+import { Phase } from '../models/phase.model';
 
 export const PhaseDescription = {
   [Phase.phaseBugReporting]: 'Bug Reporting Phase',

--- a/src/app/phase-moderation/phase-moderation.component.ts
+++ b/src/app/phase-moderation/phase-moderation.component.ts
@@ -3,7 +3,7 @@ import { IssuesFilter } from '../core/models/issue.model';
 import { IssueService } from '../core/services/issue.service';
 import { ErrorHandlingService } from '../core/services/error-handling.service';
 import { UserService } from '../core/services/user.service';
-import { Phase } from '../core/services/phase.service';
+import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
 import { LabelService } from '../core/services/label.service';
 import { GithubService } from '../core/services/github.service';

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { UserService } from '../core/services/user.service';
 import { IssuesFilter } from '../core/models/issue.model';
-import { Phase } from '../core/services/phase.service';
+import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
 import { IssueService } from '../core/services/issue.service';
 

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -9,7 +9,7 @@ import { ErrorHandlingService } from '../../core/services/error-handling.service
 import { finalize } from 'rxjs/operators';
 import { IssuesDataTable } from './IssuesDataTable';
 import { MatPaginator, MatSort } from '@angular/material';
-import { Phase, PhaseService } from '../../core/services/phase.service';
+import { PhaseService } from '../../core/services/phase.service';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { AuthService } from '../../core/services/auth.service';
-import { PhaseService, Phase, PhaseDescription } from '../../core/services/phase.service';
+import { PhaseService, PhaseDescription } from '../../core/services/phase.service';
+import { Phase } from '../../core/models/phase.model';
 import { UserService } from '../../core/services/user.service';
 import { Router, RoutesRecognized } from '@angular/router';
 import { filter, pairwise } from 'rxjs/operators';

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -1,0 +1,59 @@
+import { assertSessionDataIntegrity } from '../../../../src/app/core/models/session.model';
+import { of } from 'rxjs';
+
+const validSessionData = {
+  openPhases: [
+    'phaseBugReporting',
+    'phaseTeamResponse',
+    'phaseTesterResponse',
+    'phaseModeration',
+  ],
+  phaseBugReporting: 'bugreporting',
+  phaseTeamResponse: 'pe-results',
+  phaseTesterResponse: 'testerresponse',
+  phaseModeration: 'pe-evaluation',
+};
+
+describe('Session Model', () => {
+  describe('Assert Session Data Integrity', () => {
+    it('should throw error on unavailable session', () => {
+      of(undefined)
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(new Error('Session Data Unavailable')),
+        });
+    });
+    it('should throw error on incorrect session data', () => {
+      of({ key: '' })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(
+              new Error('Session Data is Incorrectly Defined')
+            ),
+        });
+      of({ key: undefined })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(
+              new Error('Session Data is Incorrectly Defined')
+            ),
+        });
+    });
+    it('should throw error on session with no open phases', () => {
+      of({ openPhases: [] })
+        .pipe(assertSessionDataIntegrity())
+        .subscribe({
+          error: (err) =>
+            expect(err).toEqual(new Error('There are no accessible phases.')),
+        });
+    });
+    it('should pass valid session data', () => {
+      of(validSessionData)
+        .pipe(assertSessionDataIntegrity())
+        .subscribe((el) => expect(el).toEqual(validSessionData));
+    });
+  });
+});

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -4,9 +4,9 @@ import {
   SESSION_DATA_INCORRECTLY_DEFINED,
   SESSION_DATA_UNAVAILABLE,
   NO_ACCESSIBLE_PHASES,
-} from "../../../../src/app/core/models/session.model";
-import { Phase } from "../../../../src/app/core/services/phase.service";
-import { of } from "rxjs";
+} from '../../../../src/app/core/models/session.model';
+import { Phase } from '../../../../src/app/core/services/phase.service';
+import { of } from 'rxjs';
 
 const validSessionData: SessionData = {
   openPhases: [
@@ -15,15 +15,15 @@ const validSessionData: SessionData = {
     Phase.phaseTesterResponse,
     Phase.phaseModeration,
   ],
-  phaseBugReporting: "bugreporting",
-  phaseTeamResponse: "pe-results",
-  phaseTesterResponse: "testerresponse",
-  phaseModeration: "pe-evaluation",
+  phaseBugReporting: 'bugreporting',
+  phaseTeamResponse: 'pe-results',
+  phaseTesterResponse: 'testerresponse',
+  phaseModeration: 'pe-evaluation',
 };
 
-describe("Session Model", () => {
-  describe("assertSessionDataIntegrity", () => {
-    it("should throw error on unavailable session", () => {
+describe('Session Model', () => {
+  describe('assertSessionDataIntegrity', () => {
+    it('should throw error on unavailable session', () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -32,8 +32,8 @@ describe("Session Model", () => {
         });
     });
 
-    it("should throw error on session data with missing values", () => {
-      of({ key: "" })
+    it('should throw error on session data with missing values', () => {
+      of({ key: '' })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
@@ -47,7 +47,7 @@ describe("Session Model", () => {
         });
     });
 
-    it("should throw error on session with no open phases", () => {
+    it('should throw error on session with no open phases', () => {
       of({ openPhases: [] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -55,7 +55,7 @@ describe("Session Model", () => {
         });
     });
 
-    it("should pass valid session data", () => {
+    it('should pass valid session data', () => {
       of(validSessionData)
         .pipe(assertSessionDataIntegrity())
         .subscribe((el) => expect(el).toEqual(validSessionData));

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -1,56 +1,61 @@
-import { assertSessionDataIntegrity } from '../../../../src/app/core/models/session.model';
-import { of } from 'rxjs';
+import {
+  assertSessionDataIntegrity,
+  SessionData,
+  SESSION_DATA_INCORRECTLY_DEFINED,
+  SESSION_DATA_UNAVAILABLE,
+  NO_ACCESSIBLE_PHASES,
+} from "../../../../src/app/core/models/session.model";
+import { Phase } from "../../../../src/app/core/services/phase.service";
+import { of } from "rxjs";
 
-const validSessionData = {
+const validSessionData: SessionData = {
   openPhases: [
-    'phaseBugReporting',
-    'phaseTeamResponse',
-    'phaseTesterResponse',
-    'phaseModeration',
+    Phase.phaseBugReporting,
+    Phase.phaseTeamResponse,
+    Phase.phaseTesterResponse,
+    Phase.phaseModeration,
   ],
-  phaseBugReporting: 'bugreporting',
-  phaseTeamResponse: 'pe-results',
-  phaseTesterResponse: 'testerresponse',
-  phaseModeration: 'pe-evaluation',
+  phaseBugReporting: "bugreporting",
+  phaseTeamResponse: "pe-results",
+  phaseTesterResponse: "testerresponse",
+  phaseModeration: "pe-evaluation",
 };
 
-describe('Session Model', () => {
-  describe('Assert Session Data Integrity', () => {
-    it('should throw error on unavailable session', () => {
+describe("Session Model", () => {
+  describe("assertSessionDataIntegrity", () => {
+    it("should throw error on unavailable session", () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(new Error('Session Data Unavailable')),
+            expect(err).toEqual(new Error(SESSION_DATA_UNAVAILABLE)),
         });
     });
-    it('should throw error on incorrect session data', () => {
-      of({ key: '' })
+
+    it("should throw error on session data with missing values", () => {
+      of({ key: "" })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(
-              new Error('Session Data is Incorrectly Defined')
-            ),
+            expect(err).toEqual(new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
         });
       of({ key: undefined })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) =>
-            expect(err).toEqual(
-              new Error('Session Data is Incorrectly Defined')
-            ),
+            expect(err).toEqual(new Error(SESSION_DATA_INCORRECTLY_DEFINED)),
         });
     });
-    it('should throw error on session with no open phases', () => {
+
+    it("should throw error on session with no open phases", () => {
       of({ openPhases: [] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
-          error: (err) =>
-            expect(err).toEqual(new Error('There are no accessible phases.')),
+          error: (err) => expect(err).toEqual(new Error(NO_ACCESSIBLE_PHASES)),
         });
     });
-    it('should pass valid session data', () => {
+
+    it("should pass valid session data", () => {
       of(validSessionData)
         .pipe(assertSessionDataIntegrity())
         .subscribe((el) => expect(el).toEqual(validSessionData));

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -5,7 +5,7 @@ import {
   SESSION_DATA_UNAVAILABLE,
   NO_ACCESSIBLE_PHASES,
 } from '../../../../src/app/core/models/session.model';
-import { Phase } from '../../../../src/app/core/services/phase.service';
+import { Phase } from '../../../../src/app/core/models/phase.model';
 import { of } from 'rxjs';
 
 const validSessionData: SessionData = {

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -22,7 +22,7 @@ const validSessionData: SessionData = {
 };
 
 describe('Session Model', () => {
-  describe('assertSessionDataIntegrity', () => {
+  describe('assertSessionDataIntegrity()', () => {
     it('should throw error on unavailable session', () => {
       of(undefined)
         .pipe(assertSessionDataIntegrity())

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -1,6 +1,7 @@
 import { DescriptionComponent } from '../../../../../src/app/shared/issue/description/description.component';
 import { FormBuilder, NgForm } from '@angular/forms';
-import { Phase, PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { Phase } from '../../../../../src/app/core/models/phase.model';
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.constants';
 import { of } from 'rxjs';

--- a/tests/app/shared/issue/label/label.component.spec.ts
+++ b/tests/app/shared/issue/label/label.component.spec.ts
@@ -5,7 +5,8 @@ import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { SEVERITY_LABELS, COLOR_SEVERITY_LOW, SEVERITY, COLOR_SEVERITY_HIGH, SEVERITY_HIGH } from '../../../../constants/label.constants';
 import { of } from 'rxjs';
-import { Phase, PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { Phase } from '../../../../../src/app/core/models/phase.model';
 
 describe('LabelComponent', () => {
   let labelComponent: any;

--- a/tests/app/shared/issue/title/title.component.spec.ts
+++ b/tests/app/shared/issue/title/title.component.spec.ts
@@ -3,7 +3,8 @@ import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { FormBuilder, NgForm } from '@angular/forms';
 import { of } from 'rxjs';
-import { Phase, PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { PhaseService } from '../../../../../src/app/core/services/phase.service';
+import { Phase } from '../../../../../src/app/core/models/phase.model';
 
 describe('TitleComponent', () => {
   let titleComponent: TitleComponent;

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -2,7 +2,7 @@ import { IssueDispute } from '../../src/app/core/models/issue-dispute.model';
 import { Issue } from '../../src/app/core/models/issue.model';
 import { Team } from '../../src/app/core/models/team.model';
 import { TesterResponse } from '../../src/app/core/models/tester-response.model';
-import { Phase } from '../../src/app/core/services/phase.service';
+import { Phase } from '../../src/app/core/models/phase.model';
 
 import { ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_WITH_ASSIGNEES } from '../constants/githubissue.constants';
 

--- a/tests/services/permissions.service.spec.ts
+++ b/tests/services/permissions.service.spec.ts
@@ -1,5 +1,6 @@
 import { PermissionService } from '../../src/app/core/services/permission.service';
-import { Phase, PhaseService } from '../../src/app/core/services/phase.service';
+import { PhaseService } from '../../src/app/core/services/phase.service';
+import { Phase } from '../../src/app/core/models/phase.model';
 import { UserService } from '../../src/app/core/services/user.service';
 import { UserRole } from '../../src/app/core/models/user.model';
 

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -1,6 +1,7 @@
 import { of } from 'rxjs';
 import { SessionData } from '../../src/app/core/models/session.model';
-import { Phase, PhaseService } from '../../src/app/core/services/phase.service';
+import { PhaseService } from '../../src/app/core/services/phase.service';
+import { Phase } from '../../src/app/core/models/phase.model';
 
 const moderationPhaseSettingsFile: {} = {
   'openPhases': [Phase.phaseModeration],


### PR DESCRIPTION
# Summary

This PR closes #573.

Enumeration definition is now in `src/app/core/models/phase.model.ts`. This solves the issue of circular dependency of the files between `SessionData` and `PhaseService`.

All other references to `Phase` are updated.