### PR TITLE
GH Actions: Add retry for tests on Mac OS

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -47,7 +47,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
     - run: npm test -- "--karma-config=./tests/karma.ci.conf.js" || npm test -- "--karma-config=./tests/karma.ci.conf.js"
-
+    # retry tests once, in case they timed out on Mac OS
   windows-setup-and-tests:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: npm run lint
-    - run: npm test -- "--karma-config=./tests/karma.ci.conf.js"
+    - run: npm test -- "--karma-config=./tests/karma.ci.conf.js" || npm test -- "--karma-config=./tests/karma.ci.conf.js"
 
   windows-setup-and-tests:
     runs-on: windows-latest

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -31,11 +31,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     browsers: ['HeadlessChrome'],
-    customLaunchers:{
-        HeadlessChrome:{
-            base: 'ChromeHeadless',
-            flags: ['--no-sandbox']
-        }
+    customLaunchers: {
+      HeadlessChrome: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
     },
     singleRun: true
   });

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -30,13 +30,7 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['HeadlessChrome'],
-    customLaunchers: {
-      HeadlessChrome: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox']
-      }
-    },
+    browsers: ['ChromeHeadless'],
     singleRun: true
   });
 };

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -30,7 +30,13 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['ChromeHeadless'],
+    browsers: ['HeadlessChrome'],
+    customLaunchers:{
+        HeadlessChrome:{
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox']
+        }
+    },
     singleRun: true
   });
 };


### PR DESCRIPTION
# Summary 

This PR fixed the #585, the issue of Karma Tests timing out in our CI / CD pipeline. 

## Details 

By adding the `||` operator, we essentially allow our pipeline to rerun the MacOSX Tests again if it failed the first time due to timeout.

## Suggested Commit Message 
```
GH Actions: Add retry for tests on Mac OS

Our Karma tests on MacOSX timeout once in a while and fail as a result.

Let's allow our pipeline to rerun our MacOSX test again in the event 
that our Karma tests on MacOSX timeout on the first try.
```
