### PR TITLE
Enable Error snack-bar to autoclose

### DIFF
--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -16,6 +16,7 @@ const FILTERABLE = ['node_modules'];
   providedIn: 'root',
 })
 export class ErrorHandlingService implements ErrorHandler {
+  static DURATION = 5000;
 
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 
@@ -54,13 +55,13 @@ export class ErrorHandlingService implements ErrorHandler {
       case 500: // Internal Server Error.
         this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
           data: error,
-          duration: 3000
+          duration: ErrorHandlingService.DURATION
         });
         break;
       case 422: // Form errors
         this.snackBar.openFromComponent(FormErrorComponent, {
           data: error,
-          duration: 3000
+          duration: ErrorHandlingService.DURATION
         });
         break;
       case 400: // Bad request
@@ -68,13 +69,13 @@ export class ErrorHandlingService implements ErrorHandler {
       case 404: // Not found
         this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
           data: error,
-          duration: 3000
+          duration: ErrorHandlingService.DURATION
         });
         break;
       default:
         this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
           data: error,
-          duration: 3000
+          duration: ErrorHandlingService.DURATION
         });
         return;
     }
@@ -83,7 +84,7 @@ export class ErrorHandlingService implements ErrorHandler {
   private handleGeneralError(error: string): void {
     this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
       data: {message: error},
-      duration: 3000
+      duration: ErrorHandlingService.DURATION
     });
   }
 }

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -67,6 +67,9 @@ export class ErrorHandlingService implements ErrorHandler {
   }
 
   private handleGeneralError(error: string): void {
-    this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: {message: error}});
+    this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
+      data: {message: error},
+      duration: 3000
+    });
   }
 }

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -5,6 +5,8 @@ import { FormErrorComponent } from '../../shared/error-toasters/form-error/form-
 import { HttpErrorResponse } from '@angular/common/http';
 import { RequestError } from '@octokit/request-error';
 import { LoggingService } from './logging.service';
+import internal = require('events');
+import { ComponentType } from '@angular/core/src/render3';
 
 export const ERRORCODE_NOT_FOUND = 404;
 
@@ -50,18 +52,30 @@ export class ErrorHandlingService implements ErrorHandler {
 
     switch (error.status) {
       case 500: // Internal Server Error.
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
+          data: error,
+          duration: 3000
+        });
         break;
       case 422: // Form errors
-        this.snackBar.openFromComponent(FormErrorComponent, {data: error});
+        this.snackBar.openFromComponent(FormErrorComponent, {
+          data: error,
+          duration: 3000
+        });
         break;
       case 400: // Bad request
       case 401: // Unauthorized
       case 404: // Not found
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
+          data: error,
+          duration: 3000
+        });
         break;
       default:
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {
+          data: error,
+          duration: 3000
+        });
         return;
     }
   }

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -11,7 +11,6 @@
                     id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
                     cdkAutosizeMaxRows="20" class="text-input-area" 
-                    (focus)="checkMyPlaceHolder()"
                     ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -10,7 +10,9 @@
           <textarea (paste)="onPaste($event)" #commentTextArea (dragover)="disableCaretMovement($event)"
                     id="{{ this.id }}" formControlName="{{ this.id }}" matInput placeholder="Description"
                     cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20" class="text-input-area"></textarea>
+                    cdkAutosizeMaxRows="20" class="text-input-area" 
+                    (focus)="checkMyPlaceHolder()"
+                    ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>


### PR DESCRIPTION
Implement the feature for the error snack-bar to automatically close after 5 seconds without the need to manually click the `Close` button

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/66840796/122262140-ada62680-cf07-11eb-9722-a84334039e11.gif)

Reason:
- Enhance the user experience as it may be troublesome for the user to manually close the error snack-bar everytime the error snack-bar pops up