### PR TITLE
OAuth: Add state parameter to authentication process

### DIFF
--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -10,8 +10,6 @@ const BASE_URL = 'https://github.com';
 const ACCESS_TOKEN_URL = 'https://catcher-proxy.herokuapp.com/authenticate';
 const CALLBACK_URL = 'http://localhost:4200';
 
-const stateErrorMessage = 'Incorrect state: Try again.\n';
-
 let authWindow;
 
 /**
@@ -91,7 +89,6 @@ function getAuthorizationCode(parentWindow: BrowserWindow, repoPermissionLevel: 
       if (error !== undefined) {
         reject(error);
       } else if (!isReturnedStateSame(state, returnedState)) {
-        reject(new Error(stateErrorMessage));
       } else if (code) {
         resolve(code);
       }

--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -88,8 +88,7 @@ function getAuthorizationCode(parentWindow: BrowserWindow, repoPermissionLevel: 
 
       if (error !== undefined) {
         reject(error);
-      } else if (!isReturnedStateSame(state, returnedState)) {
-      } else if (code) {
+      } else if (isReturnedStateSame(state, returnedState) && code) {
         resolve(code);
       }
       setImmediate(function () {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -105,10 +105,6 @@ export class AuthComponent implements OnInit, OnDestroy {
     }
 
     if (!this.authService.isReturnedStateSame(state)) {
-      this.authService.changeAuthState(AuthState.NotAuthenticated);
-      if (!(event.source instanceof MessagePort) && !(event.source instanceof ServiceWorker)) {
-        event.source.postMessage('close', AppConfig.origin);
-      }
       return;
     }
 

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -106,7 +106,6 @@ export class AuthComponent implements OnInit, OnDestroy {
 
     if (!this.authService.isReturnedStateSame(state)) {
       this.authService.changeAuthState(AuthState.NotAuthenticated);
-      this.errorHandlingService.handleError(this.errorHandlingService.stateErrorMessage);
       if (!(event.source instanceof MessagePort) && !(event.source instanceof ServiceWorker)) {
         event.source.postMessage('close', AppConfig.origin);
       }

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -104,7 +104,7 @@ export class AuthComponent implements OnInit, OnDestroy {
         return;
     }
 
-    if (state !== this.authService.state) {
+    if (!this.authService.isReturnedStateSame(state)) {
       this.authService.changeAuthState(AuthState.NotAuthenticated);
       this.errorHandlingService.handleError(this.errorHandlingService.stateErrorMessage);
       if (!(event.source instanceof MessagePort) && !(event.source instanceof ServiceWorker)) {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -70,6 +70,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.isReady = false;
     const oauthCode = this.activatedRoute.snapshot.queryParamMap.get('code');
+    const state = this.activatedRoute.snapshot.queryParamMap.get('state');
 
     if (this.authService.isAuthenticated()) {
       this.router.navigate([this.phaseService.currentPhase]);
@@ -77,7 +78,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     }
 
     if (oauthCode) { // In the web's oauth window
-      window.opener.postMessage({ oauthCode }, AppConfig.origin);
+      window.opener.postMessage({ oauthCode, state }, AppConfig.origin);
       this.listenForCloseOAuthWindowMessage();
     } else { // In the main app window
       this.checkAppIsOutdated();
@@ -96,11 +97,22 @@ export class AuthComponent implements OnInit, OnDestroy {
     if (event.origin !== AppConfig.origin) {
       return;
     }
-    const { oauthCode } = event.data;
+
+    const { oauthCode, state } = event.data;
 
     if (!oauthCode) {
+        return;
+    }
+
+    if (state !== this.authService.state) {
+      this.authService.changeAuthState(AuthState.NotAuthenticated);
+      this.errorHandlingService.handleError(this.errorHandlingService.stateErrorMessage);
+      if (!(event.source instanceof MessagePort) && !(event.source instanceof ServiceWorker)) {
+        event.source.postMessage('close', AppConfig.origin);
+      }
       return;
     }
+
     const accessTokenUrl = `${AppConfig.accessTokenUrl}/${oauthCode}/client_id/${AppConfig.clientId}`;
     fetch(accessTokenUrl).then(res => res.json())
       .then(data => {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -16,6 +16,7 @@ import { GithubEventService } from './githubevent.service';
 import { generateSessionId } from '../../shared/lib/session';
 import { AppConfig } from '../../../environments/environment';
 import { LoggingService } from './logging.service';
+import { uuid } from '../../shared/lib/uuid';
 
 export enum AuthState { 'NotAuthenticated', 'AwaitingAuthentication', 'ConfirmOAuthUser', 'Authenticated'}
 
@@ -26,6 +27,7 @@ export class AuthService {
   authStateSource = new BehaviorSubject(AuthState.NotAuthenticated);
   currentAuthState = this.authStateSource.asObservable();
   accessToken = new BehaviorSubject(undefined);
+  state: string;
 
   constructor(private electronService: ElectronService, private router: Router, private ngZone: NgZone,
               private http: HttpClient,  private errorHandlingService: ErrorHandlingService,
@@ -90,6 +92,14 @@ export class AuthService {
     this.authStateSource.next(newAuthState);
   }
 
+
+  /**
+   * Generates and assigns an unguessable random 'state' string to pass to Github for protection against cross-site request forgery attacks
+   */
+  generateStateString() {
+    this.state = uuid();
+  }
+
   /**
    * Will start the Github OAuth web flow process.
    */
@@ -97,11 +107,13 @@ export class AuthService {
     const githubRepoPermission = this.phaseService.githubRepoPermissionLevel();
     this.changeAuthState(AuthState.AwaitingAuthentication);
 
+    this.generateStateString();
+
     if (this.electronService.isElectron()) {
       this.electronService.sendIpcMessage('github-oauth', githubRepoPermission);
     } else {
       this.createOauthWindow(encodeURI(
-        `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user`
+        `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
       ));
     }
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -111,11 +111,10 @@ export class AuthService {
     const githubRepoPermission = this.phaseService.githubRepoPermissionLevel();
     this.changeAuthState(AuthState.AwaitingAuthentication);
 
-    this.generateStateString();
-
     if (this.electronService.isElectron()) {
       this.electronService.sendIpcMessage('github-oauth', githubRepoPermission);
     } else {
+      this.generateStateString();
       this.createOauthWindow(encodeURI(
         `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
       ));

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
   authStateSource = new BehaviorSubject(AuthState.NotAuthenticated);
   currentAuthState = this.authStateSource.asObservable();
   accessToken = new BehaviorSubject(undefined);
-  state: string;
+  private state: string;
 
   constructor(private electronService: ElectronService, private router: Router, private ngZone: NgZone,
               private http: HttpClient,  private errorHandlingService: ErrorHandlingService,
@@ -98,6 +98,10 @@ export class AuthService {
    */
   generateStateString() {
     this.state = uuid();
+  }
+
+  isReturnedStateSame(returnedState: string): boolean {
+    return returnedState === this.state;
   }
 
   /**

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -12,9 +12,6 @@ export const ERRORCODE_NOT_FOUND = 404;
   providedIn: 'root',
 })
 export class ErrorHandlingService {
-  stateErrorMessage: string = 'Incorrect state: Try again.\n' +
-  'To change account, please sign into the desired account from the official Github website:\n' +
-  'www.github.com';
 
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -12,6 +12,9 @@ export const ERRORCODE_NOT_FOUND = 404;
   providedIn: 'root',
 })
 export class ErrorHandlingService {
+  stateErrorMessage: string = 'Incorrect state: Try again.\n' +
+  'To change account, please sign into the desired account from the official Github website:\n' +
+  'www.github.com';
 
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 


### PR DESCRIPTION
### Changes made:
- State parameter has been added to our authentication process for both web and desktop application versions

### Comments:
In the case where a particular user's account is constantly under attack (although I am not sure how likely this is), users might want to switch to another Github account to make their bug reports (again, because students use 1 registered account under CS2103 group to make bug reports, most students will likely not have a backup account at hand), when they are using the web version, they are able to just sign into another account via the Github website. 


However for the desktop version, the authentication session will start for the account that the user previously used for CATcher on pressing the "submit" button. 
![image](https://user-images.githubusercontent.com/66008784/110226654-14d93580-7f2c-11eb-9a88-ec225c7339d3.png)
Once such an attack is detected for that account, the authentication session will terminate and users will be brought back to the "submit" page, without getting to the "continue as user/login to another account" page. 
![image](https://user-images.githubusercontent.com/66008784/110226659-2a4e5f80-7f2c-11eb-930a-644ca783ff96.png)
(this page only appears after the account has passed the state parameter check)

This means that if their account is constantly getting attacked, they are unable to access CATcher using another account. 

We might need to make a couple of changes to fix this problem, for example, moving the "sign into another account" button to the "submit" page instead. 




Proposed commit message:
```
OAuth: Adding state parameter to authentication process

CATcher authentication process does not include the state 
parameter which helps to protect users against cross-site 
request forgery attacks.

Adding state parameter will improve security. 

Let's
* add state parameter to authentication process
* terminate current authentication session if returned state 
  parameter does not match state parameter of current session
```