### PR TITLE
PhaseService#storeSessionData: Remove current phase verification

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,11 +33,13 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
+  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
+  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -170,6 +172,7 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
+    this.sessionSelected = profile.profileName;
   }
 
   /**
@@ -201,10 +204,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const dataRepo: string = this.getDataRepoDetails(sessionInformation);
     this.githubService.storeOrganizationDetails(org, dataRepo);
 
-    this.phaseService.storeSessionData().pipe(
-      throwIfFalse(isValidSession => isValidSession,
-                   () => new Error('Invalid Session'))
-    ).subscribe(() => {
+    this.phaseService.storeSessionData().subscribe(() => {
       try {
         this.authService.startOAuthProcess();
       } catch (error) {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -33,13 +33,11 @@ export class AuthComponent implements OnInit, OnDestroy {
   isAppOutdated: boolean;
   versionCheckingError: boolean;
 
-  sessionSelected: string;
   authState: AuthState;
   accessTokenSubscription: Subscription;
   authStateSubscription: Subscription;
   profileForm: FormGroup;
   currentUserName: string;
-  noSessionSelected = "No session selected";
 
   constructor(public appService: ApplicationService,
               public electronService: ElectronService,
@@ -172,7 +170,6 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   onProfileSelect(profile: Profile): void {
     this.profileForm.get('session').setValue(profile.encodedText);
-    this.sessionSelected = profile.profileName;
   }
 
   /**

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -74,12 +74,11 @@ export class PhaseService {
    * Will fetch session data and update phase service with it.
    * @returns - If the session is valid return true, else false
    */
-  storeSessionData(): Observable<boolean> {
+  storeSessionData(): Observable<void> {
     return this.fetchSessionData().pipe(
       assertSessionDataIntegrity(),
       map((sessionData: SessionData) => {
         this.updateSessionParameters(sessionData);
-        return this.currentPhase !== undefined;
       })
     );
   }

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -72,7 +72,6 @@ export class PhaseService {
 
   /**
    * Will fetch session data and update phase service with it.
-   * @returns - If the session is valid return true, else false
    */
   storeSessionData(): Observable<void> {
     return this.fetchSessionData().pipe(

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -19,17 +19,17 @@ describe('PhaseService', () => {
   });
 
   describe('.storeSessionData()', () => {
-    it('should return an Observable of true if an openPhase is defined', () => {
+    it('should return an Observable of void if an openPhase is defined', () => {
       githubService.fetchSettingsFile.and.returnValue(of(BUG_REPORTING_PHASE_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: boolean) => {
-        expect(result).toBeTrue();
+      phaseService.storeSessionData().subscribe((result: void) => {
+        expect().nothing();
       });
     });
 
-    it('should return an Observable of true if multiple openPhases are defined', () => {
+    it('should return an Observable of void if multiple openPhases are defined', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: boolean) => {
-        expect(result).toBeTrue();
+      phaseService.storeSessionData().subscribe((result: void) => {
+        expect().nothing();
       });
     });
 

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -26,7 +26,7 @@ describe('PhaseService', () => {
       });
     });
 
-    it('should not throw any errors if there is are multiple defined openPhases', () => {
+    it('should not throw any errors if there are multiple defined openPhases', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
       phaseService.storeSessionData().subscribe({
         error: () => fail()

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -19,17 +19,19 @@ describe('PhaseService', () => {
   });
 
   describe('.storeSessionData()', () => {
-    it('should return an Observable of void if an openPhase is defined', () => {
+    it('should not throw any errors if there is a defined openPhase', () => {
       githubService.fetchSettingsFile.and.returnValue(of(BUG_REPORTING_PHASE_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: void) => {
-        expect().nothing();
+      phaseService.storeSessionData().subscribe({
+        next: (e) => expect(e).toEqual(BUG_REPORTING_PHASE_SESSION_DATA),
+        error: () => fail()
       });
     });
 
-    it('should return an Observable of void if multiple openPhases are defined', () => {
+    it('should not throw any errors if there is are multiple defined openPhase', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
-      phaseService.storeSessionData().subscribe((result: void) => {
-        expect().nothing();
+      phaseService.storeSessionData().subscribe({
+        next: (e) => expect(e).toEqual(MULTIPLE_OPEN_PHASES_SESSION_DATA),
+        error: () => fail()
       });
     });
 

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -22,7 +22,6 @@ describe('PhaseService', () => {
     it('should not throw any errors if there is a defined openPhase', () => {
       githubService.fetchSettingsFile.and.returnValue(of(BUG_REPORTING_PHASE_SESSION_DATA));
       phaseService.storeSessionData().subscribe({
-        next: (e) => expect(e).toEqual(BUG_REPORTING_PHASE_SESSION_DATA),
         error: () => fail()
       });
     });
@@ -30,7 +29,6 @@ describe('PhaseService', () => {
     it('should not throw any errors if there is are multiple defined openPhase', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
       phaseService.storeSessionData().subscribe({
-        next: (e) => expect(e).toEqual(MULTIPLE_OPEN_PHASES_SESSION_DATA),
         error: () => fail()
       });
     });

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -26,7 +26,7 @@ describe('PhaseService', () => {
       });
     });
 
-    it('should not throw any errors if there is are multiple defined openPhase', () => {
+    it('should not throw any errors if there is are multiple defined openPhases', () => {
       githubService.fetchSettingsFile.and.returnValue(of(MULTIPLE_OPEN_PHASES_SESSION_DATA));
       phaseService.storeSessionData().subscribe({
         error: () => fail()


### PR DESCRIPTION
Summary:
Fixes #595

Changes Made:
- Refactoring of storeSessionData method to remove the redundant current phase validation check
- Also removed the pipe used by phaseService, which was dependent on storeSessionData returning an Observable<Boolean> type and the validation is now being done by the `assertSessionDataIntegrity()` method
- Updated the relevant test cases

```
storeSessionData performs current phase validation

assertSessionDataIntegrity now does the validation of an openPhase

Let's
- Remove current phase validation result under storeSessionData
- Remove pipe called by phaseService which is used for current phase validation

Validation is now covered by assertSessionDataIntegrity, making the current 
phase validation under storeSessionData redundant

phaseService pipe was previously used to validate the current phase based 
on the boolean result returned by storeSessionData
```