### PR TITLE
Dev Notes: Add section on E2E tests

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -111,7 +111,7 @@ The following additional parameters would allow for further customisation,
 | `--protractor-config=e2e/protractor.*.conf.js` | Allows substitution of the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
 
-#### webdriver-manager
+#### Troubleshooting conflicts between the versions of the browser and browser driver
 
 If tests are not correctly carried out in your local machine due to outdated Browser Drivers (e.g. ChromeDriver, GeckoDriver) a possible solution is to run `webdriver-manager update` which will attempt to update all local drivers to the latest version and should help mitigate any incompatibility issues. If you are still unable to run the E2E tests, please check that the Browser itself is up-to-date and re-run the webdriver command post-browser update.
   

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -114,7 +114,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
    - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
      - Login Credentials (Username).
      - User Role and Team Information.
-     - "Test Mode" activation by setting `test` property to `true`.
+     - A `test` flag that is set to `true`, so that CATcher switches into "E2E test mode"
 3. Mock Service Injections
    - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
    - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -81,7 +81,7 @@ One main guideline is that a `describe` block should be created for each method 
 #### CATcher Test Prep
 
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
-1. Build CATcher with using `test` architecture.
+1. Build CATcher using `test` architecture.
    - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
 2. Provide Test Environment Information
    - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
@@ -89,8 +89,8 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
      - User Team and Tutorial Information.
      - "Test Mode" activation by setting `test` property to `true`.
 3. Mock Service Injections
-   - Data reflected in the environment file then assists the application replace the use of some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
-   - These Service Injections are carried in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
+   - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
+   - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
 4. Browser Action Injections using Protractor
    - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
 
@@ -108,7 +108,7 @@ The following additional parameters would allow for further customisation,
 
 | Additional Parameter | Description | Full Command Example |
 | :---: | :-----: | :-------: |
-| `--protractor-config=e2e/protractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
+| `--protractor-config=e2e/protractor.*.conf.js` | Allows substitution of the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
 
 #### webdriver-manager
@@ -117,7 +117,7 @@ If tests are not correctly carried out in your local machine due to outdated Bro
   
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
-- CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to furhter develop mock services and debug E2E Tests.
+- CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to further develop mock services and debug E2E Tests.
 
 # Implementation
 

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -113,7 +113,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
 2. Provide Test Environment Information
    - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
      - Login Credentials (Username).
-     - User Team and Tutorial Information.
+     - User Role and Team Information.
      - "Test Mode" activation by setting `test` property to `true`.
 3. Mock Service Injections
    - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -113,7 +113,7 @@ The following additional parameters would allow for further customisation,
 
 #### Troubleshooting conflicts between the versions of the browser and browser driver
 
-If tests are not correctly carried out in your local machine due to outdated Browser Drivers (e.g. ChromeDriver, GeckoDriver) a possible solution is to run `webdriver-manager update` which will attempt to update all local drivers to the latest version and should help mitigate any incompatibility issues. If you are still unable to run the E2E tests, please check that the Browser itself is up-to-date and re-run the webdriver command post-browser update.
+If tests fail on your machine due to mismatches between the versions of the browser and the browser driver, you can use the [`webdriver-manager`](https://github.com/angular/webdriver-manager#readme) tool to install the right version of the driver.  By default, running `webdriver-manager update` updates all drivers to the latest version, but particular versions can be specified as options.
   
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -76,9 +76,9 @@ Scuri uses [Jasmine's spy feature](https://jasmine.github.io/2.0/introduction.ht
 We loosely follow the [Jasmine Style Guide](https://github.com/CareMessagePlatform/jasmine-styleguide) when writing tests. 
 One main guideline is that a `describe` block should be created for each method / scenario under test, and an `it` block should be created for each property being verified.
 
-### E2E Testing
+# E2E Testing
 
-#### Running E2E Tests
+## Running E2E Tests
 
 E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `protractor.conf.js` in the Chrome Browser.   
 The following additional parameters would allow for further customisation,
@@ -88,7 +88,7 @@ The following additional parameters would allow for further customisation,
 | `--protractor-config=e2e/protractor.*.conf.js` | Allows substitution of the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
 
-#### Troubleshooting conflicts between the versions of the browser and browser driver
+## Troubleshooting conflicts between the versions of the browser and browser driver
 
 If tests fail on your machine due to mismatches between the versions of the browser and the browser driver, you can use the [`webdriver-manager`](https://github.com/angular/webdriver-manager#readme) tool to install the right version of the driver.  By default, running `webdriver-manager update` updates all drivers to the latest version, but particular versions can be specified as options.
   
@@ -96,14 +96,14 @@ If tests fail on your machine due to mismatches between the versions of the brow
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
 - CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to further develop mock services and debug E2E Tests.
 
-#### Protractor Configuration
+## Protractor Configuration
 
 - Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
 - The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
 - E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
 - E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
 
-#### How the E2E tests work
+## How the E2E tests work
 
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
 1. Build CATcher using `test` architecture.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -87,7 +87,7 @@ The following additional parameters would allow for further customisation,
 
 | Additional Parameter | Description | Full Command Example |
 | :---: | :-----: | :-------: |
-| `--protractor-config=e2e/protractor.*.conf.js` | Allows substitution of the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
+| `--protractor-config=e2e/protractor.*.conf.js` | Allows selection of the Protractor configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
 
 ## Troubleshooting conflicts between the versions of the browser and browser driver

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -78,29 +78,6 @@ One main guideline is that a `describe` block should be created for each method 
 
 ### E2E Testing
 
-#### How the E2E tests work
-
-E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
-1. Build CATcher using `test` architecture.
-   - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
-2. Provide Test Environment Information
-   - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
-     - Login Credentials (Username).
-     - User Team and Tutorial Information.
-     - "Test Mode" activation by setting `test` property to `true`.
-3. Mock Service Injections
-   - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
-   - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
-4. Browser Action Injections using Protractor
-   - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
-
-#### Protractor Configuration
-
-- Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
-- The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
-- E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
-- E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
-
 #### Running E2E Tests
 
 E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `protractor.conf.js` in the Chrome Browser.   
@@ -118,6 +95,29 @@ If tests fail on your machine due to mismatches between the versions of the brow
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
 - CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to further develop mock services and debug E2E Tests.
+
+#### Protractor Configuration
+
+- Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
+- The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
+- E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
+- E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
+
+#### How the E2E tests work
+
+E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
+1. Build CATcher using `test` architecture.
+   - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
+2. Provide Test Environment Information
+   - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
+     - Login Credentials (Username).
+     - User Team and Tutorial Information.
+     - "Test Mode" activation by setting `test` property to `true`.
+3. Mock Service Injections
+   - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
+   - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
+4. Browser Action Injections using Protractor
+   - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
 
 # Implementation
 

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -92,7 +92,6 @@ The following additional parameters would allow for further customisation,
 
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
-- CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to further develop mock services and debug E2E Tests.
 
 ## Troubleshooting conflicts between the versions of the browser and browser driver
 

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -104,6 +104,8 @@ The following additional parameters would allow for further customisation,
 | :---: | :-----: | :-------: |
 | `--potractor-config=e2e/potractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --potractor-config=e2e/potractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
+#### webdriver-manager
+If tests are not correctly carried out in your local machine due to outdated Browser Drivers (e.g. ChromeDriver, GeckoDriver) a possible solution is to run `webdriver-manager update` which will attempt to update all local drivers to the latest version and should help mitigate any incompatibility issues. If you are still unable to run the E2E tests, please check that the Browser itself is up-to-date and re-run the webdriver command post-browser update.
   
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -118,7 +118,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
 3. Mock Service Injections
    - Once CATcher switches to E2E test mode, it creates mocks of some services, in order to simulate behaviour that is outside the scope of E2E Testing. This includes authentication, and communication with GitHub (via its APIs).
    - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
-4. Browser Action Injections using Protractor
+4. Browser Action Automation using Protractor
    - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
 
 # Implementation

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -109,7 +109,7 @@ If tests fail on your machine due to mismatches between the versions of the brow
 
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
 1. Build CATcher using `test` architecture
-   - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
+   - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This file provides data that allows CATcher to switch into "E2E test" mode.
 2. Provide Test Environment Information
    - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
      - Login Credentials (Username).

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -85,20 +85,22 @@ E2E Tests can be executed using `npm run e2e`. You should see CATcher launch in 
 Unlike the production version of CATcher, we do not use the actual GitHub API in the E2E tests. Mock data is used to simulate the GitHub API. You can run `npm run ng:serve:test` to run CATcher in this "offline" mode (to further develop or debug the E2E tests).
 The following additional parameters would allow for further customisation,
 
-| Additional Parameter | Description | Full Command Example |
-| :---: | :-----: | :-------: |
-| `--protractor-config=e2e/protractor.*.conf.js` | Allows selection of the Protractor configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
-| `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
+| Additional Parameter | Default | Description | Full Command Example | Command Explanation
+| :---: | :---: | :-----: | :-------: | :------: |
+| `--protractor-config=e2e/protractor.*.conf.js` | `potractor.conf.js` | Allows selection of the Protractor configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` | Runs E2E Tests on the Firefox Browser |
+| `--suite=*` | All Suites | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting` | Run E2E Tests from Login and BugReporting Suites only |
 
-## Troubleshooting conflicts between the versions of the browser and browser driver
-
-If tests fail on your machine due to mismatches between the versions of the browser and the browser driver, you can use the [`webdriver-manager`](https://github.com/angular/webdriver-manager#readme) tool to install the right version of the driver.  By default, running `webdriver-manager update` updates all drivers to the latest version, but particular versions can be specified as options.
-  
 **TO NOTE:**
 - Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
 - CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to further develop mock services and debug E2E Tests.
 
+## Troubleshooting conflicts between the versions of the browser and browser driver
+
+If tests fail on your machine due to mismatches between the versions of the browser and the browser driver, you can use the [`webdriver-manager`](https://github.com/angular/webdriver-manager#readme) tool to install the right version of the driver.  By default, running `webdriver-manager update` updates all drivers to the latest version, but particular versions can be specified as options.
+
 ## Protractor Configuration
+
+E2E Tests are run using [Protractor](http://www.protractortest.org/#/) testing framework.
 
 - Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
 - The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
@@ -107,7 +109,7 @@ If tests fail on your machine due to mismatches between the versions of the brow
 
 ## How the E2E tests work
 
-E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
+E2E Tests are run with the following stages:
 1. Build CATcher using `test` architecture
    - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This file provides data that allows CATcher to switch into "E2E test" mode.
 2. Provide Test Environment Information

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -80,7 +80,9 @@ One main guideline is that a `describe` block should be created for each method 
 
 ## Running E2E Tests
 
-E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `protractor.conf.js` in the Chrome Browser.   
+E2E Tests can be executed using `npm run e2e`. You should see CATcher launch in an instance of Google Chrome, with some automated actions occurring on it. Note: Google Chrome needs to be installed on the machine.
+
+Unlike the production version of CATcher, we do not use the actual GitHub API in the E2E tests. Mock data is used to simulate the GitHub API. You can run `npm run ng:serve:test` to run CATcher in this "offline" mode (to further develop or debug the E2E tests).
 The following additional parameters would allow for further customisation,
 
 | Additional Parameter | Description | Full Command Example |

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -76,6 +76,39 @@ Scuri uses [Jasmine's spy feature](https://jasmine.github.io/2.0/introduction.ht
 We loosely follow the [Jasmine Style Guide](https://github.com/CareMessagePlatform/jasmine-styleguide) when writing tests. 
 One main guideline is that a `describe` block should be created for each method / scenario under test, and an `it` block should be created for each property being verified.
 
+### E2E Testing
+#### CATcher Test Prep
+E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
+1. Build CATcher with using `test` architecture.
+   - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
+2. Provide Test Environment Information
+   - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,
+     - Login Credentials (Username).
+     - User Team and Tutorial Information.
+     - "Test Mode" activation by setting `test` property to `true`.
+3. Mock Service Injections
+   - Data reflected in the environment file then assists the application replace the use of some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolationj) and others.
+   - These Service Injections are carried in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
+4. Browser Action Injections using Protractor
+   - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
+#### Protractor Configuration
+- Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
+- The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
+- E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
+- E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
+#### Running E2E Tests
+E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `potractor.conf.js` in the Chrome Browser.   
+The following additional parameters would allow for further customisation,
+
+| Additional Parameter | Description | Full Command Example |
+| :---: | :-----: | :-------: |
+| `--potractor-config=e2e/potractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --potractor-config=e2e/potractor.firefox.conf.js` |
+| `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
+  
+**TO NOTE:**
+- Relevant Browsers must be installed prior to running tests (i.e. Chrome, Firefox).
+- CATcher can be launched in the Test Build by using the command `npm run ng:serve:test` to furhter develop mock services and debug E2E Tests.
+
 # Implementation
 
 ## Overview

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -87,7 +87,7 @@ The following additional parameters would allow for further customisation,
 
 | Additional Parameter | Default | Description | Full Command Example | Command Explanation
 | :---: | :---: | :-----: | :-------: | :------: |
-| `--protractor-config=e2e/protractor.*.conf.js` | `potractor.conf.js` | Allows selection of the Protractor configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` | Runs E2E Tests on the Firefox Browser |
+| `--protractor-config=e2e/protractor.*.conf.js` | `protractor.conf.js` | Allows selection of the Protractor configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` | Runs E2E Tests on the Firefox Browser |
 | `--suite=*` | All Suites | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting` | Run E2E Tests from Login and BugReporting Suites only |
 
 **TO NOTE:**

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -87,7 +87,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
      - User Team and Tutorial Information.
      - "Test Mode" activation by setting `test` property to `true`.
 3. Mock Service Injections
-   - Data reflected in the environment file then assists the application replace the use of some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolationj) and others.
+   - Data reflected in the environment file then assists the application replace the use of some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
    - These Service Injections are carried in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
 4. Browser Action Injections using Protractor
    - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
@@ -97,12 +97,12 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
 - E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
 - E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
 #### Running E2E Tests
-E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `potractor.conf.js` in the Chrome Browser.   
+E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `protractor.conf.js` in the Chrome Browser.   
 The following additional parameters would allow for further customisation,
 
 | Additional Parameter | Description | Full Command Example |
 | :---: | :-----: | :-------: |
-| `--potractor-config=e2e/potractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --potractor-config=e2e/potractor.firefox.conf.js` |
+| `--protractor-config=e2e/protractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
 #### webdriver-manager
 If tests are not correctly carried out in your local machine due to outdated Browser Drivers (e.g. ChromeDriver, GeckoDriver) a possible solution is to run `webdriver-manager update` which will attempt to update all local drivers to the latest version and should help mitigate any incompatibility issues. If you are still unable to run the E2E tests, please check that the Browser itself is up-to-date and re-run the webdriver command post-browser update.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -119,7 +119,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
    - Once CATcher switches to E2E test mode, it creates mocks of some services, in order to simulate behaviour that is outside the scope of E2E Testing. This includes authentication, and communication with GitHub (via its APIs).
    - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
 4. Browser Action Automation using Protractor
-   - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
+   - With the application ready for testing, we then utilize `Protractor` to run test cases that are located in the `/e2e` directory.
 
 # Implementation
 

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -77,7 +77,9 @@ We loosely follow the [Jasmine Style Guide](https://github.com/CareMessagePlatfo
 One main guideline is that a `describe` block should be created for each method / scenario under test, and an `it` block should be created for each property being verified.
 
 ### E2E Testing
+
 #### CATcher Test Prep
+
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
 1. Build CATcher with using `test` architecture.
    - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
@@ -91,12 +93,16 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
    - These Service Injections are carried in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
 4. Browser Action Injections using Protractor
    - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.
+
 #### Protractor Configuration
+
 - Protractor primarily requires the `*.conf.js` files to define E2E Testing Environments (this includes Browser Details, Base URL, etc...)
 - The base configuration data is stored in `protractor.base.conf.js` which is then extended by separate configuration files for individual browsers as well as the CI/CD pipeline.
 - E2E Tests are typically split into `Page-Objects Files` and `Test Files` in accordance with the [Protractor Style Guide](http://www.protractortest.org/#/style-guide) (more information regarding the interaction between the aforementioned filetypes can be found there).
 - E2E Tests are also grouped into suites based on the Application's Phase (i.e. Login, Bug-Reporting). Currently defined suite information is located in the `protractor.base.conf.js` file as well.
+
 #### Running E2E Tests
+
 E2E Tests can be executed by using `npm run e2e` which conducts testing  using the default `protractor.conf.js` in the Chrome Browser.   
 The following additional parameters would allow for further customisation,
 
@@ -104,7 +110,9 @@ The following additional parameters would allow for further customisation,
 | :---: | :-----: | :-------: |
 | `--protractor-config=e2e/protractor.*.conf.js` | Allows to substitute the default configuration file | `npm run e2e -- --protractor-config=e2e/protractor.firefox.conf.js` |
 | `--suite=*` | Runs E2E Tests for specific suites | `npm run e2e -- --suite=login,bugReporting`
+
 #### webdriver-manager
+
 If tests are not correctly carried out in your local machine due to outdated Browser Drivers (e.g. ChromeDriver, GeckoDriver) a possible solution is to run `webdriver-manager update` which will attempt to update all local drivers to the latest version and should help mitigate any incompatibility issues. If you are still unable to run the E2E tests, please check that the Browser itself is up-to-date and re-run the webdriver command post-browser update.
   
 **TO NOTE:**

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -78,7 +78,7 @@ One main guideline is that a `describe` block should be created for each method 
 
 ### E2E Testing
 
-#### CATcher Test Prep
+#### How the E2E tests work
 
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
 1. Build CATcher using `test` architecture.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -116,7 +116,7 @@ E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/)
      - User Role and Team Information.
      - A `test` flag that is set to `true`, so that CATcher switches into "E2E test mode"
 3. Mock Service Injections
-   - Data reflected in the environment file then assists the application in replacing some existing services with those that bypass specific functions that are irrelevant to E2E Testing. This includes Authentication Bypassing, Backend API Simulation (so that tests can be carried out in isolation) and others.
+   - Once CATcher switches to E2E test mode, it creates mocks of some services, in order to simulate behaviour that is outside the scope of E2E Testing. This includes authentication, and communication with GitHub (via its APIs).
    - These Service Injections are carried out in the respective `*-module.ts` files with the help of Factories (located in `/src/app/core/services/factories`) that check the current build environment and make the Service Replacements accordingly.
 4. Browser Action Injections using Protractor
    - With the application ready for testing, we then utilize `Protractor` to devise test cases that are located in the `/e2e` directory.

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -108,7 +108,7 @@ If tests fail on your machine due to mismatches between the versions of the brow
 ## How the E2E tests work
 
 E2E Tests are currently run using [Protractor](http://www.protractortest.org/#/) testing framework with the following stages. 
-1. Build CATcher using `test` architecture.
+1. Build CATcher using `test` architecture
    - Using `test` build configuration located in `angular.json` under `projects.catcher.architect.configurations` we build a version of CATcher within a test environment that replaces `src/environments/environment.ts` with `src/environments/environment.test.ts` on runtime. This allows for the feeding of information into the application to differ its actions in comparison to the default / production environments.
 2. Provide Test Environment Information
    - The Test Environment (in `src/environments/environment.test.ts`) provides information such as,


### PR DESCRIPTION
Fixes #606 

Proposed Commit Message:
```
Dev Notes: Add section on E2E tests

Let's add instructions on running the E2E tests
into the Dev Notes, along with information
about the structure and operations of the E2E tests.
```