### PR TITLE
IssueTable: Fix 'view in web-browser' functionality

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -78,7 +78,7 @@ import { PermissionService } from './core/services/permission.service';
     {
       provide: GithubService,
       useFactory: GithubServiceFactory,
-      deps: [Apollo, ErrorHandlingService, ElectronService]
+      deps: [ErrorHandlingService, Apollo, ElectronService]
     },
     {
       provide: AuthService,

--- a/src/app/core/services/factories/factory.github.service.ts
+++ b/src/app/core/services/factories/factory.github.service.ts
@@ -5,7 +5,7 @@ import { ErrorHandlingService } from '../error-handling.service';
 import { GithubService } from '../github.service';
 import { MockGithubService } from '../mocks/mock.github.service';
 
-export function GithubServiceFactory(apollo: Apollo, electron: ElectronService, handling: ErrorHandlingService) {
+export function GithubServiceFactory(handling: ErrorHandlingService, apollo: Apollo, electron: ElectronService) {
   if (AppConfig.test) {
       return new MockGithubService();
   }


### PR DESCRIPTION
Fixes #619 

## Summary
The order of Dependencies stated in `app.module.ts` for the `GithubServiceFactory` was wrong. This resulted in services injected in the wrong order into `GithubService`. In this case `ErrorHandlingService` was injected as `ElectronService`, and that is why when the `View In Web` button was clicked, `console` threw the error that the `electronService.openLink(..)` was not a function.

### To Note
It seems that when Mocking Services using Factory, the array of `dependencies` in the `app.module.ts` must be the same order of the input parameters of the  `Factory` function.

Proposed Commit Message:
```
Fixed View-In-Web Button on IssueTable Component

It seems the order of dependencies listed in the app.module.ts
is crucial in ensuring that the right dependencies are injected
into the Factories. Re-ordering the list of dependencies to match
the parameters of the factory fixed the ElectronService import into
the Factory and thus fixed its injection into GithubService.
```