### PR TITLE
Rename 'View In Browser' to 'View on GitHub' 

### DIFF
--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -22,8 +22,8 @@
   </div>
 
   <span style="flex: 1 1 auto"></span>
-  <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page in web-browser" (click)="viewBrowser()">
-    View in Browser
+  <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on Github" (click)="viewBrowser()">
+    View on Github
     <mat-icon>link</mat-icon>
   </button>
   <button *ngIf="auth.isAuthenticated() && isReloadButtonShown() && !this.isReloadButtonDisabled"

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -22,7 +22,7 @@
   </div>
 
   <span style="flex: 1 1 auto"></span>
-  <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on Github" (click)="viewBrowser()">
+  <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">
     View on GitHub
     <mat-icon>link</mat-icon>
   </button>

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -23,7 +23,7 @@
 
   <span style="flex: 1 1 auto"></span>
   <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on Github" (click)="viewBrowser()">
-    View on Github
+    View on GitHub
     <mat-icon>link</mat-icon>
   </button>
   <button *ngIf="auth.isAuthenticated() && isReloadButtonShown() && !this.isReloadButtonDisabled"


### PR DESCRIPTION
Fixes #572 

Changes:
- `View in browser` button renamed to `View on Github`
- `View current page in web-browser` tooltip updated to `View current page on Github`

Proposed commit message:
```
Header component: Update button and tooltip 

Let's
* Rename button to 'View on Github'
* Update tooltip to 'View current page on Github'
```