### PR TITLE
Enforcing prettier on commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",
-      "pre-push": "npx prettier --check && npm run lint && npm run test"
+      "pre-push": "npm run lint && npm run test"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick",
-      "pre-push": "npm run lint && npm run test"
+      "pre-commit": "pretty-quick --staged",
+      "pre-push": "npx prettier --check && npm run lint && npm run test"
     }
   },
   "dependencies": {


### PR DESCRIPTION
# Summary

Fixes #631.
I have opted not to add `prettier --check` as it adds significant time to the pre-push hook. 

## Proposed Commit Message

```
pretty-quick setting does not automatically restage formatted files.
It is possible for devs to push a commit without applying prettier suggestions.

Let's
* add the `--staged` flag to automatically restage and commit formatting changes

```