### PR TITLE
CI E2E Tests: Fetch correct ChromeDriver version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
+    - run: sudo apt-get update
     - run: sudo apt-get install google-chrome-stable
+    - run: sudo apt-get install firefox
     - run: npm run webdriver-manager update
     - run: npm run actions:e2e
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,10 +25,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
-    - run: sudo apt-get update
-    - run: sudo apt-get install google-chrome-stable
-    - run: sudo apt-get install firefox
-    - run: npm run webdriver-manager update
+    - run: npm run webdriver-manager update -- --gecko false --standalone false --versions.chrome $(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | grep -iE " [0-9]{1,3}))
+    - run: npm run webdriver-manager update -- --chrome false --standalone false
     - run: npm run actions:e2e
 
   macos-setup-and-tests:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,6 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
+    - run: apt-get install google-chrome-stable
     - run: npm run webdriver-manager update
     - run: npm run actions:e2e
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
-    - run: npm run webdriver-manager update -- --gecko false --standalone false --versions.chrome $(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | grep -iEo " [0-9]{1,3} | head -n1))
+    - run: npm run webdriver-manager update -- --gecko false --standalone false --versions.chrome $(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | grep -iEo "[0-9]{1,3}" | head -n1))
     - run: npm run webdriver-manager update -- --chrome false --standalone false
     - run: npm run actions:e2e
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
-    - run: npm run webdriver-manager update -- --gecko false --standalone false --versions.chrome $(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | grep -iE " [0-9]{1,3}))
+    - run: npm run webdriver-manager update -- --gecko false --standalone false --versions.chrome $(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | grep -iEo " [0-9]{1,3} | head -n1))
     - run: npm run webdriver-manager update -- --chrome false --standalone false
     - run: npm run actions:e2e
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,7 +25,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
-    - run: apt-get install google-chrome-stable
+    - run: sudo apt-get install google-chrome-stable
     - run: npm run webdriver-manager update
     - run: npm run actions:e2e
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "electron:mac": "npm run build:prod && electron-builder build --mac",
     "test": "npm run codegen:gql && ng test",
     "e2e": "npm run codegen:gql && npm run postinstall:web && ng e2e",
-    "actions:e2e": "npm run codegen:gql && npm run postinstall:web && ng e2e --protractor-config=e2e/protractor.gh-actions.conf",
+    "actions:e2e": "npm run codegen:gql && npm run postinstall:web && ng e2e --protractor-config=e2e/protractor.gh-actions.conf --webdriver-update=false",
     "webdriver-manager": "webdriver-manager",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",


### PR DESCRIPTION
Proposed Commit Message:
```
CI E2E Tests: Fetch correct ChromeDriver version

Our E2E test setup in CI can sometimes
download a version of ChromeDriver that
is ahead of the Chrome browser on the
CI machine.

Let's get webdriver-manager to
download a ChromeDriver version
that matches the machine's Chrome installation,
when running E2E tests in CI.
```