### PR TITLE
Fix graphql-tag version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "diff-match-patch": "^1.0.4",
     "electron-log": "^4.2.4",
     "graphql": "^14.6.0",
-    "graphql-tag": "^2.10.0",
+    "graphql-tag": "2.11.0",
     "karma-spec-reporter": "0.0.32",
     "moment": "^2.24.0",
     "ngx-markdown": "^8.2.1",


### PR DESCRIPTION
# Summary

Upon investigation, seems like the type error is caused by certain versions of `graphql-tag` not being supported by `typescript`. Updating typescript might cause similar problems with karma, so `graphql-tag` is afixed to a known working version.
Closes #695 

## Proposed commit message

```
Workflows fail when npm install pulls the latest version of a package, 
which may be unsupported by other packages.
Let's set a fixed version number for graphql-tag
```
