### PR TITLE
Usage Notes: Document format of profiles.json

### DIFF
--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -44,7 +44,7 @@ The json supplied should only consist of **one key-pair value**, where the key i
 
 `profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
 
-> **Note**: You **must** have both of these fields in each `Profile` and no extra unnecessary fields! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
+> **Note**: You **must** have both of these fields in each `Profile` and the values for these fields **should not be empty**! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
 
 # Notes on Using the Desktop App
 ## For Windows Users

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,9 +1,9 @@
 - [Get Started](#get-started)
-  - [Format of `profiles.json`](#format-of-profilesjson)
 - [Notes on Using the Desktop App](#notes-on-using-the-desktop-app)
   - [For Windows Users](#for-windows-users)
   - [For Mac Users](#for-mac-users)
   - [For Linux Users](#for-linux-users)
+- [Customising the available sessions](#customising-the-available-sessions)
 - [Reporting Problems in using CATcher](#reporting-problems-in-using-catcher)
 
 
@@ -22,29 +22,6 @@ Start the desktop app by clicking on the executable file; no installation is req
 Once the app is launched (either web or desktop version), it will prompt you to enter the session you are participating in, using a dropdown.
 
 ![session_select](https://imgur.com/nBOy7zH.png)
-
-## Format of `profiles.json` 
-
-If your sessions are not present in the default dropdown list on CATcher's startup page, you can load custom sessions by clicking on the **file icon** beside the session dropdown. 
-
-Following which, submit a json file with the name `profiles.json`, where the format is specified below.
-
-```json
-{
-    "profiles": [
-        {
-            "profileName": "CATcher", 
-            "encodedText": "CATcher-org/public_data"
-        }
-    ]
-}
-```
-
-The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
-
-`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
-
-> **Note**: You **must** have both of these fields in each `Profile` and the values for these fields **should not be empty**! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
 
 # Notes on Using the Desktop App
 ## For Windows Users
@@ -77,6 +54,30 @@ There are 2 methods to achieve this:
   - Enable the `Allow executing file as program` option. 
   - Note: the GUI menus may differ slightly on different Linux distributions.
 - From the command line: Use `chmod +x CATcher-x.y.z.AppImage`
+
+
+# Customising the available sessions 
+
+If your sessions are not present in the default dropdown list on CATcher's startup page, you can load custom sessions by clicking on the **file icon** beside the session dropdown. 
+
+Following which, submit a json file with the name `profiles.json`, where the format is specified below.
+
+```json
+{
+    "profiles": [
+        {
+            "profileName": "CATcher", 
+            "encodedText": "CATcher-org/public_data"
+        }
+    ]
+}
+```
+
+The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
+
+`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
+
+> **Note**: You **must** have both of these fields in each `Profile` and the values for these fields **should not be empty**! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
 
 # Reporting problems in using CATcher
 If you face any issue in using CATcher, you can create a new issue in CATcher's repository. If necessary, it would also be helpful if you can provide us with your logs. 

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -25,7 +25,7 @@ Once the app is launched (either web or desktop version), it will prompt you to 
 
 ## Format of `profiles.json` 
 
-You can choose to load other repositories supplied by clicking on the file icon. 
+You can choose to load other repositories supplied by clicking on the **file icon** beside the session dropdown. 
 
 Following which, submit a json file with the name `profiles.json`, where the format is specified below.
 
@@ -42,8 +42,9 @@ Following which, submit a json file with the name `profiles.json`, where the for
 
 The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
 
-> **Note**: `profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your CATcher session. 
+`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your CATcher session. 
 
+> **Note**: You **must** have both of these fields in each `Profile` and no extra unnecessary fields! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
 
 # Notes on Using the Desktop App
 ## For Windows Users

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -73,7 +73,7 @@ Following which, submit a json file with the name `profiles.json`, where the for
 }
 ```
 
-The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
+The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles`, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
 
 `profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
 

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,4 +1,5 @@
 - [Get Started](#get-started)
+  - [Format of `profiles.json`](#format-of-profiles.json)
 - [Notes on Using the Desktop App](#notes-on-using-the-desktop-app)
   - [For Windows Users](#for-windows-users)
   - [For Mac Users](#for-mac-users)
@@ -21,6 +22,28 @@ Start the desktop app by clicking on the executable file; no installation is req
 Once the app is launched (either web or desktop version), it will prompt you to enter the session you are participating in, using a dropdown.
 
 ![session_select](https://imgur.com/nBOy7zH.png)
+
+## Format of `profiles.json` 
+
+You can choose to load other repositories supplied by clicking on the file icon. 
+
+Following which, submit a json file with the name `profiles.json`, where the format is specified below.
+
+```json
+{
+    "profiles": [
+        {
+            "profileName": "CATcher", 
+            "encodedText": "CATcher-org/public_data"
+        }
+    ]
+}
+```
+
+The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
+
+> **Note**: `profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your CATcher session. 
+
 
 # Notes on Using the Desktop App
 ## For Windows Users

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,5 +1,5 @@
 - [Get Started](#get-started)
-  - [Format of `profiles.json`](#format-of-profiles.json)
+  - [Format of `profiles.json`](#format-of-profilesjson)
 - [Notes on Using the Desktop App](#notes-on-using-the-desktop-app)
   - [For Windows Users](#for-windows-users)
   - [For Mac Users](#for-mac-users)

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -25,7 +25,7 @@ Once the app is launched (either web or desktop version), it will prompt you to 
 
 ## Format of `profiles.json` 
 
-You can choose to load other repositories supplied by clicking on the **file icon** beside the session dropdown. 
+You can choose to load your custom sessions by clicking on the **file icon** beside the session dropdown. 
 
 Following which, submit a json file with the name `profiles.json`, where the format is specified below.
 
@@ -42,7 +42,7 @@ Following which, submit a json file with the name `profiles.json`, where the for
 
 The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles` supplied, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
 
-`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your CATcher session. 
+`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
 
 > **Note**: You **must** have both of these fields in each `Profile` and no extra unnecessary fields! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
 

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -25,7 +25,7 @@ Once the app is launched (either web or desktop version), it will prompt you to 
 
 ## Format of `profiles.json` 
 
-You can choose to load your custom sessions by clicking on the **file icon** beside the session dropdown. 
+If your sessions are not present in the default dropdown list on CATcher's startup page, you can load custom sessions by clicking on the **file icon** beside the session dropdown. 
 
 Following which, submit a json file with the name `profiles.json`, where the format is specified below.
 

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -60,7 +60,7 @@ There are 2 methods to achieve this:
 
 If your sessions are not present in the default dropdown list on CATcher's startup page, you can load custom sessions by clicking on the **file icon** beside the session dropdown. 
 
-Following which, submit a json file with the name `profiles.json`, where the format is specified below.
+Following which, submit a file with the `.json` file extension, where the format is specified below.
 
 ```json
 {
@@ -75,9 +75,9 @@ Following which, submit a json file with the name `profiles.json`, where the for
 
 The json supplied should only consist of **one key-pair value**, where the key is `"profiles"` and the value is an array of `Profiles`, where each `Profile` is an object containing the `profileName` and `encodedText` fields. 
 
-`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. 
+`profileName` refers to the profile name displayed in the session select page. `encodedText` refers to the repository which stores the required settings for your custom session. The `encodedText` will be in the format of `organisation/repository`.
 
-> **Note**: You **must** have both of these fields in each `Profile` and the values for these fields **should not be empty**! Else, the `profile.json` file that you have supplied will not be parsed successfully. 
+> **Note**: You **must** have both of these fields in each `Profile` and the values for these fields **should not be empty**! Else, the `.json` file that you have supplied will not be parsed successfully. F 
 
 # Reporting problems in using CATcher
 If you face any issue in using CATcher, you can create a new issue in CATcher's repository. If necessary, it would also be helpful if you can provide us with your logs. 


### PR DESCRIPTION
# Summary 

This PR fixes #584, which adds a section on the format of `profiles.json` to be supplied. 

## Description 

You can see the actual visual changes [here](https://github.com/seanlowjk/CATcher/blob/documentation/profiles-json-format/docs/usage-notes.md#format-of-profilesjson)

## Proposed Commit Message 

Dev Notes: Add section on E2E tests

```
We do not have the expected format of profiles.json 
documented. 

Let's document the expected format of
'profiles.json' under Usage Notes so that future users
will be able to supply a correct file format to load
custom sessions. 
```