### PR TITLE
AuthService: Throw error message if pop-up windows are blocked

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -209,13 +209,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   }
 
   logIntoAnotherAccount() {
-    this.electronService.clearCookies();
-    try {
-      this.authService.startOAuthProcess();
-    } catch (error) {
-      this.errorHandlingService.handleError(error);
-      this.authService.changeAuthState(AuthState.NotAuthenticated);
-    }
+    this.authService.startOAuthProcess();
   }
 
   onGithubWebsiteClicked() {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -196,7 +196,12 @@ export class AuthComponent implements OnInit, OnDestroy {
       throwIfFalse(isValidSession => isValidSession,
                    () => new Error('Invalid Session'))
     ).subscribe(() => {
-      this.authService.startOAuthProcess();
+      try {
+        this.authService.startOAuthProcess();
+      } catch (error) {
+        this.errorHandlingService.handleError(error);
+        this.authService.changeAuthState(AuthState.NotAuthenticated);
+      }
     }, (error) => {
       this.errorHandlingService.handleError(error);
       this.isSettingUpSession = false;
@@ -205,7 +210,12 @@ export class AuthComponent implements OnInit, OnDestroy {
 
   logIntoAnotherAccount() {
     this.electronService.clearCookies();
-    this.authService.startOAuthProcess();
+    try {
+      this.authService.startOAuthProcess();
+    } catch (error) {
+      this.errorHandlingService.handleError(error);
+      this.authService.changeAuthState(AuthState.NotAuthenticated);
+    }
   }
 
   onGithubWebsiteClicked() {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -209,6 +209,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   }
 
   logIntoAnotherAccount() {
+    this.electronService.clearCookies();
     this.authService.startOAuthProcess();
   }
 

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -6,7 +6,7 @@ import { NgZone } from '@angular/core';
 import { ElectronService } from './electron.service';
 import { UserService } from './user.service';
 import { PhaseService } from './phase.service';
-import { ErrorHandlingService } from './error-handling.service';
+import { ENABLE_POPUP_MESSAGE, ErrorHandlingService } from './error-handling.service';
 import { GithubService } from './github.service';
 import { IssueService } from './issue.service';
 import { DataService } from './data.service';
@@ -154,6 +154,11 @@ export class AuthService {
     const options = `width=${width},height=${height},left=${left},top=${top}`;
     const oauthWindow = window.open(`${url}`, 'Authorization', options);
     const authService = this;
+
+    if (oauthWindow == null) {
+      throw ENABLE_POPUP_MESSAGE;
+    }
+
     oauthWindow.addEventListener('unload', () => {
       if (!oauthWindow.closed) {
         // unload event could be triggered when there is a redirection, hence, a confirmation needed.

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -6,7 +6,7 @@ import { NgZone } from '@angular/core';
 import { ElectronService } from './electron.service';
 import { UserService } from './user.service';
 import { PhaseService } from './phase.service';
-import { ENABLE_POPUP_MESSAGE, ErrorHandlingService } from './error-handling.service';
+import { ErrorHandlingService } from './error-handling.service';
 import { GithubService } from './github.service';
 import { IssueService } from './issue.service';
 import { DataService } from './data.service';
@@ -28,6 +28,8 @@ export class AuthService {
   currentAuthState = this.authStateSource.asObservable();
   accessToken = new BehaviorSubject(undefined);
   private state: string;
+
+  ENABLE_POPUP_MESSAGE = 'Please enable pop-ups in your browser';
 
   constructor(private electronService: ElectronService, private router: Router, private ngZone: NgZone,
               private http: HttpClient,  private errorHandlingService: ErrorHandlingService,
@@ -156,7 +158,7 @@ export class AuthService {
     const authService = this;
 
     if (oauthWindow == null) {
-      throw ENABLE_POPUP_MESSAGE;
+      throw this.ENABLE_POPUP_MESSAGE;
     }
 
     oauthWindow.addEventListener('unload', () => {

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -7,6 +7,7 @@ import { RequestError } from '@octokit/request-error';
 import { LoggingService } from './logging.service';
 
 export const ERRORCODE_NOT_FOUND = 404;
+export const ENABLE_POPUP_MESSAGE = 'Please enable pop-ups in your browser';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -7,7 +7,6 @@ import { RequestError } from '@octokit/request-error';
 import { LoggingService } from './logging.service';
 
 export const ERRORCODE_NOT_FOUND = 404;
-export const ENABLE_POPUP_MESSAGE = 'Please enable pop-ups in your browser';
 
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
Fixes #636

### Summary

Pop-up windows are blocked by default on Safari. This causes the authentication window to be blocked, causing users to be stuck on loading screen without any notification.

#### Changes Made
- Error message has been added to inform users to enable pop-up windows in their browser
- Users are brought back to the previous select session page instead of loading screen


Proposed commit message:
```
AuthService: Throw error message if pop-up windows are blocked

The authentication window is blocked by default in Safari, causing
users to be stuck on loading screen without any notification.

Showing error message to notify users to enable pop-ups and
then directing them back to the start of authentication will
make our application more user-friendly.

Let's
* Show error message when pop-ups are blocked
* Restart authentication process
```