### PR TITLE
Add Version Number to Header and Logs 

### DIFF
--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ElectronService } from './electron.service';
 import { ElectronLog } from 'electron-log';
+import { ApplicationService } from './application.service';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,8 @@ export class LoggingService {
   private isInSession = false;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
-  public readonly LOG_START_HEADER = '====== New CATcher Session Log ======';
+  public readonly LOG_START_HEADER = '====== New CATcher@' +
+    new ApplicationService(null).currentVersion + ' Session Log ======';
   public readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -2,7 +2,7 @@
   <button *ngIf="isBackButtonShown()" mat-icon-button class="mat-toolbar mat-primary" style="transform: scale(0.9)" (click)="goBack()">
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
-  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher</a>
+  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher v{{this.getVersionNumber()}}</a>
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
     ({{this.getPhaseDescription(phaseService.currentPhase)}})
   </span>

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -2,7 +2,7 @@
   <button *ngIf="isBackButtonShown()" mat-icon-button class="mat-toolbar mat-primary" style="transform: scale(0.9)" (click)="goBack()">
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
-  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher v{{this.getVersionNumber()}}</a>
+  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher@{{this.getVersionNumber()}}</a>
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
     ({{this.getPhaseDescription(phaseService.currentPhase)}})
   </span>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -13,6 +13,7 @@ import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
 import { LoggingService } from '../../core/services/logging.service';
+import { ApplicationService } from '../../core/services/application.service';
 
 @Component({
   selector: 'app-layout-header',
@@ -31,6 +32,7 @@ export class HeaderComponent implements OnInit {
               public phaseService: PhaseService,
               public userService: UserService,
               private loggingService: LoggingService,
+              private applicationService: ApplicationService,
               private location: Location,
               private githubEventService: GithubEventService,
               private issueService: IssueService,
@@ -83,6 +85,10 @@ export class HeaderComponent implements OnInit {
     return this.phaseService.currentPhase === Phase.phaseBugReporting ||
     this.userService.currentUser.role === UserRole.Student ||
     (this.issueService.getIssueTeamFilter() !== 'All Teams' || this.router.url.includes('/issues'));
+  }
+
+  getVersionNumber(): string {
+    return this.applicationService.currentVersion;
   }
 
   getPhaseDescription(openPhase: string): string {

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -31,11 +31,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     browsers: ['HeadlessChrome'],
-    customLaunchers:{
-        HeadlessChrome:{
-            base: 'ChromeHeadless',
-            flags: ['--no-sandbox']
-        }
+    customLaunchers: {
+      HeadlessChrome: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
     },
     singleRun: true
   });

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -30,7 +30,13 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    browsers: ['ChromeHeadless'],
+    browsers: ['HeadlessChrome'],
+    customLaunchers:{
+        HeadlessChrome:{
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox']
+        }
+    },
     singleRun: true
   });
 };


### PR DESCRIPTION
# Summary 

This PR fixes #650 

## Description 
Adds the version number from `ApplicationService` to `LoggingService` and `HeaderComponent`

## To Discuss 
1. Currently, the only way to access the `currentVersion` is via constructing a new `ApplicationService` and accessing the instance attribute, Should we make this attribute `static` instead?

## Suggested Commit Message 
```
Add Version Number to Header and Logs 

There is no way for users to check which version of CATcher they are using. 
Let's include the version number in the Header and Logs such that debugging becomes easier. 
``` 

### To Note: 

e2e tests are currently failing on my side, will fix them before asking for review >< 