### PR TITLE
Implement cached logging capability

### DIFF
--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -82,11 +82,7 @@ The json supplied should only consist of **one key-pair value**, where the key i
 # Reporting problems in using CATcher
 If you face any issue in using CATcher, you can create a new issue in CATcher's repository. If necessary, it would also be helpful if you can provide us with your logs. 
 
-For the web app, logs appear on the browser's console, and are tagged as either 'Error' or 'Info'.
-The pages below explain how to access the console, on different browsers:
-- [Firefox](https://developer.mozilla.org/en-US/docs/Tools/Web_Console)
-- [Chrome](https://developers.google.com/web/tools/chrome-devtools/open#console)
-- [Edge](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/open/?tabs=cmd-Windows#open-the-console-panel)
+For the web app, logs are saved in your browser and can be retrieved by clicking the "`Download Log`"button.
 
 For the desktop app, logs can be retrieved from the following directory:
 - Linux: ~/.config/CATcher/logs/*.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "main.js",
   "scripts": {
     "postinstall": "npm run postinstall:electron && electron-builder install-app-deps",

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -16,6 +16,7 @@ import { ApplicationService } from '../core/services/application.service';
 import { throwIfFalse } from '../shared/lib/custom-ops';
 import { AppConfig } from '../../environments/environment';
 import { GithubUser } from '../core/models/github-user.model';
+import { LoggingService } from '../core/services/logging.service';
 
 @Component({
   selector: 'app-auth',
@@ -48,6 +49,7 @@ export class AuthComponent implements OnInit, OnDestroy {
               private errorHandlingService: ErrorHandlingService,
               private router: Router,
               private phaseService: PhaseService,
+              private loggingService: LoggingService,
               private titleService: Title,
               private ngZone: NgZone,
               private activatedRoute: ActivatedRoute
@@ -68,6 +70,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.loggingService.startSession();
     this.isReady = false;
     const oauthCode = this.activatedRoute.snapshot.queryParamMap.get('code');
     const state = this.activatedRoute.snapshot.queryParamMap.get('state');

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -62,6 +62,7 @@ export class AuthService {
     this.phaseService.reset();
     this.dataService.reset();
     this.githubEventService.reset();
+    this.logger.reset();
     this.setLandingPageTitle();
     this.issueService.setIssueTeamFilter('All Teams');
     this.reset();
@@ -87,6 +88,7 @@ export class AuthService {
     if (newAuthState === AuthState.Authenticated) {
       const sessionId = generateSessionId();
       this.issueService.setSessionId(sessionId);
+      this.logger.startSession();
       this.logger.info(`Successfully authenticated with session: ${sessionId}`);
     }
     this.authStateSource.next(newAuthState);

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -88,7 +88,6 @@ export class AuthService {
     if (newAuthState === AuthState.Authenticated) {
       const sessionId = generateSessionId();
       this.issueService.setSessionId(sessionId);
-      this.logger.startSession();
       this.logger.info(`Successfully authenticated with session: ${sessionId}`);
     }
     this.authStateSource.next(newAuthState);

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -49,14 +49,19 @@ export class LoggingService {
    */
   getTrimmedLogCache(currentLog: string, sessionCount: number): string {
     const sessionLogSeparator: string = '\n'.repeat(2); // More new-lines added for clarity.
+    const currentDateTime = new Date().toLocaleString();
 
     // Check if Trimming is Necessary
     const numberOfSessions: number = currentLog == null ? 0 : currentLog.split('\n')
       .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
       .length;
 
+    if (!numberOfSessions) {
+      return `${this.LOG_START_HEADER}\n${currentDateTime}`;
+    }
+
     if (numberOfSessions < sessionCount) {
-      return `${numberOfSessions ? `${currentLog}${sessionLogSeparator}` : ''}${this.LOG_START_HEADER}`;
+      return `${currentLog}${sessionLogSeparator}${this.LOG_START_HEADER}\n${currentDateTime}`;
     }
 
     const separatedSessionLogs: string[] = currentLog.split(`${this.LOG_START_HEADER}`)
@@ -64,7 +69,7 @@ export class LoggingService {
       .map((line: string) => `${this.LOG_START_HEADER}\n${line.trim()}`);
 
     separatedSessionLogs.splice(0, separatedSessionLogs.length - sessionCount + 1);
-    separatedSessionLogs.push(this.LOG_START_HEADER);
+    separatedSessionLogs.push(`${this.LOG_START_HEADER}\n${currentDateTime}`);
 
     return separatedSessionLogs.join(sessionLogSeparator);
   }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -62,7 +62,7 @@ export class LoggingService {
       .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
       .length;
 
-    if (!numberOfSessions) {
+    if (numberOfSessions === 0) {
       return logHeaderWithDateTime;
     }
 

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -18,29 +18,29 @@ export class LoggingService {
   }
 
   saveToLocalStorage(...params: any[]) {
-    console.log('incoming params');
-    console.log(params);
+    const oldestSessionLogRegex = /(AppConfig,.*\n[\S\s]*)(?=AppConfig,.*)/g;
     const existingLog = localStorage.getItem(this.LOG_KEY);
-    localStorage.setItem(this.LOG_KEY, params.toString());
-    console.log('existing params');
-    console.log(existingLog);
+    const newLog = `${existingLog ? `${existingLog}\n` : ''}${params.toString()}`.replace(oldestSessionLogRegex, '');
+    localStorage.setItem(this.LOG_KEY, newLog);
   }
 
   info(...params: any[]) {
     this.saveToLocalStorage(params);
     this.logger.info(params);
-    this.saveToLocalStorage(params);
   }
 
   error(...params: any[]) {
+    this.saveToLocalStorage(params);
     this.logger.error(params);
   }
 
   warn(...params: any[]) {
+    this.saveToLocalStorage(params);
     this.logger.warn(params);
   }
 
   debug(...params: any[]) {
+    this.saveToLocalStorage(params);
     this.logger.debug(params);
   }
 }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -9,6 +9,8 @@ export class LoggingService {
   private logger: ElectronLog | Console;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
+  private readonly LOG_START_HEADER = '====== Initializing CATcher Log ======'
+  private readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {
     if (electronService.isElectron()) {
@@ -16,6 +18,44 @@ export class LoggingService {
     } else {
       this.logger = console;
     }
+
+    this.initializeLogCache();
+  }
+
+  initializeLogCache() {
+    this.setCachedLog(this.getTrimmedLogCache(this.getCachedLog(), this.LOG_COUNT_LIMIT));
+  }
+
+  /**
+   * Trims the existing Log in the browser's cache to a select number
+   * of Sessions if necessary.
+   * @param sessionCount The number of Session Logs to preserve in the cache
+   */
+  getTrimmedLogCache(currentLog: string, sessionCount: number): string {
+    // Check if Trimming is Necessary
+    const numberOfSessions: number = currentLog.split('\n')
+      .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
+      .length;
+
+    if(numberOfSessions < sessionCount) {
+      return `${currentLog}\n${this.LOG_START_HEADER}`;
+    }
+
+    const seperatedSessionLogs: string[] = [''];
+    currentLog.split('\n')
+      .forEach((currentLogLine: string) => {
+        if(currentLogLine === this.LOG_START_HEADER) {
+          seperatedSessionLogs.push(currentLogLine);
+        } else {
+          seperatedSessionLogs[seperatedSessionLogs.length - 1] += `\n${currentLogLine}`;
+        }
+      });
+    
+    seperatedSessionLogs.push(this.LOG_START_HEADER);
+    seperatedSessionLogs.splice(0, seperatedSessionLogs.length - sessionCount);
+    return seperatedSessionLogs.reduce((mergedLog: string, currentSessionLog: string) => {
+      return `${mergedLog}\n${currentSessionLog}`;
+    })
   }
 
   getCachedLog(): string {
@@ -26,11 +66,8 @@ export class LoggingService {
     localStorage.setItem(this.LOG_KEY, updatedLog);
   }
 
-  saveToLocalStorage(...params: any[]) {
-    const oldestSessionLogRegex = /(AppConfig,.*\n[\S\s]*)(?=AppConfig,.*)/g;
-    const existingLog = this.getCachedLog();
-    const newLog = `${existingLog ? `${existingLog}\n` : ''}${params.toString()}`.replace(oldestSessionLogRegex, '');
-    this.setCachedLog(newLog);
+  updateLog(... updatedLog: any[]): void {
+    this.setCachedLog(`${this.getCachedLog()}\n${updatedLog.toString()}`);
   }
 
   exportLogFile() {
@@ -54,22 +91,22 @@ export class LoggingService {
   }
 
   info(...params: any[]) {
-    this.saveToLocalStorage(params);
+    this.updateLog(params);
     this.logger.info(params);
   }
 
   error(...params: any[]) {
-    this.saveToLocalStorage(params);
+    this.updateLog(params);
     this.logger.error(params);
   }
 
   warn(...params: any[]) {
-    this.saveToLocalStorage(params);
+    this.updateLog(params);
     this.logger.warn(params);
   }
 
   debug(...params: any[]) {
-    this.saveToLocalStorage(params);
+    this.updateLog(params);
     this.logger.debug(params);
   }
 }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -33,7 +33,7 @@ export class LoggingService {
    */
   getTrimmedLogCache(currentLog: string, sessionCount: number): string {
     // Check if Trimming is Necessary
-    const numberOfSessions: number = currentLog ? 0 : currentLog.split('\n')
+    const numberOfSessions: number = currentLog == null ? 0 : currentLog.split('\n')
       .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
       .length;
 

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -50,6 +50,7 @@ export class LoggingService {
   getTrimmedLogCache(currentLog: string, sessionCount: number): string {
     const sessionLogSeparator: string = '\n'.repeat(2); // More new-lines added for clarity.
     const currentDateTime = new Date().toLocaleString();
+    const logHeaderWithDateTime = `${this.LOG_START_HEADER}\n${currentDateTime}`;
 
     // Check if Trimming is Necessary
     const numberOfSessions: number = currentLog == null ? 0 : currentLog.split('\n')
@@ -57,11 +58,11 @@ export class LoggingService {
       .length;
 
     if (!numberOfSessions) {
-      return `${this.LOG_START_HEADER}\n${currentDateTime}`;
+      return logHeaderWithDateTime;
     }
 
     if (numberOfSessions < sessionCount) {
-      return `${currentLog}${sessionLogSeparator}${this.LOG_START_HEADER}\n${currentDateTime}`;
+      return `${currentLog}${sessionLogSeparator}${logHeaderWithDateTime}`;
     }
 
     const separatedSessionLogs: string[] = currentLog.split(`${this.LOG_START_HEADER}`)
@@ -69,7 +70,7 @@ export class LoggingService {
       .map((line: string) => `${this.LOG_START_HEADER}\n${line.trim()}`);
 
     separatedSessionLogs.splice(0, separatedSessionLogs.length - sessionCount + 1);
-    separatedSessionLogs.push(`${this.LOG_START_HEADER}\n${currentDateTime}`);
+    separatedSessionLogs.push(`${logHeaderWithDateTime}`);
 
     return separatedSessionLogs.join(sessionLogSeparator);
   }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -8,7 +8,7 @@ import { ElectronLog } from 'electron-log';
 export class LoggingService {
   private logger: ElectronLog | Console;
   private readonly LOG_KEY = 'CATcher-Log';
-  private readonly LOG_FILE_NAME = 'CATcher-log.txt'
+  private readonly LOG_FILE_NAME = 'CATcher-log.txt';
 
   constructor(electronService: ElectronService) {
     if (electronService.isElectron()) {
@@ -42,7 +42,7 @@ export class LoggingService {
     hiddenElement.setAttribute('style', 'display: none;');
     hiddenElement.href = blobUrl;
     hiddenElement.download = this.LOG_FILE_NAME;
-    
+
     // Add to DOM and Click to prompt download.
     document.body.appendChild(hiddenElement);
     hiddenElement.click();

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -10,8 +10,8 @@ export class LoggingService {
   private isInSession = false;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
-  private readonly LOG_START_HEADER = '====== New CATcher Session Log ======';
-  private readonly LOG_COUNT_LIMIT = 4;
+  public readonly LOG_START_HEADER = '====== New CATcher Session Log ======';
+  public readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {
     if (electronService.isElectron()) {

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -9,7 +9,7 @@ export class LoggingService {
   private logger: ElectronLog | Console;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
-  private readonly LOG_START_HEADER = '====== Initializing CATcher Log ======'
+  private readonly LOG_START_HEADER = '====== Initializing CATcher Log ======';
   private readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {
@@ -19,7 +19,7 @@ export class LoggingService {
       this.logger = console;
     }
 
-    this.initializeLogCache()
+    this.initializeLogCache();
   }
 
   initializeLogCache() {
@@ -37,25 +37,25 @@ export class LoggingService {
       .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
       .length;
 
-    if(numberOfSessions < sessionCount) {
+    if (numberOfSessions < sessionCount) {
       return `${currentLog}\n${this.LOG_START_HEADER}`;
     }
 
     const seperatedSessionLogs: string[] = [''];
     currentLog.split('\n')
       .forEach((currentLogLine: string) => {
-        if(currentLogLine === this.LOG_START_HEADER) {
+        if (currentLogLine === this.LOG_START_HEADER) {
           seperatedSessionLogs.push(currentLogLine);
         } else {
           seperatedSessionLogs[seperatedSessionLogs.length - 1] += `\n${currentLogLine}`;
         }
       });
-    
+
     seperatedSessionLogs.push(this.LOG_START_HEADER);
     seperatedSessionLogs.splice(0, seperatedSessionLogs.length - sessionCount);
     return seperatedSessionLogs.reduce((mergedLog: string, currentSessionLog: string) => {
       return `${mergedLog}\n${currentSessionLog}`;
-    })
+    });
   }
 
   getCachedLog(): string {

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -7,6 +7,7 @@ import { ElectronLog } from 'electron-log';
 })
 export class LoggingService {
   private logger: ElectronLog | Console;
+  private readonly LOG_KEY = 'CATcher-Log';
 
   constructor(electronService: ElectronService) {
     if (electronService.isElectron()) {
@@ -16,8 +17,19 @@ export class LoggingService {
     }
   }
 
+  saveToLocalStorage(...params: any[]) {
+    console.log('incoming params');
+    console.log(params);
+    const existingLog = localStorage.getItem(this.LOG_KEY);
+    localStorage.setItem(this.LOG_KEY, params.toString());
+    console.log('existing params');
+    console.log(existingLog);
+  }
+
   info(...params: any[]) {
+    this.saveToLocalStorage(params);
     this.logger.info(params);
+    this.saveToLocalStorage(params);
   }
 
   error(...params: any[]) {

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -33,7 +33,7 @@ export class LoggingService {
    */
   getTrimmedLogCache(currentLog: string, sessionCount: number): string {
     // Check if Trimming is Necessary
-    const numberOfSessions: number = currentLog.split('\n')
+    const numberOfSessions: number = currentLog ? 0 : currentLog.split('\n')
       .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
       .length;
 

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -7,7 +7,7 @@ import { ElectronLog } from 'electron-log';
 })
 export class LoggingService {
   private logger: ElectronLog | Console;
-  private isInSession: boolean = false;
+  private isInSession = false;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
   private readonly LOG_START_HEADER = '====== New CATcher Session Log ======';

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -32,6 +32,11 @@ export class LoggingService {
    * in session.
    */
   startSession() {
+    // Prevents the OAuth Pop-up window from being able to
+    // start a session.
+    if (window.opener && window.opener !== window) {
+      return;
+    }
     if (!this.isInSession) {
       this.isInSession = true;
       this.initializeLogCache();

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -19,7 +19,7 @@ export class LoggingService {
       this.logger = console;
     }
 
-    this.initializeLogCache();
+    this.initializeLogCache()
   }
 
   initializeLogCache() {

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -8,6 +8,7 @@ import { ElectronLog } from 'electron-log';
 export class LoggingService {
   private logger: ElectronLog | Console;
   private readonly LOG_KEY = 'CATcher-Log';
+  private readonly LOG_FILE_NAME = 'CATcher-log.txt'
 
   constructor(electronService: ElectronService) {
     if (electronService.isElectron()) {
@@ -17,11 +18,39 @@ export class LoggingService {
     }
   }
 
+  getCachedLog(): string {
+    return localStorage.getItem(this.LOG_KEY);
+  }
+
+  setCachedLog(updatedLog: string): void {
+    localStorage.setItem(this.LOG_KEY, updatedLog);
+  }
+
   saveToLocalStorage(...params: any[]) {
     const oldestSessionLogRegex = /(AppConfig,.*\n[\S\s]*)(?=AppConfig,.*)/g;
-    const existingLog = localStorage.getItem(this.LOG_KEY);
+    const existingLog = this.getCachedLog();
     const newLog = `${existingLog ? `${existingLog}\n` : ''}${params.toString()}`.replace(oldestSessionLogRegex, '');
-    localStorage.setItem(this.LOG_KEY, newLog);
+    this.setCachedLog(newLog);
+  }
+
+  exportLogFile() {
+    const log: string = this.getCachedLog();
+    const blob: Blob = new Blob([log], {type: 'file/txt'});
+    const blobUrl: string = window.URL.createObjectURL(blob);
+
+    const hiddenElement: HTMLAnchorElement = document.createElement('a');
+    hiddenElement.setAttribute('style', 'display: none;');
+    hiddenElement.href = blobUrl;
+    hiddenElement.download = this.LOG_FILE_NAME;
+    
+    // Add to DOM and Click to prompt download.
+    document.body.appendChild(hiddenElement);
+    hiddenElement.click();
+
+    // Remove URL + Created Attached Element
+    window.URL.revokeObjectURL(blobUrl);
+    document.body.removeChild(hiddenElement);
+    hiddenElement.remove();
   }
 
   info(...params: any[]) {

--- a/src/app/core/services/mocks/mock.auth.service.ts
+++ b/src/app/core/services/mocks/mock.auth.service.ts
@@ -73,7 +73,6 @@ export class MockAuthService {
     if (newAuthState === AuthState.Authenticated) {
       const sessionId = `${Date.now()}-${uuid()}`;
       this.issueService.setSessionId(sessionId);
-      this.logger.startSession();
       this.logger.info(`Successfully authenticated with session: ${sessionId}`);
     }
     this.authStateSource.next(newAuthState);

--- a/src/app/core/services/mocks/mock.auth.service.ts
+++ b/src/app/core/services/mocks/mock.auth.service.ts
@@ -59,6 +59,7 @@ export class MockAuthService {
     this.phaseService.reset();
     this.dataService.reset();
     this.githubEventService.reset();
+    this.logger.reset();
     this.setLandingPageTitle();
     this.issueService.setIssueTeamFilter('All Teams');
     this.reset();
@@ -72,6 +73,7 @@ export class MockAuthService {
     if (newAuthState === AuthState.Authenticated) {
       const sessionId = `${Date.now()}-${uuid()}`;
       this.issueService.setSessionId(sessionId);
+      this.logger.startSession();
       this.logger.info(`Successfully authenticated with session: ${sessionId}`);
     }
     this.authStateSource.next(newAuthState);

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -22,6 +22,10 @@
   </div>
 
   <span style="flex: 1 1 auto"></span>
+  <button *ngIf="auth.isAuthenticated()" mat-button matTooltip="Download CATcher Log" (click)="this.loggingService.exportLogFile()">
+    Download Log
+    <mat-icon>receipt</mat-icon>
+  </button>
   <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">
     View on GitHub
     <mat-icon>link</mat-icon>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -12,6 +12,7 @@ import { IssueService } from '../../core/services/issue.service';
 import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
+import { LoggingService } from '../../core/services/logging.service';
 
 @Component({
   selector: 'app-layout-header',
@@ -29,6 +30,7 @@ export class HeaderComponent implements OnInit {
               public auth: AuthService,
               public phaseService: PhaseService,
               public userService: UserService,
+              private loggingService: LoggingService,
               private location: Location,
               private githubEventService: GithubEventService,
               private issueService: IssueService,

--- a/tests/services/logging.service.spec.ts
+++ b/tests/services/logging.service.spec.ts
@@ -1,24 +1,26 @@
-import { LoggingService } from "../../src/app/core/services/logging.service";
+import { LoggingService } from '../../src/app/core/services/logging.service';
 
 let loggingService: LoggingService;
-const getFilteredLogCount: (currentLog: string, predicate: (line: string) => boolean) => number = (currentLog: string, predicate: (line :string) => boolean) => loggingService
-  .getTrimmedLogCache(currentLog, loggingService.LOG_COUNT_LIMIT)
-  .split('\n')
-  .filter((line: string) => predicate(line))
-  .length;
+const getFilteredLogCount: (currentLog: string, predicate: (line: string) => boolean) => number = (
+  currentLog: string,
+  predicate: (line: string) => boolean
+) =>
+  loggingService
+    .getTrimmedLogCache(currentLog, loggingService.LOG_COUNT_LIMIT)
+    .split('\n')
+    .filter((line: string) => predicate(line)).length;
 const oldLogIdentifier = 'Old Log';
 const repeatLogStartHeader: (numberOfRepitions: number) => string = (numberofRepitions: number) => {
-  return `${loggingService.LOG_START_HEADER}\n${oldLogIdentifier}\n`.repeat(numberofRepitions)
+  return `${loggingService.LOG_START_HEADER}\n${oldLogIdentifier}\n`.repeat(numberofRepitions);
 };
 const logHeaderFilter: (line: string) => boolean = (line: string) => line === loggingService.LOG_START_HEADER;
 const oldLogFilter: (line: string) => boolean = (line: string) => line === oldLogIdentifier;
 
-
 describe('LoggingService', () => {
   beforeAll(() => {
-      const electronService = jasmine.createSpyObj('ElectronService', ['isElectron']);
-      electronService.isElectron = jasmine.createSpy('isElectron', () => false);
-      loggingService = new LoggingService(electronService);
+    const electronService = jasmine.createSpyObj('ElectronService', ['isElectron']);
+    electronService.isElectron = jasmine.createSpy('isElectron', () => false);
+    loggingService = new LoggingService(electronService);
   });
 
   describe('.getTrimmedLogCache()', () => {
@@ -31,7 +33,7 @@ describe('LoggingService', () => {
     it('should return additional logs if cache contains existing log', () => {
       let logCounter = 1;
 
-      while(logCounter < loggingService.LOG_COUNT_LIMIT) {
+      while (logCounter < loggingService.LOG_COUNT_LIMIT) {
         expect(getFilteredLogCount(repeatLogStartHeader(logCounter), logHeaderFilter)).toEqual(logCounter + 1);
         logCounter += 1;
       }
@@ -39,24 +41,24 @@ describe('LoggingService', () => {
 
     it('should return updated log if log in cache contains max number of sessions', () => {
       // Number of logs must stay the same
-      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), logHeaderFilter))
-        .toEqual(loggingService.LOG_COUNT_LIMIT);
+      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), logHeaderFilter)).toEqual(
+        loggingService.LOG_COUNT_LIMIT
+      );
 
       // Number of Old Logs must be reduced by 1 (To make way for the new session log)
-      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), oldLogFilter))
-        .toEqual(loggingService.LOG_COUNT_LIMIT - 1);
+      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), oldLogFilter)).toEqual(
+        loggingService.LOG_COUNT_LIMIT - 1
+      );
     });
 
     it('should return trimmed and updated log if log in cache exceeds max number of sessions', () => {
       const exceededSessionCount = loggingService.LOG_COUNT_LIMIT + 10; // Arbitrary Exceed Count
 
       // Number of logs must be at max number
-      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), logHeaderFilter))
-        .toEqual(loggingService.LOG_COUNT_LIMIT);
+      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), logHeaderFilter)).toEqual(loggingService.LOG_COUNT_LIMIT);
 
       // Number of Old Logs must be Max - 1 (To make way for the new session log)
-      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), oldLogFilter))
-        .toEqual(loggingService.LOG_COUNT_LIMIT - 1);
+      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), oldLogFilter)).toEqual(loggingService.LOG_COUNT_LIMIT - 1);
     });
   });
 });

--- a/tests/services/logging.service.spec.ts
+++ b/tests/services/logging.service.spec.ts
@@ -10,7 +10,7 @@ const getFilteredLogCount: (currentLog: string, predicate: (line: string) => boo
     .split('\n')
     .filter((line: string) => predicate(line)).length;
 const oldLogIdentifier = 'Old Log';
-const repeatLogStartHeader: (numberOfRepitions: number) => string = (numberofRepitions: number) => {
+const repeatOldLogStartHeader: (numberOfRepitions: number) => string = (numberofRepitions: number) => {
   return `${loggingService.LOG_START_HEADER}\n${oldLogIdentifier}\n`.repeat(numberofRepitions);
 };
 const logHeaderFilter: (line: string) => boolean = (line: string) => line === loggingService.LOG_START_HEADER;
@@ -34,19 +34,19 @@ describe('LoggingService', () => {
       let logCounter = 1;
 
       while (logCounter < loggingService.LOG_COUNT_LIMIT) {
-        expect(getFilteredLogCount(repeatLogStartHeader(logCounter), logHeaderFilter)).toEqual(logCounter + 1);
+        expect(getFilteredLogCount(repeatOldLogStartHeader(logCounter), logHeaderFilter)).toEqual(logCounter + 1);
         logCounter += 1;
       }
     });
 
     it('should return updated log if log in cache contains max number of sessions', () => {
       // Number of logs must stay the same
-      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), logHeaderFilter)).toEqual(
+      expect(getFilteredLogCount(repeatOldLogStartHeader(loggingService.LOG_COUNT_LIMIT), logHeaderFilter)).toEqual(
         loggingService.LOG_COUNT_LIMIT
       );
 
       // Number of Old Logs must be reduced by 1 (To make way for the new session log)
-      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), oldLogFilter)).toEqual(
+      expect(getFilteredLogCount(repeatOldLogStartHeader(loggingService.LOG_COUNT_LIMIT), oldLogFilter)).toEqual(
         loggingService.LOG_COUNT_LIMIT - 1
       );
     });
@@ -55,10 +55,10 @@ describe('LoggingService', () => {
       const exceededSessionCount = loggingService.LOG_COUNT_LIMIT + 10; // Arbitrary Exceed Count
 
       // Number of logs must be at max number
-      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), logHeaderFilter)).toEqual(loggingService.LOG_COUNT_LIMIT);
+      expect(getFilteredLogCount(repeatOldLogStartHeader(exceededSessionCount), logHeaderFilter)).toEqual(loggingService.LOG_COUNT_LIMIT);
 
       // Number of Old Logs must be Max - 1 (To make way for the new session log)
-      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), oldLogFilter)).toEqual(loggingService.LOG_COUNT_LIMIT - 1);
+      expect(getFilteredLogCount(repeatOldLogStartHeader(exceededSessionCount), oldLogFilter)).toEqual(loggingService.LOG_COUNT_LIMIT - 1);
     });
   });
 });

--- a/tests/services/logging.service.spec.ts
+++ b/tests/services/logging.service.spec.ts
@@ -1,0 +1,62 @@
+import { LoggingService } from "../../src/app/core/services/logging.service";
+
+let loggingService: LoggingService;
+const getFilteredLogCount: (currentLog: string, predicate: (line: string) => boolean) => number = (currentLog: string, predicate: (line :string) => boolean) => loggingService
+  .getTrimmedLogCache(currentLog, loggingService.LOG_COUNT_LIMIT)
+  .split('\n')
+  .filter((line: string) => predicate(line))
+  .length;
+const oldLogIdentifier = 'Old Log';
+const repeatLogStartHeader: (numberOfRepitions: number) => string = (numberofRepitions: number) => {
+  return `${loggingService.LOG_START_HEADER}\n${oldLogIdentifier}\n`.repeat(numberofRepitions)
+};
+const logHeaderFilter: (line: string) => boolean = (line: string) => line === loggingService.LOG_START_HEADER;
+const oldLogFilter: (line: string) => boolean = (line: string) => line === oldLogIdentifier;
+
+
+describe('LoggingService', () => {
+  beforeAll(() => {
+      const electronService = jasmine.createSpyObj('ElectronService', ['isElectron']);
+      electronService.isElectron = jasmine.createSpy('isElectron', () => false);
+      loggingService = new LoggingService(electronService);
+  });
+
+  describe('.getTrimmedLogCache()', () => {
+    it('should return 1 new log if cache does not contain existing log', () => {
+      expect(getFilteredLogCount(undefined, logHeaderFilter)).toEqual(1);
+      expect(getFilteredLogCount('', logHeaderFilter)).toEqual(1);
+      expect(expect(getFilteredLogCount('gibberish', logHeaderFilter)).toEqual(1));
+    });
+
+    it('should return additional logs if cache contains existing log', () => {
+      let logCounter = 1;
+
+      while(logCounter < loggingService.LOG_COUNT_LIMIT) {
+        expect(getFilteredLogCount(repeatLogStartHeader(logCounter), logHeaderFilter)).toEqual(logCounter + 1);
+        logCounter += 1;
+      }
+    });
+
+    it('should return updated log if log in cache contains max number of sessions', () => {
+      // Number of logs must stay the same
+      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), logHeaderFilter))
+        .toEqual(loggingService.LOG_COUNT_LIMIT);
+
+      // Number of Old Logs must be reduced by 1 (To make way for the new session log)
+      expect(getFilteredLogCount(repeatLogStartHeader(loggingService.LOG_COUNT_LIMIT), oldLogFilter))
+        .toEqual(loggingService.LOG_COUNT_LIMIT - 1);
+    });
+
+    it('should return trimmed and updated log if log in cache exceeds max number of sessions', () => {
+      const exceededSessionCount = loggingService.LOG_COUNT_LIMIT + 10; // Arbitrary Exceed Count
+
+      // Number of logs must be at max number
+      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), logHeaderFilter))
+        .toEqual(loggingService.LOG_COUNT_LIMIT);
+
+      // Number of Old Logs must be Max - 1 (To make way for the new session log)
+      expect(getFilteredLogCount(repeatLogStartHeader(exceededSessionCount), oldLogFilter))
+        .toEqual(loggingService.LOG_COUNT_LIMIT - 1);
+    });
+  });
+});

--- a/tests/services/logging.service.spec.ts
+++ b/tests/services/logging.service.spec.ts
@@ -27,7 +27,7 @@ describe('LoggingService', () => {
     it('should return 1 new log if cache does not contain existing log', () => {
       expect(getFilteredLogCount(undefined, logHeaderFilter)).toEqual(1);
       expect(getFilteredLogCount('', logHeaderFilter)).toEqual(1);
-      expect(expect(getFilteredLogCount('gibberish', logHeaderFilter)).toEqual(1));
+      expect(getFilteredLogCount('gibberish', logHeaderFilter)).toEqual(1);
     });
 
     it('should return additional logs if cache contains existing log', () => {


### PR DESCRIPTION
Fixes #615 

### Summary
Caching of logs will now be done on `localStorage` which will be stored on the user's browser. We will be maintaining 4 sessions worth of logs in the cache but this number can be adjusted as per the app's requirement. A "Download Log" button has been added to the header should the user need to download the logs as a text file and submit it to us for inspection/troubleshooting.

### Download Log Button
![image](https://user-images.githubusercontent.com/39243082/109946375-2398d000-7d13-11eb-99c7-3543250284a5.png)

### Log Sample
```
====== New CATcher Session Log ======
3/11/2021, 12:35:53 AM
AppConfig,[object Object]
Mode web

====== New CATcher Session Log ======
3/11/2021, 12:39:53 AM
AppConfig,[object Object]
Mode web
Successfully authenticated with session: 1615394725773-6c82bc7e-8307-4546-95ee-c6820ba6618c

====== New CATcher Session Log ======
3/11/2021, 12:45:40 AM
Successfully authenticated with session: 1615394740443-ff8de1e6-413c-4da9-b503-8a5e1c8e03dc

====== New CATcher Session Log ======
3/12/2021, 1:39:21 AM
AppConfig,[object Object]
Mode web
AppConfig,[object Object]
Mode web
Successfully authenticated with session: 1615484371414-7c741ad6-e2c5-4a70-90f8-053bf93a709b
```

#### Note
- 1st Log is a sample from running the application in `Test` mode (i.e. `npm run ng:serve:test` but not logging in
- 2nd Log is a sample where the app is run in `Test` mode and login is successful
- 3rd Log is a sample where the user logs out and logs back in without refreshing the page (i.e. App Services are not triggered from scratch).
- 4th Log  is sample from Dev Version (i.e. `npm run ng:serve:web`)(with actual authentication). The repetition is caused by the logs from the OAuth Window
[Note: The last log does not contain AppConfig ... as the the application was not restarted, the user simply logged out and back in]

#### Also Note
Since this is stored in `localStorage` the information can only be wiped programmatically or when the user clears their browser cache. There is a limit (typically 5-10MB) depending on the browser but I don't think we'd ever hit that especially since we are planning to limit the information based on some number of sessions (4 Sessions worth of Logs will currently be kept in the cache).

---

Proposed Commit Message:

```
Caching Logs in Browser

Log Information will now be cached on browser (through localStorage)
for retrieval later on when troubleshooting user issues. This Log can be
downloaded from the Application Header as a .txt file.
```