### PR TITLE
AuthComponent: Log the selected settings repo

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -39,6 +39,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
+  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -171,7 +172,7 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
-    this.sessionSelected = profile.profileName
+    this.sessionSelected = profile.profileName;
   }
 
   /**
@@ -203,8 +204,8 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
-    this.logger.info("Selected Session: " + (this.sessionSelected || "No session selected")) 
-    this.logger.info("Selected Settings Location: " + sessionInformation)
+    this.logger.info("Selected Session: " + (this.sessionSelected || this.noSessionSelected));
+    this.logger.info("Selected Settings Location: " + sessionInformation);
 
     this.phaseService.storeSessionData().pipe(
       throwIfFalse(isValidSession => isValidSession,

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,13 +33,11 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
-  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
-  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -172,7 +170,6 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
-    this.sessionSelected = profile.profileName;
   }
 
   /**
@@ -204,7 +201,6 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
-    this.logger.info("Selected Session: " + (this.sessionSelected || this.noSessionSelected));
     this.logger.info("Selected Settings Location: " + sessionInformation);
 
     this.phaseService.storeSessionData().pipe(

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -201,7 +201,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
-    this.logger.info("Selected Settings Location: " + sessionInformation);
+    this.logger.info(`Selected Settings Repo: ${sessionInformation}`);
 
     this.phaseService.storeSessionData().pipe(
       throwIfFalse(isValidSession => isValidSession,

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,6 +33,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
+  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
@@ -170,6 +171,7 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
+    this.sessionSelected = profile.profileName
   }
 
   /**
@@ -200,6 +202,9 @@ export class AuthComponent implements OnInit, OnDestroy {
     const org: string = this.getOrgDetails(sessionInformation);
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
+
+    this.logger.info("Selected Session: " + (this.sessionSelected || "No session selected")) 
+    this.logger.info("Selected Settings Location: " + sessionInformation)
 
     this.phaseService.storeSessionData().pipe(
       throwIfFalse(isValidSession => isValidSession,


### PR DESCRIPTION
Fixes #690

Changes made:
- Add logging of the session selected during authentication
- Add logging of the settings location during authentication

Proposed Commit message:
```
No logging of the setting location during authentication

When user fails the authentication, it might be difficult to 
troubleshoot the issue without any logging

Let's add logging of the settings location 

Logging the settings location will allow the user to check if the 
correct settings has been selected during troubleshooting
```


