### PR TITLE
Dev Notes: Document release procedure

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -139,14 +139,21 @@ CATcher uses the OAuth 2.0 protocol to authenticate users. Below is a summary of
 
 The authentication process is kicked off in the `AuthComponent`, but the code that co-ordinates steps 1 and 2 can be found in [`oauth.ts`](../oauth.ts)(For Electron) or `AuthService`(For Web). Step 2 requires a client secret granted to CATcher. To protect this, we run a web service, [gatekeeper](https://github.com/CATcher-org/gatekeeper) that executes step 2 on behalf of the client CATcher app.
 
-# Handling Releases
+# Releasing a new version of CATcher
 
-Releases are primarily crafted using Github Actions that handles deployments and the building of executables for multiple operating systems. A release can be created with the following steps:
+Releasing a new version of CATcher involves the following steps:
+  - Update CATcher's version number in `package.json`
+  - Build the CATcher desktop application's executables for Linux, MacOS and Windows
+  - Build the CATcher web app, and then deploy it onto our GitHub Pages site (https://catcher-org.github.io/CATcher/)
+  - Create a release on GitHub, upload the desktop app's executables and write a changelog that describes any new features or bug fixes.
 
+We have a GitHub Actions' workflow that can perform many of the tasks above in a single-click.
+
+Follow these steps to create a release using this workflow:
   - Create and Merge a Pull Request that updates the version of the application in the `package.json` file.
-  - Navigate to the 'Actions' Tab of the `CATcher` repository and start the `Draft Deployment` Workflow. This deploys the application and creates a Draft Release containing the compiled executables.
+  - Navigate to the 'Actions' Tab of the `CATcher` repository and start the `Draft Deployment` Workflow. This workflow deploys the web app and creates a Draft Release containing the desktop app's executables
   - Edit the Draft Release and update the description with a changelog of recently merged Pull Requests.
-  - Save the Draft and create the Full Release.
+  - Publish the release.
 
 # Future Developments
 Here are a few suggestions that future developers can work on to improve this application!

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -139,6 +139,14 @@ CATcher uses the OAuth 2.0 protocol to authenticate users. Below is a summary of
 
 The authentication process is kicked off in the `AuthComponent`, but the code that co-ordinates steps 1 and 2 can be found in [`oauth.ts`](../oauth.ts)(For Electron) or `AuthService`(For Web). Step 2 requires a client secret granted to CATcher. To protect this, we run a web service, [gatekeeper](https://github.com/CATcher-org/gatekeeper) that executes step 2 on behalf of the client CATcher app.
 
+# Handling Releases
+
+Releases are primarily crafted using Github Actions that handle deployments and the building of executables for multiple operating systems. A release can be created with the following steps:
+
+  - Create and Merge and Pull Request that updates the version of the application in the `package.json` file.
+  - Navigate to the 'Actions' Tab of the `CATcher` repository and start the `Draft Deployment` Workflow. This deploys the application and creates a Draft Release containing the compiled executables.
+  - Edit the Draft Release and update the description with a changelog of recently merged Pull Requests.
+  - Save the Draft and create the Full Release.
 
 # Future Developments
 Here are a few suggestions that future developers can work on to improve this application!

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -141,9 +141,9 @@ The authentication process is kicked off in the `AuthComponent`, but the code th
 
 # Handling Releases
 
-Releases are primarily crafted using Github Actions that handle deployments and the building of executables for multiple operating systems. A release can be created with the following steps:
+Releases are primarily crafted using Github Actions that handles deployments and the building of executables for multiple operating systems. A release can be created with the following steps:
 
-  - Create and Merge and Pull Request that updates the version of the application in the `package.json` file.
+  - Create and Merge a Pull Request that updates the version of the application in the `package.json` file.
   - Navigate to the 'Actions' Tab of the `CATcher` repository and start the `Draft Deployment` Workflow. This deploys the application and creates a Draft Release containing the compiled executables.
   - Edit the Draft Release and update the description with a changelog of recently merged Pull Requests.
   - Save the Draft and create the Full Release.


### PR DESCRIPTION
Fixes #651 

Proposed Commit Message:
```
Update Dev Instructions with Release Procedure

Previously, the developer documentation did not include
the instructions on creating a release. This has now been added.
```