### PR TITLE
IssuesDataTable: Move issue search implementation into independent module, add tests

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,29 @@
+# The purpose of this workflow file is to generate
+# a code coverage report from Codecov on new
+# pushes and pull requests to the master branch
+
+name: Get Code Coverage Report
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  code-coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run test -- "--code-coverage"
+      - uses: codecov/codecov-action@v1
+        with:
+          directory: ./tests/coverage

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { PermissionService } from '../core/services/permission.service';
 import { UserService } from '../core/services/user.service';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../shared/issue-tables/issue-tables-columns';
 
 @Component({
   selector: 'app-phase-bug-reporting',

--- a/src/app/phase-moderation/phase-moderation.component.ts
+++ b/src/app/phase-moderation/phase-moderation.component.ts
@@ -7,7 +7,8 @@ import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
 import { LabelService } from '../core/services/label.service';
 import { GithubService } from '../core/services/github.service';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../shared/issue-tables/issue-tables-columns';
 
 @Component({
   selector: 'app-phase-moderation',

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -5,7 +5,8 @@ import { Issue } from '../../core/models/issue.model';
 import { UserService } from '../../core/services/user.service';
 import { UserRole } from '../../core/models/user.model';
 import { PermissionService } from '../../core/services/permission.service';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 
 @Component({
   selector: 'app-issues-faulty',

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.ts
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.ts
@@ -5,7 +5,8 @@ import { Issue, STATUS } from '../../core/models/issue.model';
 import { PermissionService } from '../../core/services/permission.service';
 import { UserService } from '../../core/services/user.service';
 import { UserRole } from '../../core/models/user.model';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 
 @Component({
   selector: 'app-issues-pending',

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.ts
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.ts
@@ -4,7 +4,8 @@ import { IssuesDataTable } from '../../shared/issue-tables/IssuesDataTable';
 import { Issue } from '../../core/models/issue.model';
 import { UserService } from '../../core/services/user.service';
 import { UserRole } from '../../core/models/user.model';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 
 @Component({
   selector: 'app-issues-responded',

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 import { Issue, STATUS } from '../../core/models/issue.model';
 
 @Component({

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { ACTION_BUTTONS, IssueTablesComponent, TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables.component';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
 import { Issue, STATUS } from '../../core/models/issue.model';
 
 @Component({

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -54,7 +54,7 @@ export class IssuesDataTable extends DataSource<Issue> {
             }
             data = getSortedData(this.sort, data);
             data = this.getFilteredTeamData(data);
-            data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, this.paginator, data);
+            data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
             data = this.getPaginatedData(data);
 
             return data;
@@ -94,6 +94,7 @@ export class IssuesDataTable extends DataSource<Issue> {
   }
 
   private getPaginatedData(data: Issue[]): Issue[] {
+    this.paginator.length = data.length;
     let startIndex = this.paginator.pageIndex * this.paginator.pageSize;
     const result = data.splice(startIndex, this.paginator.pageSize);
     if (result.length === 0) {

--- a/src/app/shared/issue-tables/issue-tables-columns.ts
+++ b/src/app/shared/issue-tables/issue-tables-columns.ts
@@ -1,0 +1,12 @@
+export enum TABLE_COLUMNS {
+    ID = 'id',
+    TITLE = 'title',
+    TEAM_ASSIGNED = 'teamAssigned',
+    TYPE = 'type',
+    SEVERITY = 'severity',
+    RESPONSE = 'responseTag',
+    ASSIGNEE = 'assignees',
+    DUPLICATED_ISSUES = 'duplicatedIssues',
+    TODO = 'Todo Remaining',
+    ACTIONS = 'actions'
+  }

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -20,19 +20,6 @@ export enum ACTION_BUTTONS {
   DELETE_ISSUE
 }
 
-export enum TABLE_COLUMNS {
-  ID = 'id',
-  TITLE = 'title',
-  TEAM_ASSIGNED = 'teamAssigned',
-  TYPE = 'type',
-  SEVERITY = 'severity',
-  RESPONSE = 'responseTag',
-  ASSIGNEE = 'assignees',
-  DUPLICATED_ISSUES = 'duplicatedIssues',
-  TODO = 'Todo Remaining',
-  ACTIONS = 'actions'
-}
-
 @Component({
   selector: 'app-issue-tables',
   templateUrl: './issue-tables.component.html',

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -56,7 +56,5 @@ function matchesDuplicatedIssue(issueService: IssueService, id: number, searchKe
 
 function matchesOtherColumns(issue: Issue, column: string, searchKey: string): boolean {
   const searchStr = String(issue[column]).toLowerCase();
-  if (containsSearchKey(searchStr, searchKey)) {
-    return true;
-  }
+  return containsSearchKey(searchStr, searchKey);
 }

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -1,6 +1,6 @@
 import { IssueService } from '../../core/services/issue.service';
 import { Issue } from '../../core/models/issue.model';
-import { TABLE_COLUMNS } from './issue-tables.component';
+import { TABLE_COLUMNS } from './issue-tables-columns';
 
 /**
  * This module serves to improve separation of concerns in IssuesDataTable.ts module by containing the logic for

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -1,9 +1,8 @@
 import { IssueService } from '../../core/services/issue.service';
 import { Issue } from '../../core/models/issue.model';
-import { MatPaginator } from '@angular/material';
 import { TABLE_COLUMNS } from './issue-tables.component';
 
-export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, paginator: MatPaginator, data: Issue[]): Issue[] {
+export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, data: Issue[]): Issue[] {
     const searchKey = filter.toLowerCase();
     const result = data.slice().filter((issue: Issue) => {
       for (const column of displayedColumn) {
@@ -32,7 +31,6 @@ export function applySearchFilter(filter: string, displayedColumn: string[], iss
       }
       return false;
     });
-    paginator.length = result.length;
     return result;
 }
 

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -2,28 +2,28 @@ import { IssueService } from '../../core/services/issue.service';
 import { Issue } from '../../core/models/issue.model';
 import { TABLE_COLUMNS } from './issue-tables.component';
 
+/**
+ * This module serves to improve separation of concerns in IssuesDataTable.ts module by containing the logic for
+ * applying search filter to the issues data table in this module.
+ * This module exports a single function applySearchFilter which is called by IssuesDataTable.
+ */
 export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, data: Issue[]): Issue[] {
     const searchKey = filter.toLowerCase();
     const result = data.slice().filter((issue: Issue) => {
       for (const column of displayedColumn) {
         switch (column) {
           case TABLE_COLUMNS.ASSIGNEE:
-            for (const assignee of issue.assignees) {
-              const lowerCaseAssignee = assignee.toLowerCase();
-              if (containsSearchKey(lowerCaseAssignee, searchKey)) {
-                return true;
-              }
+            if (matchesAssignee(issue.assignees, searchKey)) {
+              return true;
             }
             break;
           case TABLE_COLUMNS.DUPLICATED_ISSUES:
-            const duplicatedIssues = issueService.issues$.getValue().filter(el => el.duplicateOf === issue.id);
-            if (duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKey)) {
+            if (matchesDuplicatedIssue(issueService, issue.id, searchKey)) {
               return true;
             }
             break;
           default:
-            const searchStr = String(issue[column]).toLowerCase();
-            if (containsSearchKey(searchStr, searchKey)) {
+            if (matchesOtherColumns(issue, column, searchKey)) {
               return true;
             }
             break;
@@ -40,4 +40,23 @@ function containsSearchKey(item: string, searchKey: string): boolean {
 
 function duplicatedIssuesContainsSearchKey(duplicatedIssues: Issue[], searchKey: string): boolean {
   return duplicatedIssues.filter(el => `#${String(el.id)}`.includes(searchKey)).length !== 0;
+}
+
+function matchesAssignee(assignees: string[], searchKey: string): boolean {
+  for (const assignee of assignees) {
+    const lowerCaseAssignee = assignee.toLowerCase();
+    return containsSearchKey(lowerCaseAssignee, searchKey);
+  }
+}
+
+function matchesDuplicatedIssue(issueService: IssueService, id: number, searchKey: string): boolean {
+  const duplicatedIssues = issueService.issues$.getValue().filter(el => el.duplicateOf === id);
+  return duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKey);
+}
+
+function matchesOtherColumns(issue: Issue, column: string, searchKey: string): boolean {
+  const searchStr = String(issue[column]).toLowerCase();
+  if (containsSearchKey(searchStr, searchKey)) {
+    return true;
+  }
 }

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -1,0 +1,45 @@
+import { IssueService } from '../../core/services/issue.service';
+import { Issue } from '../../core/models/issue.model';
+import { MatPaginator } from '@angular/material';
+import { TABLE_COLUMNS } from './issue-tables.component';
+
+export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, paginator: MatPaginator, data: Issue[]): Issue[] {
+    const searchKey = filter.toLowerCase();
+    const result = data.slice().filter((issue: Issue) => {
+      for (const column of displayedColumn) {
+        switch (column) {
+          case TABLE_COLUMNS.ASSIGNEE:
+            for (const assignee of issue.assignees) {
+              const lowerCaseAssignee = assignee.toLowerCase();
+              if (containsSearchKey(lowerCaseAssignee, searchKey)) {
+                return true;
+              }
+            }
+            break;
+          case TABLE_COLUMNS.DUPLICATED_ISSUES:
+            const duplicatedIssues = issueService.issues$.getValue().filter(el => el.duplicateOf === issue.id);
+            if (duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKey)) {
+              return true;
+            }
+            break;
+          default:
+            const searchStr = String(issue[column]).toLowerCase();
+            if (containsSearchKey(searchStr, searchKey)) {
+              return true;
+            }
+            break;
+        }
+      }
+      return false;
+    });
+    paginator.length = result.length;
+    return result;
+}
+
+function containsSearchKey(item: string, searchKey: string): boolean {
+  return item.indexOf(searchKey) !== -1;
+}
+
+function duplicatedIssuesContainsSearchKey(duplicatedIssues: Issue[], searchKey: string): boolean {
+  return duplicatedIssues.filter(el => `#${String(el.id)}`.includes(searchKey)).length !== 0;
+}

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -7,7 +7,7 @@ import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { applySearchFilter } from '../../../../src/app/shared/issue-tables/search-filter';
 import { USER_ANUBHAV } from '../../../constants/data.constants';
 
-fdescribe('search-filter', () => {
+describe('search-filter', () => {
     describe('applySearchFilter()', () => {
         const dummyTeam: Team = new Team({
         id: 'dummyId',

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -5,8 +5,9 @@ import { DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, ISSUE_WITH_ASSIG
 import { TABLE_COLUMNS } from '../../../../src/app/shared/issue-tables/issue-tables.component';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { applySearchFilter } from '../../../../src/app/shared/issue-tables/search-filter';
+import { USER_ANUBHAV } from '../../../constants/data.constants';
 
-describe('search-filter', () => {
+fdescribe('search-filter', () => {
     describe('applySearchFilter()', () => {
         const dummyTeam: Team = new Team({
         id: 'dummyId',
@@ -48,7 +49,7 @@ describe('search-filter', () => {
         });
 
         it('returns filtered list of issues which includes issues that contain the search key in any of its assignees', () => {
-            dummySearchKey = 'anubh-v';
+            dummySearchKey = USER_ANUBHAV.loginId;
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithAssigneee]);
         });
@@ -61,29 +62,29 @@ describe('search-filter', () => {
 
         it('returns filtered list of issues which includes issues that contain the search key in any other column', () => {
             // Checks id of issue
-            dummySearchKey = '92';
+            dummySearchKey = mediumSeverityIssueWithResponse.id.toString();
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithResponse]);
 
             // Checks title of issue
-            dummySearchKey = 'screen freezes';
+            dummySearchKey = mediumSeverityIssueWithAssigneee.title;
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithAssigneee]);
 
             // Checks type of issue
-            dummySearchKey = 'documentationbug';
+            dummySearchKey = highSeverityDocumentationBugIssue.type;
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
                 .toEqual([highSeverityDocumentationBugIssue]);
 
             // Checks severity of issue
-            dummySearchKey = 'low';
+            dummySearchKey = lowSeverityFeatureFlawIssue.severity;
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
                 .toEqual([lowSeverityFeatureFlawIssue]);
 
             // Checks response of issue
-            dummySearchKey = 'accepted';
+            dummySearchKey = mediumSeverityIssueWithResponse.responseTag;
             expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
-                .toEqual([mediumSeverityIssueWithResponse]);
+               .toEqual([mediumSeverityIssueWithResponse]);
         });
     });
 });

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -13,7 +13,7 @@ describe('search-filter', () => {
         id: 'dummyId',
         teamMembers: [],
         });
-        let dummySearchKey: string;
+        let searchKey: string;
         const mediumSeverityIssueWithResponse: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
         mediumSeverityIssueWithResponse.responseTag = 'Accepted';
         const mediumSeverityIssueWithAssigneee: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, dummyTeam);
@@ -29,7 +29,7 @@ describe('search-filter', () => {
             lowSeverityFeatureFlawIssue,
             highSeverityDocumentationBugIssue
         ];
-        const displayedColumn: string[] = [
+        const displayedColumns: string[] = [
             TABLE_COLUMNS.ID,
             TABLE_COLUMNS.TITLE,
             TABLE_COLUMNS.TYPE,
@@ -48,42 +48,42 @@ describe('search-filter', () => {
             issueService.updateLocalStore(duplicatedIssue);
         });
 
-        it('returns filtered list of issues which includes issues that contain the search key in any of its assignees', () => {
-            dummySearchKey = USER_ANUBHAV.loginId;
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+        it('can filter for issues which are assigned to a specific user', () => {
+            searchKey = USER_ANUBHAV.loginId;
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithAssigneee]);
         });
 
-        it('returns filtered list of issues which includes issues that contain the search key in any of its duplicate issues id', () => {
-            dummySearchKey = duplicatedIssue.id.toString();
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+        it('can filter for an issue by the id of its duplicate issues', () => {
+            searchKey = duplicatedIssue.id.toString();
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([highSeverityDocumentationBugIssue]);
         });
 
-        it('returns filtered list of issues which includes issues that contain the search key in any other column', () => {
-            // Checks id of issue
-            dummySearchKey = mediumSeverityIssueWithResponse.id.toString();
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+        it('can filter for issues that contain the search key in any other column', () => {
+            // Search by id of issue
+            searchKey = mediumSeverityIssueWithResponse.id.toString();
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithResponse]);
 
-            // Checks title of issue
-            dummySearchKey = mediumSeverityIssueWithAssigneee.title;
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+            // Search by title of issue
+            searchKey = mediumSeverityIssueWithAssigneee.title;
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([mediumSeverityIssueWithAssigneee]);
 
-            // Checks type of issue
-            dummySearchKey = highSeverityDocumentationBugIssue.type;
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+            // Search by type of issue
+            searchKey = highSeverityDocumentationBugIssue.type;
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([highSeverityDocumentationBugIssue]);
 
-            // Checks severity of issue
-            dummySearchKey = lowSeverityFeatureFlawIssue.severity;
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+            // Search by severity of issue
+            searchKey = lowSeverityFeatureFlawIssue.severity;
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                 .toEqual([lowSeverityFeatureFlawIssue]);
 
-            // Checks response of issue
-            dummySearchKey = mediumSeverityIssueWithResponse.responseTag;
-            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+            // Search by response of issue
+            searchKey = mediumSeverityIssueWithResponse.responseTag;
+            expect(applySearchFilter(searchKey, displayedColumns, issueService, issuesList))
                .toEqual([mediumSeverityIssueWithResponse]);
         });
     });

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -2,7 +2,7 @@ import { Issue } from '../../../../src/app/core/models/issue.model';
 import { Team } from '../../../../src/app/core/models/team.model';
 import { DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, ISSUE_WITH_ASSIGNEES, ISSUE_WITH_EMPTY_DESCRIPTION,
     ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY } from '../../../constants/githubissue.constants';
-import { TABLE_COLUMNS } from '../../../../src/app/shared/issue-tables/issue-tables.component';
+import { TABLE_COLUMNS } from '../../../../src/app/shared/issue-tables/issue-tables-columns';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { applySearchFilter } from '../../../../src/app/shared/issue-tables/search-filter';
 import { USER_ANUBHAV } from '../../../constants/data.constants';

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -1,0 +1,63 @@
+import { BehaviorSubject } from 'rxjs';
+import { Issue } from '../../../../src/app/core/models/issue.model';
+import { Team } from '../../../../src/app/core/models/team.model';
+import { ISSUE_WITH_ASSIGNEES, ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
+import { TABLE_COLUMNS } from '../../../../src/app/shared/issue-tables/issue-tables.component';
+import { IssueService } from '../../../../src/app/core/services/issue.service';
+import { MatPaginator, MatPaginatorIntl, MAT_PAGINATOR_INTL_PROVIDER_FACTORY } from '@angular/material';
+import { applySearchFilter } from '../../../../src/app/shared/issue-tables/search-filter';
+import { ChangeDetectorRef } from '@angular/core';
+import { injectChangeDetectorRef } from '@angular/core/src/render3/view_engine_compatibility';
+
+
+fdescribe('search-filter', () => {
+    describe('applySearchFilter()', () => {
+        const dummyTeam: Team = new Team({
+        id: 'dummyId',
+        teamMembers: [],
+        });
+        let dummySearchKey: string;
+        const dummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+        const otherDummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, dummyTeam);
+        //const duplicateOfDummyIssue: Issue = Issue
+        const issuesList: Issue[] = [dummyIssue, otherDummyIssue];
+
+        const filter: string = new BehaviorSubject('').value;
+        const displayedColumn: string[] = [
+            TABLE_COLUMNS.ID,
+            TABLE_COLUMNS.TITLE,
+            TABLE_COLUMNS.TYPE,
+            TABLE_COLUMNS.SEVERITY,
+            TABLE_COLUMNS.RESPONSE,
+            TABLE_COLUMNS.ASSIGNEE,
+            TABLE_COLUMNS.DUPLICATED_ISSUES,
+            TABLE_COLUMNS.ACTIONS
+        ];
+        const issueService: IssueService = new IssueService(null, null, null, null, null, null);
+        const paginator: MatPaginator = new MatPaginator(new MatPaginatorIntl(), null);
+
+
+        beforeEach(() => {
+            issueService.updateLocalStore(dummyIssue);
+            issueService.updateLocalStore(otherDummyIssue);
+        });
+
+        it('returns filtered list of issues which includes issues that contain the search key in any of its assignees', () => {
+            dummySearchKey = 'a';
+            console.log(applySearchFilter(dummySearchKey, displayedColumn, issueService, paginator, issuesList));
+            //expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, paginator, issuesList)).toEqual([]);
+        });
+
+        // it('returns filtered list of issues which includes issues that contain the search key in any of its duplicate issues id', () => {
+        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
+        // });
+
+        // it('returns filtered list of issues which includes issues that contain the search key in any other column', () => {
+        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
+        // });
+
+        // it('returns filtered list which does not include issues that do not contain the search key in any column', () => {
+        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
+        // });
+    });
+});

--- a/tests/app/shared/issue-tables/search-filter.spec.ts
+++ b/tests/app/shared/issue-tables/search-filter.spec.ts
@@ -1,28 +1,33 @@
-import { BehaviorSubject } from 'rxjs';
 import { Issue } from '../../../../src/app/core/models/issue.model';
 import { Team } from '../../../../src/app/core/models/team.model';
-import { ISSUE_WITH_ASSIGNEES, ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
+import { DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, ISSUE_WITH_ASSIGNEES, ISSUE_WITH_EMPTY_DESCRIPTION,
+    ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY } from '../../../constants/githubissue.constants';
 import { TABLE_COLUMNS } from '../../../../src/app/shared/issue-tables/issue-tables.component';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
-import { MatPaginator, MatPaginatorIntl, MAT_PAGINATOR_INTL_PROVIDER_FACTORY } from '@angular/material';
 import { applySearchFilter } from '../../../../src/app/shared/issue-tables/search-filter';
-import { ChangeDetectorRef } from '@angular/core';
-import { injectChangeDetectorRef } from '@angular/core/src/render3/view_engine_compatibility';
 
-
-fdescribe('search-filter', () => {
+describe('search-filter', () => {
     describe('applySearchFilter()', () => {
         const dummyTeam: Team = new Team({
         id: 'dummyId',
         teamMembers: [],
         });
         let dummySearchKey: string;
-        const dummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-        const otherDummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, dummyTeam);
-        //const duplicateOfDummyIssue: Issue = Issue
-        const issuesList: Issue[] = [dummyIssue, otherDummyIssue];
+        const mediumSeverityIssueWithResponse: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+        mediumSeverityIssueWithResponse.responseTag = 'Accepted';
+        const mediumSeverityIssueWithAssigneee: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, dummyTeam);
+        const lowSeverityFeatureFlawIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY, dummyTeam);
+        const highSeverityDocumentationBugIssue: Issue =
+            Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, dummyTeam);
+        const duplicatedIssue: Issue = Issue.createPhaseTeamResponseIssue(DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY, dummyTeam);
+        duplicatedIssue.duplicateOf = highSeverityDocumentationBugIssue.id;
 
-        const filter: string = new BehaviorSubject('').value;
+        const issuesList: Issue[] = [
+            mediumSeverityIssueWithResponse,
+            mediumSeverityIssueWithAssigneee,
+            lowSeverityFeatureFlawIssue,
+            highSeverityDocumentationBugIssue
+        ];
         const displayedColumn: string[] = [
             TABLE_COLUMNS.ID,
             TABLE_COLUMNS.TITLE,
@@ -31,33 +36,54 @@ fdescribe('search-filter', () => {
             TABLE_COLUMNS.RESPONSE,
             TABLE_COLUMNS.ASSIGNEE,
             TABLE_COLUMNS.DUPLICATED_ISSUES,
-            TABLE_COLUMNS.ACTIONS
         ];
         const issueService: IssueService = new IssueService(null, null, null, null, null, null);
-        const paginator: MatPaginator = new MatPaginator(new MatPaginatorIntl(), null);
-
 
         beforeEach(() => {
-            issueService.updateLocalStore(dummyIssue);
-            issueService.updateLocalStore(otherDummyIssue);
+            issueService.updateLocalStore(mediumSeverityIssueWithResponse);
+            issueService.updateLocalStore(mediumSeverityIssueWithAssigneee);
+            issueService.updateLocalStore(lowSeverityFeatureFlawIssue);
+            issueService.updateLocalStore(highSeverityDocumentationBugIssue);
+            issueService.updateLocalStore(duplicatedIssue);
         });
 
         it('returns filtered list of issues which includes issues that contain the search key in any of its assignees', () => {
-            dummySearchKey = 'a';
-            console.log(applySearchFilter(dummySearchKey, displayedColumn, issueService, paginator, issuesList));
-            //expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, paginator, issuesList)).toEqual([]);
+            dummySearchKey = 'anubh-v';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([mediumSeverityIssueWithAssigneee]);
         });
 
-        // it('returns filtered list of issues which includes issues that contain the search key in any of its duplicate issues id', () => {
-        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
-        // });
+        it('returns filtered list of issues which includes issues that contain the search key in any of its duplicate issues id', () => {
+            dummySearchKey = duplicatedIssue.id.toString();
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([highSeverityDocumentationBugIssue]);
+        });
 
-        // it('returns filtered list of issues which includes issues that contain the search key in any other column', () => {
-        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
-        // });
+        it('returns filtered list of issues which includes issues that contain the search key in any other column', () => {
+            // Checks id of issue
+            dummySearchKey = '92';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([mediumSeverityIssueWithResponse]);
 
-        // it('returns filtered list which does not include issues that do not contain the search key in any column', () => {
-        //     expect(applySearchFilter(dummySearchKey, )).toBeTrue;
-        // });
+            // Checks title of issue
+            dummySearchKey = 'screen freezes';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([mediumSeverityIssueWithAssigneee]);
+
+            // Checks type of issue
+            dummySearchKey = 'documentationbug';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([highSeverityDocumentationBugIssue]);
+
+            // Checks severity of issue
+            dummySearchKey = 'low';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([lowSeverityFeatureFlawIssue]);
+
+            // Checks response of issue
+            dummySearchKey = 'accepted';
+            expect(applySearchFilter(dummySearchKey, displayedColumn, issueService, issuesList))
+                .toEqual([mediumSeverityIssueWithResponse]);
+        });
     });
 });

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -76,6 +76,12 @@ export const USER_JUNWEI = {
   team: TEAM_3
 };
 
+export const USER_ANUBHAV = {
+  loginId: 'anubh-v',
+  role: UserRole.Student,
+  team: TEAM_3
+};
+
 export const USER_Q = {
   loginId: 'q',
   role: UserRole.Tutor,

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -12,6 +12,7 @@ import {
 import { IssueState } from '../../graphql/graphql-types';
 import { EMPTY_TEAM_RESPONSE, PENDING_TUTOR_MODERATION } from './githubcomment.constants';
 import { GithubLabel } from '../../src/app/core/models/github/github-label.model';
+import { USER_ANUBHAV } from './data.constants';
 
 const randomId: () => string = () => {
   return Math.floor(Math.random() * 1000000000).toString();
@@ -40,7 +41,7 @@ export const ISSUE_WITH_EMPTY_DESCRIPTION = new GithubIssue({
   updated_at: '2020-03-13T13:37:32Z',
   url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/92',
   user: {
-    login: 'anubh-v',
+    login: USER_ANUBHAV.loginId,
     avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
     url: 'https://api.github.com/users/anubh-v',
   },
@@ -60,7 +61,7 @@ export const ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY = new GithubIssue({
   updated_at: '2020-03-13T13:37:32Z',
   url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
   user: {
-    login: 'anubh-v',
+    login: USER_ANUBHAV.loginId,
     avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
     url: 'https://api.github.com/users/anubh-v',
   },
@@ -80,7 +81,7 @@ export const ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY = new GithubIssue({
   updated_at: '2012-03-12T19:12:02Z',
   url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
   user: {
-    login: 'anubh-v',
+    login: USER_ANUBHAV.loginId,
     avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
     url: 'https://api.github.com/users/anubh-v',
   },
@@ -100,7 +101,7 @@ export const DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY = new GithubI
   updated_at: '2012-04-12T19:12:02Z',
   url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
   user: {
-    login: 'anubh-v',
+    login: USER_ANUBHAV.loginId,
     avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
     url: 'https://api.github.com/users/anubh-v',
   },
@@ -111,7 +112,7 @@ export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
   number: 91,
   assignees: [
     {
-      login: 'anubh-v',
+      login: USER_ANUBHAV.loginId,
       id: 35621759,
       url: 'https://api.github.com/users/anubh-v',
     }
@@ -126,7 +127,7 @@ export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
   updated_at: '2020-03-02T12:50:02Z',
   url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/91',
   user: {
-    login: 'anubh-v',
+    login: USER_ANUBHAV.loginId,
     avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
     url: 'https://api.github.com/users/anubh-v',
   },
@@ -152,7 +153,7 @@ export const generateIssueWithRandomData: () => GithubIssue = () => {
     updated_at: created_and_updated_date,
     url: `https://api.github.com/repos/CATcher-org/pe-results/issues/${issueNumber}`,
     user: {
-      login: 'anubh-v',
+      login: USER_ANUBHAV.loginId,
       avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
       url: 'https://api.github.com/users/anubh-v',
     },

--- a/tests/constants/githubissue.constants.ts
+++ b/tests/constants/githubissue.constants.ts
@@ -46,6 +46,66 @@ export const ISSUE_WITH_EMPTY_DESCRIPTION = new GithubIssue({
   },
 });
 
+export const ISSUE_WITH_EMPTY_DESCRIPTION_LOW_SEVERITY = new GithubIssue({
+  id: '384830567',
+  number: 130,
+  assignees: [],
+  comments: [],
+  body: '',
+  created_at: '2020-03-02T16:19:02Z',
+  labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
+    GITHUB_LABEL_FEATURE_FLAW, GITHUB_LABEL_LOW_SEVERITY],
+  state: IssueState.Open,
+  title: 'App is sometimes slow',
+  updated_at: '2020-03-13T13:37:32Z',
+  url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
+  user: {
+    login: 'anubh-v',
+    avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
+    url: 'https://api.github.com/users/anubh-v',
+  },
+});
+
+export const ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY = new GithubIssue({
+  id: '573957398',
+  number: 32,
+  assignees: [],
+  comments: [],
+  body: '',
+  created_at: '2010-03-12T19:12:02Z',
+  labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
+    GITHUB_LABEL_DOCUMENTATION_BUG, GITHUB_LABEL_HIGH_SEVERITY],
+  state: IssueState.Open,
+  title: 'Too many typos',
+  updated_at: '2012-03-12T19:12:02Z',
+  url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
+  user: {
+    login: 'anubh-v',
+    avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
+    url: 'https://api.github.com/users/anubh-v',
+  },
+});
+
+export const DUPLICATED_ISSUE_WITH_EMPTY_DESCRIPTION_HIGH_SEVERITY = new GithubIssue({
+  id: '573957399',
+  number: 33,
+  assignees: [],
+  comments: [],
+  body: '',
+  created_at: '2010-04-12T19:12:02Z',
+  labels: [GITHUB_LABEL_TEAM_LABEL, GITHUB_LABEL_TUTORIAL_LABEL,
+    GITHUB_LABEL_DOCUMENTATION_BUG, GITHUB_LABEL_HIGH_SEVERITY],
+  state: IssueState.Open,
+  title: 'Too many typos 2',
+  updated_at: '2012-04-12T19:12:02Z',
+  url: 'https://api.github.com/repos/CATcher-org/pe-results/issues/130',
+  user: {
+    login: 'anubh-v',
+    avatar_url: 'https://avatars1.githubusercontent.com/u/35621759?v=4',
+    url: 'https://api.github.com/users/anubh-v',
+  },
+});
+
 export const ISSUE_WITH_ASSIGNEES = new GithubIssue({
   id: '551732011',
   number: 91,


### PR DESCRIPTION
Fixes #551 

Changes Made:
- Moved logic for applying search filter in `IssuesDataTable` to another module
- Added tests for the module to check if search filter is applied correctly


Proposed Commit Message:
```
IssuesDataTable: Move getFilteredData method to new module

Logic for applying search filter to the table of issues is defined 
in a private method within IssuesDataTable.

Moving this logic to another module will improve separation of 
concerns. Adding tests for this logic would help with future
regression testing. 

Let's
* Move logic for search filter to another module
* Add tests for the module
```
