### PR TITLE
Upgrade to Electron v11

### DIFF
--- a/electron-utils/menu-bar.ts
+++ b/electron-utils/menu-bar.ts
@@ -1,4 +1,4 @@
-import { app, MenuItemConstructorOptions } from 'electron';
+import { app, MenuItemConstructorOptions, MenuItem, Menu } from 'electron';
 
 // Edited version of a template menu-bar provided by the electron API,
 // refer to https://electronjs.org/docs/api/menu for more information.
@@ -48,4 +48,17 @@ export function createMenuOptions(isDevMode: boolean): MenuItemConstructorOption
     );
   }
   return mainMenuTemplate;
+}
+
+export function createContextMenu(point) {
+  const INSPECT_MENU_ITEM = new MenuItem({
+    label: 'Inspect Element',
+    click:  (menuItem, window, e) => {
+      window.webContents.inspectElement(point.x, point.y);
+    }
+  });
+
+  const contextMenu = new Menu();
+  contextMenu.append(INSPECT_MENU_ITEM);
+  return contextMenu;
 }

--- a/electron-utils/menu-bar.ts
+++ b/electron-utils/menu-bar.ts
@@ -51,7 +51,7 @@ export function createMenuOptions(isDevMode: boolean): MenuItemConstructorOption
 }
 
 export function createContextMenu(window: BrowserWindow) {
-  const point = {x:null, y:null};
+  const point = {x: null, y: null};
   const INSPECT_MENU_ITEM = new MenuItem({
     label: 'Inspect Element',
     click:  (menuItem, window, e) => {
@@ -61,7 +61,7 @@ export function createContextMenu(window: BrowserWindow) {
 
   const contextMenu = new Menu();
   contextMenu.append(INSPECT_MENU_ITEM);
-  
+
   window.webContents.on('context-menu',  (e, click) => {
     point.x = click.x;
     point.y = click.y;

--- a/electron-utils/menu-bar.ts
+++ b/electron-utils/menu-bar.ts
@@ -50,21 +50,29 @@ export function createMenuOptions(isDevMode: boolean): MenuItemConstructorOption
   return mainMenuTemplate;
 }
 
-export function createContextMenu(window: BrowserWindow) {
-  const point = {x: null, y: null};
-  const INSPECT_MENU_ITEM = new MenuItem({
+function createInspectElementMenuItem(contextMenuCoords: {x, y}): MenuItem {
+   return new MenuItem({
     label: 'Inspect Element',
-    click:  (menuItem, window, e) => {
-      window.webContents.inspectElement(point.x, point.y);
+    click:  (menuItem, window, event) => {
+      window.webContents.inspectElement(contextMenuCoords.x, contextMenuCoords.y);
     }
   });
+}
 
+/**
+ * Creates a menu that is displayed when the context-menu event fires on the
+ * given BrowserWindow (i.e. usually when user right-clicks on the window).
+ * This menu will contain an 'Inspect Element' MenuItem.
+ */
+export function createContextMenu(win: BrowserWindow): void {
+  const contextMenuCoords = {x: null, y: null};
   const contextMenu = new Menu();
-  contextMenu.append(INSPECT_MENU_ITEM);
+  contextMenu.append(createInspectElementMenuItem(contextMenuCoords));
 
-  window.webContents.on('context-menu',  (e, click) => {
-    point.x = click.x;
-    point.y = click.y;
-    contextMenu.popup({window: window});
+  win.webContents.on('context-menu',  (event, contextMenuParams) => {
+    // record the mouse position, when context-menu event is fired
+    contextMenuCoords.x = contextMenuParams.x;
+    contextMenuCoords.y = contextMenuParams.y;
+    contextMenu.popup({window: win});
   });
 }

--- a/electron-utils/menu-bar.ts
+++ b/electron-utils/menu-bar.ts
@@ -1,4 +1,4 @@
-import { app, MenuItemConstructorOptions, MenuItem, Menu } from 'electron';
+import { app, MenuItemConstructorOptions, MenuItem, Menu, BrowserWindow } from 'electron';
 
 // Edited version of a template menu-bar provided by the electron API,
 // refer to https://electronjs.org/docs/api/menu for more information.
@@ -50,7 +50,8 @@ export function createMenuOptions(isDevMode: boolean): MenuItemConstructorOption
   return mainMenuTemplate;
 }
 
-export function createContextMenu(point) {
+export function createContextMenu(window: BrowserWindow) {
+  const point = {x:null, y:null};
   const INSPECT_MENU_ITEM = new MenuItem({
     label: 'Inspect Element',
     click:  (menuItem, window, e) => {
@@ -60,5 +61,10 @@ export function createContextMenu(point) {
 
   const contextMenu = new Menu();
   contextMenu.append(INSPECT_MENU_ITEM);
-  return contextMenu;
+  
+  window.webContents.on('context-menu',  (e, click) => {
+    point.x = click.x;
+    point.y = click.y;
+    contextMenu.popup({window: window});
+  });
 }

--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -64,7 +64,12 @@ function getAuthorizationCode(parentWindow: BrowserWindow, repoPermissionLevel: 
     authWindow.webContents.on('will-navigate', (event, newUrl) => {
       if (newUrl.startsWith(CALLBACK_URL)) {
         onCallback(newUrl);
+      } else if (newUrl.startsWith(`${BASE_URL}/session`) || (newUrl.startsWith(`${BASE_URL}/login`))) {
+        // continue navigation within the auth window
+        return;
       } else {
+        // do not navigate to external links in the auth window
+        // instead, navigate to them in the user's browser
         event.preventDefault();
         shell.openExternal(newUrl).then(() => Logger.info('External link is clicked on auth window, opening system browser...'));
       }

--- a/main.ts
+++ b/main.ts
@@ -26,7 +26,7 @@ ipcMain.on('github-oauth', (event, repoPermissionLevel) => {
   });
 });
 
-ipcMain.handle('clear-cookies', () => {
+ipcMain.handle('clear-storage', () => {
     return win.webContents.session.clearStorageData();
 });
 

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, MenuItem } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
-import { createMenuOptions } from './electron-utils/menu-bar';
+import { createMenuOptions, createContextMenu } from './electron-utils/menu-bar';
 import { isDeveloperMode, isLinuxOs, isMacOs, appTitle } from './electron-utils/supporting-logic';
 import { getAccessToken } from './electron-utils/oauth';
 
@@ -52,21 +52,13 @@ function createWindow() {
 
   nativeTheme.themeSource = 'light';
 
-
-
-   const INSPECT_MENU_ITEM = new MenuItem({
-    label: 'Inspect Element',
-    click:  (menuItem, window, e) => {
-      const point = screen.getCursorScreenPoint();
-      window.webContents.inspectElement(point.x, point.y);
-    }
-  });
-
-  const rightClickMenu = new Menu();
-  rightClickMenu.append(INSPECT_MENU_ITEM);
+  const point = {x:null, y:null};
+  const contextMenu = createContextMenu(point);
 
   win.webContents.on('context-menu',  (e, click) => {
-    rightClickMenu.popup({window: win});
+    point.x = click.x;
+    point.y = click.y;
+    contextMenu.popup({window: win});
   });
 
   if (isDevMode) {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, MenuItem } from 'electron';
+import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, MenuItem, shell } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import { createMenuOptions, createContextMenu } from './electron-utils/menu-bar';
@@ -24,6 +24,14 @@ ipcMain.on('github-oauth', (event, repoPermissionLevel) => {
       error: error.message,
       isWindowClosed: error.message === 'WINDOW_CLOSED'});
   });
+});
+
+ipcMain.handle('clear-cookies', () => {
+    return win.webContents.session.clearStorageData();
+});
+
+ipcMain.handle('open-link', (e, address) => {
+    shell.openExternal(address);
 });
 
 
@@ -52,19 +60,12 @@ function createWindow() {
 
   nativeTheme.themeSource = 'light';
 
-  const point = {x:null, y:null};
-  const contextMenu = createContextMenu(point);
-
-  win.webContents.on('context-menu',  (e, click) => {
-    point.x = click.x;
-    point.y = click.y;
-    contextMenu.popup({window: win});
-  });
-
   if (isDevMode) {
     require('electron-reload')(__dirname, {
       electron: require(`${__dirname}/node_modules/electron`)
     });
+
+    createContextMenu(win);
     win.loadURL('http://localhost:4200');
     win.webContents.openDevTools();
   } else {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain } from 'electron';
+import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, MenuItem } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import { createMenuOptions } from './electron-utils/menu-bar';
@@ -51,6 +51,23 @@ function createWindow() {
   win.setTitle(appTitle);
 
   nativeTheme.themeSource = 'light';
+
+
+
+   const INSPECT_MENU_ITEM = new MenuItem({
+    label: 'Inspect Element',
+    click:  (menuItem, window, e) => {
+      const point = screen.getCursorScreenPoint();
+      window.webContents.inspectElement(point.x, point.y);
+    }
+  });
+
+  const rightClickMenu = new Menu();
+  rightClickMenu.append(INSPECT_MENU_ITEM);
+
+  win.webContents.on('context-menu',  (e, click) => {
+    rightClickMenu.popup({window: win});
+  });
 
   if (isDevMode) {
     require('electron-reload')(__dirname, {
@@ -109,6 +126,7 @@ try {
       createWindow();
     }
   });
+
 
 } catch (e) {
   Logger.error('Something went wrong in Electron.', e);

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, MenuItem, shell } from 'electron';
+import { app, BrowserWindow, screen, Menu, nativeTheme, MenuItemConstructorOptions, ipcMain, shell } from 'electron';
 import * as path from 'path';
 import * as url from 'url';
 import { createMenuOptions, createContextMenu } from './electron-utils/menu-bar';
@@ -119,7 +119,6 @@ try {
       createWindow();
     }
   });
-
 
 } catch (e) {
   Logger.error('Something went wrong in Electron.', e);

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/node": "~12.12.6",
     "angular-cli-ghpages": "^1.0.0-rc.1",
     "codelyzer": "~5.2.1",
-    "electron": "9.1.0",
+    "electron": "10.4.7",
     "electron-builder": "22.2.0",
     "electron-reload": "1.5.0",
     "graphql-codegen-fragment-matcher": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/node": "~12.12.6",
     "angular-cli-ghpages": "^1.0.0-rc.1",
     "codelyzer": "~5.2.1",
-    "electron": "10.4.7",
+    "electron": "11.4.8",
     "electron-builder": "22.2.0",
     "electron-reload": "1.5.0",
     "graphql-codegen-fragment-matcher": "^0.18.2",

--- a/src/app/core/services/electron.service.ts
+++ b/src/app/core/services/electron.service.ts
@@ -28,7 +28,7 @@ export class ElectronService {
 
   clearCookies() {
     if (this.isElectron()) {
-      this.ipcRenderer.invoke('clear-cookies');
+      this.ipcRenderer.invoke('clear-storage');
     }
   }
 

--- a/src/app/core/services/electron.service.ts
+++ b/src/app/core/services/electron.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ipcRenderer, remote, clipboard, Menu, MenuItem } from 'electron';
-import * as fs from 'fs';
-import { AppConfig } from '../../../environments/environment';
+import { ipcRenderer } from 'electron';
 
 declare var window: Window;
 declare global {
@@ -16,17 +14,10 @@ declare global {
 })
 export class ElectronService {
   ipcRenderer: typeof ipcRenderer;
-  remote: typeof remote;
-  clipboard: typeof clipboard;
-  fs: typeof fs;
 
   constructor() {
     if (this.isElectron()) {
       this.ipcRenderer = window.require('electron').ipcRenderer;
-      this.remote = window.require('electron').remote;
-      this.clipboard = window.require('electron').clipboard;
-      this.fs = window.require('fs');
-
     }
   }
 
@@ -37,7 +28,7 @@ export class ElectronService {
 
   clearCookies() {
     if (this.isElectron()) {
-      this.remote.getCurrentWebContents().session.clearStorageData();
+      this.ipcRenderer.invoke('clear-cookies');
     }
   }
 
@@ -61,7 +52,7 @@ export class ElectronService {
 
   openLink(address: string) {
     if (this.isElectron()) {
-      this.remote.shell.openExternal(address);
+      this.ipcRenderer.invoke('open-link', address);
     } else {
       window.open(address);
     }

--- a/src/app/core/services/electron.service.ts
+++ b/src/app/core/services/electron.service.ts
@@ -15,10 +15,6 @@ declare global {
   providedIn: 'root',
 })
 export class ElectronService {
-  readonly INSPECT_MENU_ITEM: MenuItem;
-  rightClickPosition = null;
-  rightClickMenu: Menu;
-
   ipcRenderer: typeof ipcRenderer;
   remote: typeof remote;
   clipboard: typeof clipboard;
@@ -31,18 +27,6 @@ export class ElectronService {
       this.clipboard = window.require('electron').clipboard;
       this.fs = window.require('fs');
 
-      this.INSPECT_MENU_ITEM = new this.remote.MenuItem({
-        label: 'Inspect Element',
-        click: () => {
-          this.remote.getCurrentWindow().webContents.inspectElement(this.rightClickPosition.x, this.rightClickPosition.y);
-        }
-      });
-      this.rightClickMenu = new this.remote.Menu();
-      this.rightClickMenu.append(this.INSPECT_MENU_ITEM);
-
-      if (!AppConfig.production) {
-        this.enableRightClickInspectElement();
-      }
     }
   }
 
@@ -50,13 +34,6 @@ export class ElectronService {
     return window && window.process && window.process.type;
   }
 
-  enableRightClickInspectElement(): void {
-    window.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      this.rightClickPosition = {x: e.x, y: e.y};
-      this.rightClickMenu.popup({window: this.remote.getCurrentWindow()});
-    }, false);
-  }
 
   clearCookies() {
     if (this.isElectron()) {


### PR DESCRIPTION
Addresses #705 

Do remember to run `npm install` when reviewing this PR locally (so that the updated Electron version is used).
Please try building the desktop app with this PR, as well!

When submitting your review for this PR, please **list the OS you used** (so we can ensure all 3 OS were tested)


```
We are using Electron v9, which is no longer supported by the
Electron team. Let's incrementally adopt newer versions of
Electron, starting with v11.

To adopt Electron v11, all usages of the `remote` module have been
removed from ElectronService. This is because the Electron team
is planning to deprecate the `remote` module. This module is disabled
by default from Electron v10 onwards, marked for deprecation in v12,
and set for removal in v14.

The affected functionality has been re-implemented in the main
process code (main.ts and electron-utils/menu-bar.ts).

This change only involves functionality in the desktop app.
(specifically, the ability to open external links, clear cookies
and the "Inspect Element" feature).

Details on the deprecation of `remote` module can be found at:
- https://www.electronjs.org/docs/api/remote
- https://github.com/electron/electron/issues/21408
- https://www.electronjs.org/docs/breaking-changes#deprecated-remote-module

```