### PR TITLE
Tests: Move mock SessionData into constants file

### DIFF
--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -3,13 +3,11 @@ import {
   NO_ACCESSIBLE_PHASES,
   NO_VALID_OPEN_PHASES,
   OPENED_PHASE_REPO_UNDEFINED,
-  SessionData,
   SESSION_DATA_UNAVAILABLE,
   SESSION_DATA_MISSING_OPENPHASES_KEY
 } from '../../../../src/app/core/models/session.model';
-import { Phase } from '../../../../src/app/core/models/phase.model';
 import { of } from 'rxjs';
-import { MODERATION_PHASE_SESSION_DATA } from '../../../constants/session.constants';
+import { BUG_REPORTING_PHASE_SESSION_DATA, NO_OPEN_PHASES_SESSION_DATA } from '../../../constants/session.constants';
 
 describe('Session Model', () => {
   describe('assertSessionDataIntegrity()', () => {
@@ -32,7 +30,7 @@ describe('Session Model', () => {
     });
 
     it('should throw error on session with no open phases', () => {
-      of({ openPhases: [] })
+      of(NO_OPEN_PHASES_SESSION_DATA)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           error: (err) => expect(err).toEqual(new Error(NO_ACCESSIBLE_PHASES)),
@@ -40,7 +38,7 @@ describe('Session Model', () => {
     });
 
     it('should throw error on session data with invalid open phases', () => {
-      of({ ...MODERATION_PHASE_SESSION_DATA, openPhases: ['unknownPhase'] })
+      of({ ...BUG_REPORTING_PHASE_SESSION_DATA, openPhases: ['unknownPhase'] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           next: () => fail(),
@@ -49,20 +47,19 @@ describe('Session Model', () => {
     });
 
     it('should throw error on session data with undefined repo for open phase', () => {
-      const modifiedSessionData: SessionData = { ...MODERATION_PHASE_SESSION_DATA, openPhases: [Phase.phaseBugReporting] };
-      of({ ...modifiedSessionData, phaseBugReporting: undefined })
+      of({ ...BUG_REPORTING_PHASE_SESSION_DATA, phaseBugReporting: undefined })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           next: () => fail(),
           error: (err) => expect(err).toEqual(new Error(OPENED_PHASE_REPO_UNDEFINED)),
         });
-      of({ ...modifiedSessionData, phaseBugReporting: null })
+      of({ ...BUG_REPORTING_PHASE_SESSION_DATA, phaseBugReporting: null })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           next: () => fail(),
           error: (err) => expect(err).toEqual(new Error(OPENED_PHASE_REPO_UNDEFINED)),
         });
-      of({ ...modifiedSessionData, phaseBugReporting: '' })
+      of({ ...BUG_REPORTING_PHASE_SESSION_DATA, phaseBugReporting: '' })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           next: () => fail(),
@@ -71,19 +68,18 @@ describe('Session Model', () => {
     });
 
     it('should not throw error if session data contains repo information of unopened phases', () => {
-      const modifiedSessionData: SessionData = { ...MODERATION_PHASE_SESSION_DATA, openPhases: [Phase.phaseBugReporting] };
-      of({ ...modifiedSessionData })
+      of(BUG_REPORTING_PHASE_SESSION_DATA)
         .pipe(assertSessionDataIntegrity())
         .subscribe({
-          next: (el) => expect(el).toEqual(modifiedSessionData),
+          next: (el) => expect(el).toEqual(BUG_REPORTING_PHASE_SESSION_DATA),
           error: () => fail(),
         });
     });
 
     it('should pass valid session data', () => {
-      of(MODERATION_PHASE_SESSION_DATA)
+      of(BUG_REPORTING_PHASE_SESSION_DATA)
         .pipe(assertSessionDataIntegrity())
-        .subscribe((el) => expect(el).toEqual(MODERATION_PHASE_SESSION_DATA));
+        .subscribe((el) => expect(el).toEqual(BUG_REPORTING_PHASE_SESSION_DATA));
     });
   });
 });

--- a/tests/app/core/models/session-model.spec.ts
+++ b/tests/app/core/models/session-model.spec.ts
@@ -9,19 +9,7 @@ import {
 } from '../../../../src/app/core/models/session.model';
 import { Phase } from '../../../../src/app/core/models/phase.model';
 import { of } from 'rxjs';
-
-const validSessionData: SessionData = {
-  openPhases: [
-    Phase.phaseBugReporting,
-    Phase.phaseTeamResponse,
-    Phase.phaseTesterResponse,
-    Phase.phaseModeration,
-  ],
-  phaseBugReporting: 'bugreporting',
-  phaseTeamResponse: 'pe-results',
-  phaseTesterResponse: 'testerresponse',
-  phaseModeration: 'pe-evaluation',
-};
+import { MODERATION_PHASE_SESSION_DATA } from '../../../constants/session.constants';
 
 describe('Session Model', () => {
   describe('assertSessionDataIntegrity()', () => {
@@ -52,7 +40,7 @@ describe('Session Model', () => {
     });
 
     it('should throw error on session data with invalid open phases', () => {
-      of({ ...validSessionData, openPhases: ['unknownPhase'] })
+      of({ ...MODERATION_PHASE_SESSION_DATA, openPhases: ['unknownPhase'] })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
           next: () => fail(),
@@ -61,7 +49,7 @@ describe('Session Model', () => {
     });
 
     it('should throw error on session data with undefined repo for open phase', () => {
-      const modifiedSessionData: SessionData = { ...validSessionData, openPhases: [Phase.phaseBugReporting] };
+      const modifiedSessionData: SessionData = { ...MODERATION_PHASE_SESSION_DATA, openPhases: [Phase.phaseBugReporting] };
       of({ ...modifiedSessionData, phaseBugReporting: undefined })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -83,7 +71,7 @@ describe('Session Model', () => {
     });
 
     it('should not throw error if session data contains repo information of unopened phases', () => {
-      const modifiedSessionData: SessionData = { ...validSessionData, openPhases: [Phase.phaseBugReporting] };
+      const modifiedSessionData: SessionData = { ...MODERATION_PHASE_SESSION_DATA, openPhases: [Phase.phaseBugReporting] };
       of({ ...modifiedSessionData })
         .pipe(assertSessionDataIntegrity())
         .subscribe({
@@ -93,9 +81,9 @@ describe('Session Model', () => {
     });
 
     it('should pass valid session data', () => {
-      of(validSessionData)
+      of(MODERATION_PHASE_SESSION_DATA)
         .pipe(assertSessionDataIntegrity())
-        .subscribe((el) => expect(el).toEqual(validSessionData));
+        .subscribe((el) => expect(el).toEqual(MODERATION_PHASE_SESSION_DATA));
     });
   });
 });

--- a/tests/constants/session.constants.ts
+++ b/tests/constants/session.constants.ts
@@ -1,21 +1,26 @@
 import { Phase } from '../../src/app/core/models/phase.model';
 import { SessionData } from '../../src/app/core/models/session.model';
 
-export const MODERATION_PHASE_SESSION_DATA: SessionData = {
-  openPhases: [Phase.phaseModeration],
+export const BUG_REPORTING_PHASE_SESSION_DATA: SessionData = {
+  openPhases: [Phase.phaseBugReporting],
   [Phase.phaseBugReporting]: 'bugreporting',
   [Phase.phaseTeamResponse]: 'pe-results',
   [Phase.phaseTesterResponse]: 'testerresponse',
   [Phase.phaseModeration]: 'pe-evaluation'
 };
 
+export const MODERATION_PHASE_SESSION_DATA: SessionData = {
+  ...BUG_REPORTING_PHASE_SESSION_DATA,
+  openPhases: [Phase.phaseModeration]
+};
+
 export const NO_OPEN_PHASES_SESSION_DATA: SessionData = {
-  ...MODERATION_PHASE_SESSION_DATA,
+  ...BUG_REPORTING_PHASE_SESSION_DATA,
   openPhases: []
 };
 
 export const MULTIPLE_OPEN_PHASES_SESSION_DATA: SessionData = {
-  ...MODERATION_PHASE_SESSION_DATA,
+  ...BUG_REPORTING_PHASE_SESSION_DATA,
   openPhases: [
     Phase.phaseBugReporting,
     Phase.phaseTeamResponse,

--- a/tests/constants/session.constants.ts
+++ b/tests/constants/session.constants.ts
@@ -1,0 +1,25 @@
+import { Phase } from '../../src/app/core/models/phase.model';
+import { SessionData } from '../../src/app/core/models/session.model';
+
+export const MODERATION_PHASE_SESSION_DATA: SessionData = {
+  openPhases: [Phase.phaseModeration],
+  [Phase.phaseBugReporting]: 'bugreporting',
+  [Phase.phaseTeamResponse]: 'pe-results',
+  [Phase.phaseTesterResponse]: 'testerresponse',
+  [Phase.phaseModeration]: 'pe-evaluation'
+};
+
+export const NO_OPEN_PHASES_SESSION_DATA: SessionData = {
+  ...MODERATION_PHASE_SESSION_DATA,
+  openPhases: []
+};
+
+export const MULTIPLE_OPEN_PHASES_SESSION_DATA: SessionData = {
+  ...MODERATION_PHASE_SESSION_DATA,
+  openPhases: [
+    Phase.phaseBugReporting,
+    Phase.phaseTeamResponse,
+    Phase.phaseTesterResponse,
+    Phase.phaseModeration,
+  ]
+};

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -1,8 +1,13 @@
 import { of } from 'rxjs';
-import { NO_ACCESSIBLE_PHASES, SessionData } from '../../src/app/core/models/session.model';
+import { NO_ACCESSIBLE_PHASES } from '../../src/app/core/models/session.model';
 import { PhaseService } from '../../src/app/core/services/phase.service';
 import { Phase } from '../../src/app/core/models/phase.model';
-import { MODERATION_PHASE_SESSION_DATA, MULTIPLE_OPEN_PHASES_SESSION_DATA, NO_OPEN_PHASES_SESSION_DATA } from '../constants/session.constants';
+import {
+  BUG_REPORTING_PHASE_SESSION_DATA,
+  MODERATION_PHASE_SESSION_DATA,
+  MULTIPLE_OPEN_PHASES_SESSION_DATA,
+  NO_OPEN_PHASES_SESSION_DATA
+} from '../constants/session.constants';
 
 let phaseService: PhaseService;
 let githubService: any;
@@ -16,7 +21,7 @@ describe('PhaseService', () => {
 
   describe('.storeSessionData()', () => {
     it('should return an Observable of true if an openPhase is defined', () => {
-      githubService.fetchSettingsFile.and.returnValue(of(MODERATION_PHASE_SESSION_DATA));
+      githubService.fetchSettingsFile.and.returnValue(of(BUG_REPORTING_PHASE_SESSION_DATA));
       phaseService.storeSessionData().subscribe((result: boolean) => {
         expect(result).toBeTrue();
       });

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -2,24 +2,7 @@ import { of } from 'rxjs';
 import { NO_ACCESSIBLE_PHASES, SessionData } from '../../src/app/core/models/session.model';
 import { PhaseService } from '../../src/app/core/services/phase.service';
 import { Phase } from '../../src/app/core/models/phase.model';
-
-const moderationPhaseSettingsFile: {} = {
-  'openPhases': [Phase.phaseModeration],
-  [Phase.phaseBugReporting]: 'bugreporting',
-  [Phase.phaseTeamResponse]: 'pe-results',
-  [Phase.phaseTesterResponse]: 'testerresponse',
-  [Phase.phaseModeration]: 'pe-evaluation'
-};
-
-const invalidPhasesSettingsFile: {} = {
-  ...moderationPhaseSettingsFile,
-  'openPhases': []
-};
-
-const multipleOpenPhasesSettingsFile: {} = {
-  ...moderationPhaseSettingsFile,
-  'openPhases': [Phase.phaseBugReporting, Phase.phaseTeamResponse]
-};
+import { MODERATION_PHASE_SESSION_DATA, MULTIPLE_OPEN_PHASES_SESSION_DATA, NO_OPEN_PHASES_SESSION_DATA } from '../constants/session.constants';
 
 let phaseService: PhaseService;
 let githubService: any;
@@ -33,21 +16,21 @@ describe('PhaseService', () => {
 
   describe('.storeSessionData()', () => {
     it('should return an Observable of true if an openPhase is defined', () => {
-      githubService.fetchSettingsFile.and.returnValue(of(moderationPhaseSettingsFile));
+      githubService.fetchSettingsFile.and.returnValue(of(MODERATION_PHASE_SESSION_DATA));
       phaseService.storeSessionData().subscribe((result: boolean) => {
         expect(result).toBeTrue();
       });
     });
 
     it('should return an Observable of true if multiple openPhases are defined', () => {
-      githubService.fetchSettingsFile.and.returnValue(of(multipleOpenPhasesSettingsFile));
+      githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
       phaseService.storeSessionData().subscribe((result: boolean) => {
         expect(result).toBeTrue();
       });
     });
 
     it('should throw an error if no openPhases are defined', () => {
-      githubService.fetchSettingsFile.and.returnValue(of(invalidPhasesSettingsFile));
+      githubService.fetchSettingsFile.and.returnValue(of(NO_OPEN_PHASES_SESSION_DATA));
       phaseService.storeSessionData().subscribe({
         next: () => fail(),
         error: (err) => expect(err).toEqual(new Error(NO_ACCESSIBLE_PHASES))
@@ -57,16 +40,13 @@ describe('PhaseService', () => {
 
   describe('.githubRepoPermissionLevel()', () => {
     it('should return "repo" if phaseModeration is included in openPhases', () => {
-      phaseService.sessionData = moderationPhaseSettingsFile as SessionData;
+      phaseService.sessionData = MODERATION_PHASE_SESSION_DATA;
       expect(phaseService.sessionData.openPhases).toContain(Phase.phaseModeration);
       expect(phaseService.githubRepoPermissionLevel()).toEqual('repo');
     });
 
     it('should return "public_repo" if phaseModeration is not included in openPhases', () => {
-      phaseService.sessionData = {
-        ...moderationPhaseSettingsFile,
-        openPhases: []
-      } as SessionData;
+      phaseService.sessionData = NO_OPEN_PHASES_SESSION_DATA;
       expect(phaseService.sessionData.openPhases).not.toContain(Phase.phaseModeration);
       expect(phaseService.githubRepoPermissionLevel()).toEqual('public_repo');
     });


### PR DESCRIPTION
# Summary 

This PR fixes #576 , where we shift the different `SessionData` defined in different files into one single **source of truth** in` session.constants.ts` 

## Description

Basically, we just shift the following to be defined in our `session.constants.ts` 

1. `MODERATION_PHASE_SESSION_DATA` where the default repository names for the 4 Phases are given, and that the current only open phase is `Phase.phaseModeration`
2. `NO_OPEN_PHASES_SESSION_DATA` has the same predefined repository names, but has **no open phases**. 
3. `MULTIPLE_OPEN_PHASES_SESSION_DATA` has the same predefined repository names, but has all 4 phases open. 

## Proposed Commit Message: 
```
Let's move the mockSessionData to a single source
of truth and to not repeat duplicate mockSessionData

To achieve this, let us define these constants in 
a single source of truth under session.constants.ts
```
