### PR TITLE
Issues Faulty Component: Decompose logical expressions into methods

### DIFF
--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -62,10 +62,11 @@ export class IssuesFaultyComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.filter = (issue: Issue): boolean => {
-      return this.issueService.hasTeamResponse(issue.id) &&
-        (!!issue.duplicateOf && this.issueService.issues$.getValue().filter(childIssue => {
-          return childIssue.duplicateOf === issue.id;
-        }).length !== 0);
+      const hasTeamResponse = (issue: Issue) => this.issueService.hasTeamResponse(issue.id);
+      const isDuplicateIssue = (issue: Issue) => !!issue.duplicateOf;
+      const isDuplicatedBy = (issue: Issue) =>
+            !!this.issueService.issues$.getValue().filter(childIssue => childIssue.duplicateOf === issue.id).length;
+      return hasTeamResponse(issue) && isDuplicateIssue(issue) && isDuplicatedBy(issue);
     };
   }
 

--- a/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
+++ b/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
@@ -1,55 +1,57 @@
 import { IssuesFaultyComponent } from '../../../../src/app/phase-team-response/issues-faulty/issues-faulty.component';
 import { Issue, STATUS } from '../../../../src/app/core/models/issue.model';
 import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
-import { Team } from '../../../../src/app/core/models/team.model';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { UserService } from '../../../../src/app/core/services/user.service';
 import { USER_Q, TEAM_4 } from '../../../constants/data.constants';
 
 describe('IssuesFaultyComponent', () => {
   describe('.ngOnInit()', () => {
-    const dummyTeam: Team = TEAM_4;
-    let dummyIssue: Issue;
-    let issuesFaultyComponent: IssuesFaultyComponent;
-    const issueService: IssueService = new IssueService(null, null, null, null, null, null, null);
-    const userService: UserService = new UserService(null, null);
+    const dummyTeam = TEAM_4;
+    const dummyIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+    const issueService = new IssueService(null, null, null, null, null, null, null);
+    issueService.updateLocalStore(dummyIssue);
+    const userService = new UserService(null, null);
     userService.currentUser = USER_Q;
+    const issuesFaultyComponent = new IssuesFaultyComponent(issueService, userService, null);
+    issuesFaultyComponent.ngOnInit();
     const DUMMY_DUPLICATE_ISSUE_ID = 1;
     const DUMMY_RESPONSE = 'dummy response';
 
-    beforeEach(() => {
-      dummyIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-      issueService.updateLocalStore(dummyIssue);
-      issuesFaultyComponent = new IssuesFaultyComponent(issueService, userService, null);
-      issuesFaultyComponent.ngOnInit();
-    });
-
     it('should set filter to return false for an issue with no team response', () => {
-      issueService.issues[dummyIssue.id].teamResponse = undefined;
+      const testIssue = { ...dummyIssue, teamResponse: undefined } as Issue;
+      issueService.updateLocalStore(testIssue);
 
-      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+      expect(issuesFaultyComponent.filter(testIssue)).toBeFalse();
     });
 
     it('should set filter to return false for a non-duplicate issue with responses', () => {
-      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
-      dummyIssue.duplicateOf = undefined;
+      const testIssue = { ...dummyIssue, teamResponse: DUMMY_RESPONSE, duplicateOf: undefined } as Issue;
+      issueService.updateLocalStore(testIssue);
 
-      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+      expect(issuesFaultyComponent.filter(testIssue)).toBeFalse();
     });
 
     it('should set filter to return false for a duplicate issue with responses that is not duplicated by other issues', () => {
-      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
-      dummyIssue.duplicateOf = DUMMY_DUPLICATE_ISSUE_ID;
+      const testIssue = {
+        ...dummyIssue,
+        teamResponse: DUMMY_RESPONSE,
+        duplicateOf: DUMMY_DUPLICATE_ISSUE_ID
+      } as Issue;
+      issueService.updateLocalStore(testIssue);
 
-      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+      expect(issuesFaultyComponent.filter(testIssue)).toBeFalse();
     });
 
     it('should set filter to return true for a duplicate issue with responses that is duplicated by other issues', () => {
-      dummyIssue.duplicateOf = dummyIssue.id;
-      issueService.updateLocalStore(dummyIssue);
-      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
+      const testIssue = {
+        ...dummyIssue,
+        teamResponse: DUMMY_RESPONSE,
+        duplicateOf: dummyIssue.id
+      } as Issue;
+      issueService.updateLocalStore(testIssue);
 
-      expect(issuesFaultyComponent.filter(dummyIssue)).toBeTrue();
+      expect(issuesFaultyComponent.filter(testIssue)).toBeTrue();
     });
   });
 });

--- a/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
+++ b/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
@@ -1,0 +1,55 @@
+import { IssuesFaultyComponent } from '../../../../src/app/phase-team-response/issues-faulty/issues-faulty.component';
+import { Issue, STATUS } from '../../../../src/app/core/models/issue.model';
+import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
+import { Team } from '../../../../src/app/core/models/team.model';
+import { IssueService } from '../../../../src/app/core/services/issue.service';
+import { UserService } from '../../../../src/app/core/services/user.service';
+import { USER_Q, TEAM_4 } from '../../../constants/data.constants';
+
+describe('IssuesFaultyComponent', () => {
+  describe('.ngOnInit()', () => {
+    const dummyTeam: Team = TEAM_4;
+    let dummyIssue: Issue;
+    let issuesFaultyComponent: IssuesFaultyComponent;
+    const issueService: IssueService = new IssueService(null, null, null, null, null, null, null);
+    const userService: UserService = new UserService(null, null);
+    userService.currentUser = USER_Q;
+    const DUMMY_DUPLICATE_ISSUE_ID = 1;
+    const DUMMY_RESPONSE = 'dummy response';
+
+    beforeEach(() => {
+      dummyIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+      issueService.updateLocalStore(dummyIssue);
+      issuesFaultyComponent = new IssuesFaultyComponent(issueService, userService, null);
+      issuesFaultyComponent.ngOnInit();
+    });
+
+    it('should set filter to return false for an issue with no team response', () => {
+      issueService.issues[dummyIssue.id].teamResponse = undefined;
+
+      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+    });
+
+    it('should set filter to return false for a non-duplicate issue with responses', () => {
+      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
+      dummyIssue.duplicateOf = undefined;
+
+      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+    });
+
+    it('should set filter to return false for a duplicate issue with responses that is not duplicated by other issues', () => {
+      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
+      dummyIssue.duplicateOf = DUMMY_DUPLICATE_ISSUE_ID;
+
+      expect(issuesFaultyComponent.filter(dummyIssue)).toBeFalse();
+    });
+
+    it('should set filter to return true for a duplicate issue with responses that is duplicated by other issues', () => {
+      dummyIssue.duplicateOf = dummyIssue.id;
+      issueService.updateLocalStore(dummyIssue);
+      issueService.issues[dummyIssue.id].teamResponse = DUMMY_RESPONSE;
+
+      expect(issuesFaultyComponent.filter(dummyIssue)).toBeTrue();
+    });
+  });
+});

--- a/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
+++ b/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
@@ -1,22 +1,27 @@
 import { IssuesFaultyComponent } from '../../../../src/app/phase-team-response/issues-faulty/issues-faulty.component';
-import { Issue, STATUS } from '../../../../src/app/core/models/issue.model';
-import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
+import { Issue } from '../../../../src/app/core/models/issue.model';
+import { generateIssueWithRandomData, ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../constants/githubissue.constants';
 import { IssueService } from '../../../../src/app/core/services/issue.service';
 import { UserService } from '../../../../src/app/core/services/user.service';
-import { USER_Q, TEAM_4 } from '../../../constants/data.constants';
+import { USER_Q, TEAM_3, TEAM_4 } from '../../../constants/data.constants';
 
 describe('IssuesFaultyComponent', () => {
   describe('.ngOnInit()', () => {
     const dummyTeam = TEAM_4;
     const dummyIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
-    const issueService = new IssueService(null, null, null, null, null, null, null);
-    issueService.updateLocalStore(dummyIssue);
+    let issueService: IssueService;
+    let issuesFaultyComponent: IssuesFaultyComponent;
     const userService = new UserService(null, null);
     userService.currentUser = USER_Q;
-    const issuesFaultyComponent = new IssuesFaultyComponent(issueService, userService, null);
-    issuesFaultyComponent.ngOnInit();
     const DUMMY_DUPLICATE_ISSUE_ID = 1;
     const DUMMY_RESPONSE = 'dummy response';
+
+    beforeEach(() => {
+      issueService = new IssueService(null, null, null, null, null, null, null);
+      issueService.updateLocalStore(dummyIssue);
+      issuesFaultyComponent = new IssuesFaultyComponent(issueService, userService, null);
+      issuesFaultyComponent.ngOnInit();
+    });
 
     it('should set filter to return false for an issue with no team response', () => {
       const testIssue = { ...dummyIssue, teamResponse: undefined } as Issue;
@@ -45,11 +50,17 @@ describe('IssuesFaultyComponent', () => {
 
     it('should set filter to return true for a duplicate issue with responses that is duplicated by other issues', () => {
       const testIssue = {
-        ...dummyIssue,
-        teamResponse: DUMMY_RESPONSE,
-        duplicateOf: dummyIssue.id
+        ...Issue.createPhaseTeamResponseIssue(generateIssueWithRandomData(), TEAM_3),
+        duplicateOf: dummyIssue.id,
+        teamResponse: DUMMY_RESPONSE
       } as Issue;
       issueService.updateLocalStore(testIssue);
+
+      const duplicateOfTestIssue = {
+        ...Issue.createPhaseTeamResponseIssue(generateIssueWithRandomData(), TEAM_3),
+        duplicateOf: testIssue.id
+      } as Issue;
+      issueService.updateLocalStore(duplicateOfTestIssue);
 
       expect(issuesFaultyComponent.filter(testIssue)).toBeTrue();
     });

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -57,7 +57,7 @@ export const jsonData = {
 };
 
 // These are objects representing some users and teams in jsonData
-const TEAM_3 = new Team({
+export const TEAM_3 = new Team({
   id: 'CS2103T-W12-3',
   teamMembers: [
     { loginId: 'junwei96', role: UserRole.Student },


### PR DESCRIPTION
Addresses a task in #553

Changes:

- Logical expressions in the `IssuesFaultyComponent` for initialising default filter has been decomposed into separate methods
- Tests have been added to check if the default filter is being initialised correctly

Proposed Commit Message:
```
IssuesFaultyComponent: Decompose logical expressions into methods

Logic expression for initialising default filter for
IssuesFaultyComponent is too long and has no tests. 

Let's
* decompose the logic expression to improve readability 
* add tests for default filter initialisation
```
