### PR TITLE
Include app version number in header and logs

### DIFF
--- a/e2e/spec/login/login.e2e-spec.ts
+++ b/e2e/spec/login/login.e2e-spec.ts
@@ -9,7 +9,7 @@ describe("CATcher's Login Page", () => {
   });
 
   it('displays "CATcher" in header bar', async () => {
-    expect(await page.getTitle()).toEqual('CATcher');
+    expect(await page.getTitle()).toContain('CATcher');
   });
 
   it('allows users to authenticate themselves', async () => {

--- a/e2e/spec/login/login.e2e-spec.ts
+++ b/e2e/spec/login/login.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { AppConfig } from '../../../src/environments/environment';
 import { LoginPage } from '../../page-objects/login.po';
 
 describe("CATcher's Login Page", () => {
@@ -9,7 +10,7 @@ describe("CATcher's Login Page", () => {
   });
 
   it('displays "CATcher" in header bar', async () => {
-    expect(await page.getTitle()).toContain('CATcher');
+    expect(await page.getTitle()).toEqual(`CATcher v${AppConfig.version}`);
   });
 
   it('allows users to authenticate themselves', async () => {

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -19,7 +19,7 @@ export class ApplicationService {
   }
 
   static getCurrentVersion(): string {
-    return appSetting.version; 
+    return appSetting.version;
   }
 
   /**

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -5,6 +5,7 @@ import { GithubRelease } from '../models/github/github.release';
 import { map } from 'rxjs/operators';
 
 const appSetting = require('../../../../package.json');
+export const currentVersion = appSetting.currentVersion;
 
 @Injectable({
   providedIn: 'root'
@@ -16,10 +17,6 @@ export class ApplicationService {
 
   constructor(private githubService: GithubService) {
     this.currentVersion = appSetting.version;
-  }
-
-  static getCurrentVersion(): string {
-    return appSetting.version;
   }
 
   /**

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -3,11 +3,9 @@ import { Observable, of } from 'rxjs';
 import { GithubService } from './github.service';
 import { GithubRelease } from '../models/github/github.release';
 import { map } from 'rxjs/operators';
+import { AppConfig } from '../../../environments/environment';
 
-const appSetting = require('../../../../package.json');
-export const currentVersion = appSetting.currentVersion;
-
-export const appVersion = appSetting.version;
+export const appVersion = AppConfig.version;
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -18,6 +18,10 @@ export class ApplicationService {
     this.currentVersion = appSetting.version;
   }
 
+  static getCurrentVersion() {
+    return appSetting.version; 
+  }
+
   /**
    * Determines whether the application is outdated.
    */

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -18,7 +18,7 @@ export class ApplicationService {
     this.currentVersion = appSetting.version;
   }
 
-  static getCurrentVersion() {
+  static getCurrentVersion(): string {
     return appSetting.version; 
   }
 

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { ElectronService } from './electron.service';
 import { ElectronLog } from 'electron-log';
 
+const appSetting = require('../../../../package.json');
+
 @Injectable({
   providedIn: 'root'
 })
@@ -10,7 +12,7 @@ export class LoggingService {
   private isInSession = false;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
-  public readonly LOG_START_HEADER = '====== New CATcher Session Log ======';
+  public readonly LOG_START_HEADER = `====== New CATcher v${appSetting.version} Session Log ======`;
   public readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ElectronService } from './electron.service';
 import { ElectronLog } from 'electron-log';
-
-const appSetting = require('../../../../package.json');
+import { AppConfig } from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +11,7 @@ export class LoggingService {
   private isInSession = false;
   private readonly LOG_KEY = 'CATcher-Log';
   private readonly LOG_FILE_NAME = 'CATcher-log.txt';
-  public readonly LOG_START_HEADER = `====== New CATcher v${appSetting.version} Session Log ======`;
+  public readonly LOG_START_HEADER = `====== New CATcher v${AppConfig.version} Session Log ======`;
   public readonly LOG_COUNT_LIMIT = 4;
 
   constructor(electronService: ElectronService) {

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -3,7 +3,7 @@
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
   <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher 
-    v{{ApplicationService.getCurrentVersion()}}</a>
+    v{{this.getVersion()}}</a>
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
     ({{this.getPhaseDescription(phaseService.currentPhase)}})
   </span>

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -2,7 +2,8 @@
   <button *ngIf="isBackButtonShown()" mat-icon-button class="mat-toolbar mat-primary" style="transform: scale(0.9)" (click)="goBack()">
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
-  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher</a>
+  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher 
+    v{{ApplicationService.getCurrentVersion()}}</a>
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
     ({{this.getPhaseDescription(phaseService.currentPhase)}})
   </span>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -13,7 +13,7 @@ import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
 import { LoggingService } from '../../core/services/logging.service';
-import { appVersion } from '../../core/services/application.service';
+import { AppConfig } from '../../../environments/environment';
 
 @Component({
   selector: 'app-layout-header',
@@ -87,7 +87,7 @@ export class HeaderComponent implements OnInit {
   }
 
   getVersion(): string {
-    return appVersion;
+    return AppConfig.version;
   }
 
   getPhaseDescription(openPhase: string): string {

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -13,7 +13,7 @@ import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
 import { LoggingService } from '../../core/services/logging.service';
-import { currentVersion } from '../../core/services/application.service';
+import { appVersion } from '../../core/services/application.service';
 
 @Component({
   selector: 'app-layout-header',
@@ -87,7 +87,7 @@ export class HeaderComponent implements OnInit {
   }
 
   getVersion(): string {
-    return currentVersion;
+    return appVersion;
   }
 
   getPhaseDescription(openPhase: string): string {

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -13,7 +13,7 @@ import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
 import { LoggingService } from '../../core/services/logging.service';
-import { ApplicationService } from '../../core/services/application.service';
+import { currentVersion } from '../../core/services/application.service';
 
 @Component({
   selector: 'app-layout-header',
@@ -87,7 +87,7 @@ export class HeaderComponent implements OnInit {
   }
 
   getVersion(): string {
-    return ApplicationService.getCurrentVersion();
+    return currentVersion;
   }
 
   getPhaseDescription(openPhase: string): string {

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -13,6 +13,7 @@ import { GithubService } from '../../core/services/github.service';
 import { UserRole } from '../../core/models/user.model';
 import { ElectronService } from '../../core/services/electron.service';
 import { LoggingService } from '../../core/services/logging.service';
+import { ApplicationService } from '../../core/services/application.service';
 
 @Component({
   selector: 'app-layout-header',
@@ -83,6 +84,10 @@ export class HeaderComponent implements OnInit {
     return this.phaseService.currentPhase === Phase.phaseBugReporting ||
     this.userService.currentUser.role === UserRole.Student ||
     (this.issueService.getIssueTeamFilter() !== 'All Teams' || this.router.url.includes('/issues'));
+  }
+
+  getVersion(): string {
+    return ApplicationService.getCurrentVersion();
   }
 
   getPhaseDescription(openPhase: string): string {

--- a/src/environments/environment.gen.ts
+++ b/src/environments/environment.gen.ts
@@ -5,9 +5,12 @@ const BaseConfig = {
   accessTokenUrl: 'https://catcher-proxy.herokuapp.com/authenticate'
 };
 
+const appSetting = require('../../package.json');
+
 export function generateDefaultEnv() {
   return {
     ...BaseConfig,
+    version: appSetting.version,
     production: false,
     test: false,
     clientId: '0cbc5e651d8b01e36687',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,7 +3,7 @@ import { Profile } from '../app/core/models/profile.model';
 const appSetting = require('../../package.json');
 
 export const AppConfig = {
-  version: appSetting.version, 
+  version: appSetting.version,
   production: true,
   test: false,
   clientId: '5e1ed08cff7f0de1d68d',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,9 +3,9 @@ import { Profile } from '../app/core/models/profile.model';
 const appSetting = require('../../package.json');
 
 export const AppConfig = {
+  version: appSetting.version, 
   production: true,
   test: false,
-  version: appSetting.version, 
   clientId: '5e1ed08cff7f0de1d68d',
   githubUrl: 'https://github.com',
   accessTokenUrl: 'https://catcher-proxy.herokuapp.com/authenticate',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,8 +1,11 @@
 import { Profile } from '../app/core/models/profile.model';
 
+const appSetting = require('../../package.json');
+
 export const AppConfig = {
   production: true,
   test: false,
+  version: appSetting.version, 
   clientId: '5e1ed08cff7f0de1d68d',
   githubUrl: 'https://github.com',
   accessTokenUrl: 'https://catcher-proxy.herokuapp.com/authenticate',


### PR DESCRIPTION
# Summary 

This PR fixes #650 

## Description 
Adds the version number from `ApplicationService` to `LoggingService` and `HeaderComponent`.
Also migrates the handling of `version` number for `package.json` to `enviornment.gen.ts` and `environment.prod.ts` 

## Suggested Commit Message 
```
Include app version number in header and logs

The app version number is displayed in the page title.
To aid debugging, let's give the version number more
prominence by displaying it on the header
and recording it in the logs too.

Let's move the version number to the AppConfig,
so we have a slightly neater method of accessing the
version number in various services and components.
``` 