### PR TITLE
Docs: update to account for web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This application will support the following order of workflow:
 
 # Getting Started
 
-* [Notes on using the CATcher Desktop App](./docs/usage-notes.md)
+* [Notes on using CATcher](./docs/usage-notes.md)
 
 * [Setting up the required GitHub organisation and repositories](./docs/setup-notes.md) (for **admin users** only)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Build Status](https://github.com/CATcher-org/CATcher/workflows/Setup%20Builds%20and%20Tests/badge.svg) [![codecov](https://codecov.io/gh/CATcher-org/CATcher/branch/master/graph/badge.svg?token=XPTILL9ZFM)](https://codecov.io/gh/CATcher-org/CATcher)
 
-**CAT**cher is a desktop application for **C**rowd-sourced **A**nonymous **T**esting software. It uses GitHub as the backend for hosting bug reports.
+**CAT**cher is a cross-platform application for **C**rowd-sourced **A**nonymous **T**esting of software. It uses GitHub as the backend for hosting bug reports.
 
 This application will support the following order of workflow:
 1. **Bug Reporting**: Testers will be informed of the teams they will be testing. Following which, they will be able to start creating new bug reports during this phase.

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,8 +1,24 @@
-# Notes on using the CATcher Desktop App
+- [Accessing the CATcher Web App](#accessing-the-catcher-web-app)
+- [Downloading the CATcher Desktop App](#downloading-the-catcher-desktop-app)
+  - [For Windows Users](#for-windows-users)
+  - [For Mac Users](#for-mac-users)
+  - [For Linux Users](#for-linux-users)
+- [Reporting Problems in using CATcher](#reporting-problems-in-using-catcher)
+
+
+# Accessing the CATcher Web App
+
+The CATcher web application can be
+accessed at
+https://catcher-org.github.io/CATcher
+
+# Downloading the CATcher Desktop App
 
 You can download the latest release from https://github.com/CATcher-org/CATcher/releases
 
 Start the application by clicking on the executable file, no installation is required.
+
+# Notes on using CATcher
 
 The app will prompt you to enter the session you are participating in, using a dropdown.
 

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,5 +1,5 @@
 - [Get Started](#get-started)
-- [Notes on Using the Desktop App](#troubleshooting-the-catcher-desktop-app)
+- [Notes on Using the Desktop App](#notes-on-using-the-desktop-app)
   - [For Windows Users](#for-windows-users)
   - [For Mac Users](#for-mac-users)
   - [For Linux Users](#for-linux-users)

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,29 +1,28 @@
-- [Accessing the CATcher Web App](#accessing-the-catcher-web-app)
-- [Downloading the CATcher Desktop App](#downloading-the-catcher-desktop-app)
+- [Get Started](#get-started)
+- [Notes on Using the Desktop App](#troubleshooting-the-catcher-desktop-app)
   - [For Windows Users](#for-windows-users)
   - [For Mac Users](#for-mac-users)
   - [For Linux Users](#for-linux-users)
 - [Reporting Problems in using CATcher](#reporting-problems-in-using-catcher)
 
 
-# Accessing the CATcher Web App
+# Get started
 
-The CATcher web application can be
+You can either use CATcher through your web browser, or download CATcher's desktop application.
+
+The CATcher web app is recommended, and can be
 accessed at
 https://catcher-org.github.io/CATcher
 
-# Downloading the CATcher Desktop App
+The latest release of the CATcher desktop app can be downloaded from https://github.com/CATcher-org/CATcher/releases
 
-You can download the latest release from https://github.com/CATcher-org/CATcher/releases
+Start the desktop app by clicking on the executable file; no installation is required.
 
-Start the application by clicking on the executable file, no installation is required.
-
-# Notes on using CATcher
-
-The app will prompt you to enter the session you are participating in, using a dropdown.
+Once the app is launched (either web or desktop version), it will prompt you to enter the session you are participating in, using a dropdown.
 
 ![session_select](https://imgur.com/nBOy7zH.png)
 
+# Notes on Using the Desktop App
 ## For Windows Users
 For normal usage, you can run the `CATcher.exe` and the following dialog would appear. Simply click on the "More Info" button and then click the "Run Anyway" button which would have appeared on the bottom right corner of the dialog. 
 
@@ -56,7 +55,15 @@ There are 2 methods to achieve this:
 - From the command line: Use `chmod +x CATcher-x.y.z.AppImage`
 
 # Reporting problems in using CATcher
-If you face any issue in using CATcher, you can create a new issue in CATcher's repository. If necessary, it would also be helpful if you can provide us with your logs. You can retrieve them in the following directory:
+If you face any issue in using CATcher, you can create a new issue in CATcher's repository. If necessary, it would also be helpful if you can provide us with your logs. 
+
+For the web app, logs appear on the browser's console, and are tagged as either 'Error' or 'Info'.
+The pages below explain how to access the console, on different browsers:
+- [Firefox](https://developer.mozilla.org/en-US/docs/Tools/Web_Console)
+- [Chrome](https://developers.google.com/web/tools/chrome-devtools/open#console)
+- [Edge](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/open/?tabs=cmd-Windows#open-the-console-panel)
+
+For the desktop app, logs can be retrieved from the following directory:
 - Linux: ~/.config/CATcher/logs/*.log
 - macOS: ~/Library/Logs/CATcher/*.log
 - Windows: %USERPROFILE%\AppData\Roaming\CATcher\logs\\*.log


### PR DESCRIPTION
Fixes #568 

Proposed commit message:
```
Since CATcher now has both desktop and browser support,
let's update our docs to include instructions for users
on both platforms.
```