### PR TITLE
Usage notes: Inform users to allow pop-ups from CATcher

### DIFF
--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -13,7 +13,7 @@ You can either use CATcher through your web browser, or download CATcher's deskt
 
 The CATcher web app is recommended, and can be
 accessed at
-https://catcher-org.github.io/CATcher
+https://catcher-org.github.io/CATcher. Please ensure your browser does not block pop-up windows from our web app.
 
 The latest release of the CATcher desktop app can be downloaded from https://github.com/CATcher-org/CATcher/releases
 


### PR DESCRIPTION
```
Some browsers may block pop-ups by default.
CATcher's authentication cannot proceed
if the GitHub login pop-up window is blocked.

Let's inform users that their browser should
allow pop-ups from CATcher.
```