### PR TITLE
Tester Response: Replace checkbox with radio buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "main.js",
   "scripts": {
     "postinstall": "npm run postinstall:electron && electron-builder install-app-deps",

--- a/src/app/shared/view-issue/tester-response/tester-response.component.css
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.css
@@ -2,3 +2,7 @@
     padding: 10px 20px 0 20px;
     display: grid;
 }
+
+.mat-radio-button ~ .mat-radio-button {
+  margin-left: 16px;
+}

--- a/src/app/shared/view-issue/tester-response/tester-response.component.html
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.html
@@ -23,7 +23,7 @@
                            [disableControl]="!isEditing"
                            [id]="getDisagreeRadioFormId(i)"
                            [formControlName]="getDisagreeRadioFormId(i)"
-                           (change)="handleChangeOfDisagreeCheckbox($event, i)">
+                           (change)="handleChangeOfDisagreeRadioButton($event, i)">
             <mat-radio-button [value]="false">
               I Agree
             </mat-radio-button>

--- a/src/app/shared/view-issue/tester-response/tester-response.component.html
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.html
@@ -18,15 +18,21 @@
         <markdown [data]="response.description"></markdown>
         <br>
         <div>
-          <mat-checkbox style="display: inline-block; width: 20%" [id]="getDisagreeBoxFormId(i)"
-                        [formControlName]="getDisagreeBoxFormId(i)"
-                        [disableControl]="!isEditing"
-                        (change)="handleChangeOfDisagreeCheckbox($event, i)"
-          >
-            I disagree
-          </mat-checkbox>
+          <mat-radio-group style="display: inline-block; width: 20%"
+                           aria-label="Select Agree or Disagree to Team's Response"
+                           [disableControl]="!isEditing"
+                           [id]="getDisagreeRadioFormId(i)"
+                           [formControlName]="getDisagreeRadioFormId(i)"
+                           (change)="handleChangeOfDisagreeCheckbox($event, i)">
+            <mat-radio-button [value]="false">
+              I Agree
+            </mat-radio-button>
+            <mat-radio-button [value]="true">
+              I Disagree
+            </mat-radio-button>
+          </mat-radio-group>
         </div>
-        <div *ngIf="testerResponseForm.get(getDisagreeBoxFormId(i)).value">
+        <div *ngIf="testerResponseForm.get(getDisagreeRadioFormId(i)).value">
           <div>
             <p style="font-weight: 500;"> Reason for Disagreement: </p>
             <markdown [data]="response.reasonForDisagreement" *ngIf="!isEditing"></markdown>

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -194,15 +194,11 @@ export class TesterResponseComponent implements OnInit, OnChanges {
     }
 
     const updatedIssue = this.issue.clone(this.phaseService.currentPhase);
-    const values: {} = this.testerResponseForm.getRawValue();
 
     updatedIssue.testerResponses.map((response: TesterResponse, index: number) => {
       // Filter Keys based on Response Index
-      const responseDataKeys = Object.keys(values).filter((key: string) => key.includes(`${index}`));
-      const disagreeKey = responseDataKeys.find((key: string) => key.startsWith(this.responseRadioIdentifier));
-      const reasonKey = responseDataKeys.find((key: string) => key.startsWith(this.responseTextIdentifier));
-      const isDisagree = values[disagreeKey];
-      const reason = isDisagree ? (values[reasonKey] || response.reasonForDisagreement) : response.INITIAL_RESPONSE;
+      const isDisagree = this.isResponseDisagreed(index);
+      const reason = isDisagree ? (this.getTesterResponseText(index) || response.reasonForDisagreement) : response.INITIAL_RESPONSE;
 
       response.setDisagree(isDisagree);
       response.setReasonForDisagreement(reason);
@@ -220,10 +216,27 @@ export class TesterResponseComponent implements OnInit, OnChanges {
   }
 
   /**
+   * Gets the Tester's Response text.
+   * @param index Tester Response Index.
+   */
+  getTesterResponseText(index: number): string {
+    return this.testerResponseForm.get(this.getTesterResponseFormId(index)).value
+  }
+
+  /**
    * @param index - index of action which the tester disagree.
    */
   getDisagreeRadioFormId(index: number): string {
     return `${this.responseRadioIdentifier}-${index}`;
+  }
+
+  /**
+   * Checks if Tester Response was agreed to or disagreed with.
+   * @param index Tester Response Index,
+   * @returns true if response was disagreed with, false if response was agreed with.
+   */
+  isResponseDisagreed(index: number): boolean {
+    return this.testerResponseForm.get(this.getDisagreeRadioFormId(index)).value;
   }
 
   get conflict(): boolean {

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -220,7 +220,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
    * @param index Tester Response Index.
    */
   getTesterResponseText(index: number): string {
-    return this.testerResponseForm.get(this.getTesterResponseFormId(index)).value
+    return this.testerResponseForm.get(this.getTesterResponseFormId(index)).value;
   }
 
   /**

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -142,10 +142,9 @@ export class TesterResponseComponent implements OnInit, OnChanges {
     this.resetForm();
   }
 
-  handleChangeOfDisagreeCheckbox(event, index: number) {
-    const checkboxFormControl = this.testerResponseForm.get(this.getDisagreeRadioFormId(index));
+  handleChangeOfDisagreeRadioButton(event, index: number) {
     const responseFormControl = this.testerResponseForm.get(this.getTesterResponseFormId(index));
-    const isDisagreeChecked = checkboxFormControl.value;
+    const isDisagreeChecked = this.isResponseDisagreed(index);
     if (isDisagreeChecked) {
       responseFormControl.enable();
     } else {

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -165,7 +165,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
    */
   createFormGroup() {
     const group: any = {};
-    // initialize fields for tester response and the checkboxes for tester to mark "Disagree"
+    // initialize fields for tester response and the radio buttons for tester to choose "Agree" / "Disagree"
     for (let i = 0; i < this.issue.testerResponses.length; i++) {
       const response = this.issue.testerResponses[i];
       group[this.getTesterResponseFormId(i)] = new FormControl({

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -31,6 +31,8 @@ export class TesterResponseComponent implements OnInit, OnChanges {
   @Output() updateEditState = new EventEmitter<boolean>();
   @ViewChild(CommentEditorComponent) commentEditor: CommentEditorComponent;
 
+  private readonly responseRadioIdentifier = 'response-radio';
+
   constructor(private formBuilder: FormBuilder,
               private issueService: IssueService,
               public userService: UserService,
@@ -139,7 +141,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
   }
 
   handleChangeOfDisagreeCheckbox(event, index: number) {
-    const checkboxFormControl = this.testerResponseForm.get(this.getDisagreeBoxFormId(index));
+    const checkboxFormControl = this.testerResponseForm.get(this.getDisagreeRadioFormId(index));
     const responseFormControl = this.testerResponseForm.get(this.getTesterResponseFormId(index));
     const isDisagreeChecked = checkboxFormControl.value;
     if (isDisagreeChecked) {
@@ -169,7 +171,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
         value: response.reasonForDisagreement,
         disabled: !response.isDisagree()
       }, Validators.required);
-      group[this.getDisagreeBoxFormId(i)] = new FormControl({
+      group[this.getDisagreeRadioFormId(i)] = new FormControl({
         value: response.isDisagree(),
         disabled: !this.isEditing
       }, Validators.required);
@@ -196,7 +198,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
 
     let index = 0;
     for (const [key, value] of Object.entries(values)) {
-      if (key.startsWith('disagree-box')) {
+      if (key.startsWith(this.responseRadioIdentifier) && value) {
         disagrees.push(value);
       } else if (key.startsWith('tester-response')) {
         reasons.push(value);
@@ -226,8 +228,8 @@ export class TesterResponseComponent implements OnInit, OnChanges {
   /**
    * @param index - index of action which the tester disagree.
    */
-  getDisagreeBoxFormId(index: number): string {
-    return `disagree-box-${index}`;
+  getDisagreeRadioFormId(index: number): string {
+    return `${this.responseRadioIdentifier}-${index}`;
   }
 
   get conflict(): boolean {


### PR DESCRIPTION
Fixes #415 

# Old

![image](https://user-images.githubusercontent.com/39243082/109456261-68aecf00-7a93-11eb-84fc-9961abd28e03.png)

# New

https://user-images.githubusercontent.com/39243082/109682718-a3128c00-7bb9-11eb-8232-ca067086b5e5.mp4

Proposed Commit Message:

```
Tester Response: Replace checkbox with radio buttons

In the tester response phase, if the tester agrees with the
team's response, she needs to save the response without modifying
anything else, in order for the agreement to be recorded.

Let's provide a more intuitive method of "agreeing with the
team's response" by using radio buttons that allow the user
to explicitly choose between 'I Disagree' and 'I Agree'.

These radio buttons replace the checkbox control in the
tester response form.
```