### PR TITLE
RepoCreatorService: Create custom operators for attempting repo creation

### DIFF
--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -163,7 +163,8 @@ export class PhaseService {
         }
       }),
       cacheSessionFixPermission(),
-      this.repoCreatorService.attemptRepoCreation(this.currentPhase, this.sessionData[this.currentPhase]),
+      this.repoCreatorService.verifyPhaseDetails(this.currentPhase), 
+      this.repoCreatorService.attemptRepoCreation(this.sessionData[this.currentPhase]),
       this.repoCreatorService.verifyRepoCreation(this.getPhaseOwner(this.currentPhase), this.sessionData[this.currentPhase]),
       throwIfFalse(
         (isSessionCreated: boolean) => isSessionCreated,

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -163,7 +163,7 @@ export class PhaseService {
         }
       }),
       cacheSessionFixPermission(),
-      this.repoCreatorService.verifyPhaseDetails(this.currentPhase), 
+      this.repoCreatorService.verifyRepoCreationPermissions(this.currentPhase),
       this.repoCreatorService.attemptRepoCreation(this.sessionData[this.currentPhase]),
       this.repoCreatorService.verifyRepoCreation(this.getPhaseOwner(this.currentPhase), this.sessionData[this.currentPhase]),
       throwIfFalse(

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -29,7 +29,7 @@ export class RepoCreatorService {
   public attemptRepoCreation(currentPhase: Phase, phaseRepo: string):
     UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
-      flatMap((sessionFixPermission: boolean | null) => {
+      flatMap((repoCreationPermission: boolean | null) => {
         if (sessionFixPermission === null) {
           // No Session Fix Necessary
           return of(null);
@@ -70,10 +70,10 @@ export class RepoCreatorService {
   * @return - Dummy Observable to give the API sometime to propagate the creation of the new repository since
   *           the API Call used here does not return any response.
   */
- private attemptSessionAvailabilityFix(currentPhase: Phase, phaseRepo: string): Observable<any> {
+ private triggerRepoCreation(currentPhase: Phase, phaseRepo: string): Observable<any> {
    if (currentPhase !== Phase.phaseBugReporting) {
      throw new Error(CURRENT_PHASE_REPO_CLOSED);
-   } else if (currentPhase === Phase.phaseBugReporting && this.userService.currentUser.role !== UserRole.Student) {
+   } else if (this.userService.currentUser.role !== UserRole.Student) {
      throw new Error(BUG_REPORTING_INVALID_ROLE);
    }
    this.githubService.createRepository(phaseRepo);

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -22,7 +22,7 @@ export class RepoCreatorService {
   ) {}
 
   /**
-   * Attempted to create the repository if permissions have been given to do so.
+   * Attempts to create the repository if permissions have been given to do so.
    * @param currentPhase the current phase of the session.
    * @param phaseRepo the name of the specified repository.
    */

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -6,6 +6,12 @@ import { UserService } from './user.service';
 import { Phase } from '../models/phase.model';
 import { UserRole } from '../models/user.model';
 
+export const MISSING_REQUIRED_REPO = 'You cannot proceed without the required repository.';
+export const CURRENT_PHASE_REPO_CLOSED = 'Current Phase\'s Repository has not been opened.';
+export const BUG_REPORTING_INVALID_ROLE =
+  "'Bug-Reporting Phase\'s repository initialisation is only available to Students.'";
+
+
 @Injectable({
   providedIn: 'root',
 })
@@ -30,7 +36,7 @@ export class RepoCreatorService {
         } else if (sessionFixPermission) {
           return this.attemptSessionAvailabilityFix(currentPhase, phaseRepo);
         } else {
-          throw new Error('You cannot proceed without the required repository.');
+          throw new Error(MISSING_REQUIRED_REPO);
         }
       })
     );
@@ -66,9 +72,9 @@ export class RepoCreatorService {
   */
  private attemptSessionAvailabilityFix(currentPhase: Phase, phaseRepo: string): Observable<any> {
    if (currentPhase !== Phase.phaseBugReporting) {
-     throw new Error('Current Phase\'s Repository has not been opened.');
+     throw new Error(CURRENT_PHASE_REPO_CLOSED);
    } else if (currentPhase === Phase.phaseBugReporting && this.userService.currentUser.role !== UserRole.Student) {
-     throw new Error('Bug-Reporting Phase\'s repository initialisation is only available to Students.');
+     throw new Error(BUG_REPORTING_INVALID_ROLE);
    }
    this.githubService.createRepository(phaseRepo);
 

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -2,21 +2,47 @@ import { Injectable } from '@angular/core';
 import { flatMap } from 'rxjs/operators';
 import { Observable, of, pipe, UnaryFunction } from 'rxjs';
 import { GithubService } from './github.service';
+import { UserService } from './user.service';
+import { Phase } from '../models/phase.model';
+import { UserRole } from '../models/user.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RepoCreatorService {
   constructor(
-    private githubService: GithubService
+    private githubService: GithubService,
+    private userService: UserService
   ) {}
+
+  /**
+   * Attempted to create the repository if permissions have been given to do so.
+   * @param currentPhase the current phase of the session.
+   * @param phaseRepo the name of the specified repository.
+   */
+  public attemptRepoCreation(currentPhase: Phase, phaseRepo: string):
+    UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
+    return pipe(
+      flatMap((sessionFixPermission: boolean | null) => {
+        if (sessionFixPermission === null) {
+          // No Session Fix Necessary
+          return of(null);
+        } else if (sessionFixPermission) {
+          return this.attemptSessionAvailabilityFix(currentPhase, phaseRepo);
+        } else {
+          throw new Error('You cannot proceed without the required repository.');
+        }
+      })
+    );
+  }
 
   /**
    * Checks if the specified repository has been created.
    * @param phaseOwner the user or organization holding the specified repository.
    * @param phaseRepo the name of the specified repository.
    */
-  public verifyRepoCreation(phaseOwner: string, phaseRepo: string): UnaryFunction<Observable<boolean | null>, Observable<boolean>> {
+  public verifyRepoCreation(phaseOwner: string, phaseRepo: string):
+    UnaryFunction<Observable<boolean | null>, Observable<boolean>> {
     return pipe(
       flatMap((isFixAttempted: boolean | null) => {
         if (!isFixAttempted) {
@@ -29,4 +55,25 @@ export class RepoCreatorService {
       })
     );
   }
+
+ /**
+  * If a Session is unavailable (because the repository is missing) attempt to create IF it is
+  * the BugReporting Phase
+  * @param currentPhase the current phase of the session.
+  * @param phaseRepo the name of the specified repository.
+  * @return - Dummy Observable to give the API sometime to propagate the creation of the new repository since
+  *           the API Call used here does not return any response.
+  */
+ private attemptSessionAvailabilityFix(currentPhase: Phase, phaseRepo: string): Observable<any> {
+   if (currentPhase !== Phase.phaseBugReporting) {
+     throw new Error('Current Phase\'s Repository has not been opened.');
+   } else if (currentPhase === Phase.phaseBugReporting && this.userService.currentUser.role !== UserRole.Student) {
+     throw new Error('Bug-Reporting Phase\'s repository initialisation is only available to Students.');
+   }
+   this.githubService.createRepository(phaseRepo);
+
+   return new Observable(subscriber => {
+     setTimeout(() => subscriber.next(true), 1000);
+   });
+ }
 }

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -30,11 +30,11 @@ export class RepoCreatorService {
     UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
       flatMap((repoCreationPermission: boolean | null) => {
-        if (sessionFixPermission === null) {
+        if (repoCreationPermission === null) {
           // No Session Fix Necessary
           return of(null);
-        } else if (sessionFixPermission) {
-          return this.attemptSessionAvailabilityFix(currentPhase, phaseRepo);
+        } else if (repoCreationPermission) {
+          return this.triggerRepoCreation(currentPhase, phaseRepo);
         } else {
           throw new Error(MISSING_REQUIRED_REPO);
         }

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { flatMap } from 'rxjs/operators';
+import { flatMap, tap } from 'rxjs/operators';
 import { Observable, of, pipe, UnaryFunction } from 'rxjs';
 import { GithubService } from './github.service';
 import { UserService } from './user.service';
@@ -29,17 +29,13 @@ export class RepoCreatorService {
   public verifyRepoCreationPermissions(currentPhase: Phase):
     UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
-      flatMap((repoCreationPermission: boolean | null) => {
-        if (repoCreationPermission === null) {
-          return of(null);
-        } else if (!repoCreationPermission) {
+      tap((repoCreationPermission: boolean | null) => {
+        if (repoCreationPermission === false) {
           throw new Error(MISSING_REQUIRED_REPO);
         } else if (currentPhase !== Phase.phaseBugReporting) {
           throw new Error(CURRENT_PHASE_REPO_CLOSED);
         } else if (this.userService.currentUser.role !== UserRole.Student) {
           throw new Error(BUG_REPORTING_INVALID_ROLE);
-        } else {
-          return of(repoCreationPermission);
         }
       })
     );

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -38,7 +38,7 @@ describe('RepoCreatorService', () => {
   });
 
   describe('.attemptRepoCreation()', () => {
-    it('should not need to create the repository if no permissions were needed', () => {
+    it('should not create the repository if repo creation is not needed', () => {
       of(null).pipe(repoCreatorService.attemptRepoCreation(Phase.phaseBugReporting, PHASE_REPO)).subscribe();
 
       expect(githubService.createRepository).not.toHaveBeenCalled();

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -38,14 +38,14 @@ describe('RepoCreatorService', () => {
   });
 
   describe('verifyRepoCreationPermissions()', () => {
-    it('should return the original permissions if a session fix was not needed', () => {
+    it('should return the original permissions if repo creation was not needed', () => {
       userService.currentUser = USER_JUNWEI;
       of(null)
         .pipe(repoCreatorService.verifyRepoCreationPermissions(Phase.phaseBugReporting))
         .subscribe((repoCreationPermission: boolean | null) => expect(repoCreationPermission).toBe(null));
     });
 
-    it('should return the original permissions if permissions', () => {
+    it('should return the original permissions if permissions were given', () => {
       userService.currentUser = USER_JUNWEI;
       of(true)
         .pipe(repoCreatorService.verifyRepoCreationPermissions(Phase.phaseBugReporting))

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -64,7 +64,6 @@ describe('RepoCreatorService', () => {
     });
 
     it('should throw an error if permissions, but wrong phase were given', () => {
-      userService.currentUser = USER_JUNWEI;
       of(true)
         .pipe(repoCreatorService.attemptRepoCreation(Phase.phaseModeration, PHASE_REPO))
         .subscribe({

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -1,15 +1,18 @@
 import { RepoCreatorService } from '../../src/app/core/services/repo-creator.service';
 import { of } from 'rxjs';
+import { UserService } from '../../src/app/core/services/user.service';
 
 const PHASE_OWNER = 'CATcher-org';
 const PHASE_REPO = 'bugreporting';
 let repoCreatorService: RepoCreatorService;
 let githubService: any;
+let userService: UserService;
 
 describe('RepoCreatorService', () => {
   beforeEach(() => {
+    userService = new UserService(null, null);
     githubService = jasmine.createSpyObj('GithubService', ['isRepositoryPresent']);
-    repoCreatorService = new RepoCreatorService(githubService);
+    repoCreatorService = new RepoCreatorService(githubService, userService);
   });
 
   describe('.verifyRepoCreation()', () => {

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -1,6 +1,8 @@
-import { RepoCreatorService } from '../../src/app/core/services/repo-creator.service';
+import { MISSING_REQUIRED_REPO, RepoCreatorService } from '../../src/app/core/services/repo-creator.service';
 import { of } from 'rxjs';
 import { UserService } from '../../src/app/core/services/user.service';
+import { Phase } from '../../src/app/core/models/phase.model';
+import { USER_JUNWEI } from '../constants/data.constants';
 
 const PHASE_OWNER = 'CATcher-org';
 const PHASE_REPO = 'bugreporting';
@@ -11,7 +13,7 @@ let userService: UserService;
 describe('RepoCreatorService', () => {
   beforeEach(() => {
     userService = new UserService(null, null);
-    githubService = jasmine.createSpyObj('GithubService', ['isRepositoryPresent']);
+    githubService = jasmine.createSpyObj('GithubService', ['isRepositoryPresent', 'createRepository']);
     repoCreatorService = new RepoCreatorService(githubService, userService);
   });
 
@@ -27,6 +29,33 @@ describe('RepoCreatorService', () => {
       of(true).pipe(repoCreatorService.verifyRepoCreation(PHASE_OWNER, PHASE_REPO)).subscribe();
 
       expect(githubService.isRepositoryPresent).toHaveBeenCalledWith(PHASE_OWNER, PHASE_REPO);
+    });
+  });
+
+  describe('.attemptRepoCreation()', () => {
+    it('should not need to create the repository if no permissions were needed', () => {
+      of(null).pipe(repoCreatorService.attemptRepoCreation(Phase.phaseBugReporting, PHASE_REPO)).subscribe();
+
+      expect(githubService.createRepository).not.toHaveBeenCalled();
+    });
+
+    it('should create the repository if permissions were given', () => {
+      userService.currentUser = USER_JUNWEI;
+      githubService.createRepository.and.callFake(() => of(true));
+      of(true).pipe(repoCreatorService.attemptRepoCreation(Phase.phaseBugReporting, PHASE_REPO)).subscribe();
+
+      expect(githubService.createRepository).toHaveBeenCalledWith(PHASE_REPO);
+    });
+
+    it('should throw an error if no permissions were given', () => {
+      of(false)
+        .pipe(repoCreatorService.attemptRepoCreation(Phase.phaseBugReporting, PHASE_REPO))
+        .subscribe({
+          next: () => fail(),
+          error: (err) => expect(err).toEqual(new Error(MISSING_REQUIRED_REPO))
+        });
+
+      expect(githubService.createRepository).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Summary 

This PR addresses part of #549 , which abstracts the **attempt  of the repo creation** step of `sessionSetup()` in `PhaseService` to two readable, custom operators in `RepoCreatorService` 

## Description 

This PR does the following: 

1. `verifyRepoCreationPermissions()` takes in an argument, `currentPhase` and checks for the following: 
  a. if `repoCreationPermission` is `null`, it suggests that no session fix is needed. 
  b. if `repoCreationPermission` is `false`, it suggests that no permissions have been given to create the required repo. And thus, should throw an error. 
  c. If `currentPhase` is not the **bug reporting phase**, throw an error. 
  d. If the `User` is **not a student**, throw an error 
  e. Else, the permissions and phase details are fine and we can proceed with repo creation. 
  
2. `attemptRepoCreation` takes in an argument `phaseRepo` and has the following logic: 
  a. If   `repoCreationPermission` is `null`, it suggested that no session fix is needed. 
  b. Else, `repoCreationPermission` can only be `true` and as a result, we attempt the repo creation and return a dummy Observable to give the API some time to create the necessary repo.
    
## Suggested Commit Message 
```
RepoCreatorService: Create custom operators for attempting repo creation

To improve readability of the session setup code,
let's shift the phase details verification and repo creation attempt code 
into two, separate custom operators in  RepoCreatorService

Let's also add tests for these custom operators.
```