### PR TITLE
Fix logging into non bugreporting phase

### DIFF
--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -65,6 +65,10 @@ export class RepoCreatorService {
     UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
       tap((repoCreationPermission: boolean | null) => {
+        if(repoCreationPermission === null) {
+          return;
+        }
+        
         if (repoCreationPermission === false) {
           throw new Error(MISSING_REQUIRED_REPO);
         } else if (currentPhase !== Phase.phaseBugReporting) {

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -65,10 +65,10 @@ export class RepoCreatorService {
     UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
       tap((repoCreationPermission: boolean | null) => {
-        if(repoCreationPermission === null) {
+        if (repoCreationPermission === null) {
           return;
         }
-        
+
         if (repoCreationPermission === false) {
           throw new Error(MISSING_REQUIRED_REPO);
         } else if (currentPhase !== Phase.phaseBugReporting) {


### PR DESCRIPTION
Fixes #692

Proposed Commit Message:

```
Patched bug of not being able to log into other phases.

Previously there was an issue when users attempt to login
directly into a phase that does not require repo-creation.
This has been fixed with an additional check during the repo
creation process.
```