### PR TITLE
Tests: Move duplicated dummyTeam into a constants file

### DIFF
--- a/tests/app/phase-team-response/issues-pending/issues-pending.component.spec.ts
+++ b/tests/app/phase-team-response/issues-pending/issues-pending.component.spec.ts
@@ -4,14 +4,11 @@ import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.con
 import { Team } from '../../../../src/app/core/models/team.model';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { UserService } from '../../../../src/app/core/services/user.service';
-import { USER_Q } from '../../../constants/data.constants';
+import { USER_Q, TEAM_4 } from '../../../constants/data.constants';
 
 describe('IssuesPendingComponent', () => {
     describe('.ngOnInit()', () => {
-        const dummyTeam: Team = new Team({
-            id: 'dummyId',
-            teamMembers: [],
-          });
+        const dummyTeam: Team = TEAM_4;
         let dummyIssue: Issue;
         let issuesPendingComponent: IssuesPendingComponent;
         const issueService: IssueService = new IssueService(null, null, null, null, null, null);

--- a/tests/app/shared/issue-tables/issue-sorter.spec.ts
+++ b/tests/app/shared/issue-tables/issue-sorter.spec.ts
@@ -2,14 +2,11 @@ import { getSortedData } from '../../../../src/app/shared/issue-tables/issue-sor
 import { MatSort } from '@angular/material';
 import { Issue } from '../../../../src/app/core/models/issue.model';
 import { ISSUE_WITH_ASSIGNEES, ISSUE_WITH_EMPTY_DESCRIPTION, ISSUE_PENDING_MODERATION } from '../../../constants/githubissue.constants';
-import { Team } from '../../../../src/app/core/models/team.model';
+import { TEAM_4 } from '../../../constants/data.constants';
 
 describe('issuer-sorter', () => {
   describe('getSortedData()', () => {
-    const dummyTeam = new Team({
-      id: 'F09-2',
-      teamMembers: [],
-    });
+    const dummyTeam = TEAM_4;
     const dummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
     const otherDummyIssue: Issue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_ASSIGNEES, dummyTeam);
     const issuesList: Issue[] = [dummyIssue, otherDummyIssue];

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -65,7 +65,7 @@ const TEAM_3 = new Team({
                 {loginId: 'ptvrajsk', role: UserRole.Student}]
 });
 
-const TEAM_4 = new Team({
+export const TEAM_4 = new Team({
   id: 'CS2103T-W12-4',
   teamMembers: [{loginId: 'ronaklakhotia', role: UserRole.Student}]
 });

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -1,6 +1,6 @@
 import { IssueDispute } from '../../src/app/core/models/issue-dispute.model';
 import { Issue } from '../../src/app/core/models/issue.model';
-import { Team } from '../../src/app/core/models/team.model';
+import { TEAM_4 } from '../constants/data.constants';
 import { TesterResponse } from '../../src/app/core/models/tester-response.model';
 import { Phase } from '../../src/app/core/models/phase.model';
 
@@ -49,10 +49,7 @@ describe('Issue model class', () => {
 });
 
 describe('Issue', () => {
-    const dummyTeam = new Team({
-        id: 'F09-2',
-        teamMembers: [],
-    });
+    const dummyTeam = TEAM_4;
     const dummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
     const otherDummyIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_ASSIGNEES);
     const dummyIssueWithTeam = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);


### PR DESCRIPTION
Fixes #603

Changes made:
- Replaced duplicate definition of dummyTeam in specs files `issues-pending.component.spec.ts`, `issue-sorter.spec.ts`, `issue.model.spec.ts ` with pre-defined `TEAM_4`  in `data.constants.ts`  to avoid code duplication and improve readability

Proposed commit message:
`Specs files: Use pre-declared constants for dummyTeam definition`