### PR TITLE
Increase number of labels in a single fetch

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -193,7 +193,7 @@ export class GithubService {
   }
 
   fetchAllLabels(): Observable<Array<{}>> {
-    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
+    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: 100, headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
       map(response => {
         return response['data'];
       }),

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -193,12 +193,13 @@ export class GithubService {
   }
 
   fetchAllLabels(): Observable<Array<{}>> {
-    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: 100, headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
-      map(response => {
-        return response['data'];
-      }),
-      catchError(err => throwError('Failed to fetch labels.'))
-    );
+    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: 100, headers: GithubService.IF_NONE_MATCH_EMPTY}))
+      .pipe(
+        map(response => {
+          return response['data'];
+        }),
+        catchError(err => throwError('Failed to fetch labels.'))
+      );
   }
 
   /**

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -34,7 +34,7 @@ let ORG_NAME = '';
 let MOD_ORG = '';
 let REPO = '';
 let DATA_REPO = '';
-const MAX_SIZE_PER_PAGE = 100;
+const MAX_ITEMS_PER_PAGE = 100;
 
 let octokit = new Octokit();
 
@@ -198,7 +198,7 @@ export class GithubService {
     return from(octokit.issues.listLabelsForRepo({
       owner: ORG_NAME,
       repo: REPO,
-      per_page: MAX_SIZE_PER_PAGE,
+      per_page: MAX_ITEMS_PER_PAGE,
       headers: GithubService.IF_NONE_MATCH_EMPTY
     }))
     .pipe(

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -34,7 +34,7 @@ let ORG_NAME = '';
 let MOD_ORG = '';
 let REPO = '';
 let DATA_REPO = '';
-let MAX_SIZE_PER_PAGE = 100;
+const MAX_SIZE_PER_PAGE = 100;
 
 let octokit = new Octokit();
 
@@ -195,13 +195,18 @@ export class GithubService {
   }
 
   fetchAllLabels(): Observable<Array<{}>> {
-    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: MAX_SIZE_PER_PAGE, headers: GithubService.IF_NONE_MATCH_EMPTY}))
-      .pipe(
-        map(response => {
-          return response['data'];
-        }),
-        catchError(err => throwError('Failed to fetch labels.'))
-      );
+    return from(octokit.issues.listLabelsForRepo({
+      owner: ORG_NAME,
+      repo: REPO,
+      per_page: MAX_SIZE_PER_PAGE,
+      headers: GithubService.IF_NONE_MATCH_EMPTY
+    }))
+    .pipe(
+      map(response => {
+        return response['data'];
+      }),
+      catchError(err => throwError('Failed to fetch labels.'))
+    );
   }
 
   /**

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -34,6 +34,8 @@ let ORG_NAME = '';
 let MOD_ORG = '';
 let REPO = '';
 let DATA_REPO = '';
+let MAX_SIZE_PER_PAGE = 100;
+
 let octokit = new Octokit();
 
 @Injectable({
@@ -193,7 +195,7 @@ export class GithubService {
   }
 
   fetchAllLabels(): Observable<Array<{}>> {
-    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: 100, headers: GithubService.IF_NONE_MATCH_EMPTY}))
+    return from(octokit.issues.listLabelsForRepo({owner: ORG_NAME, repo: REPO, per_page: MAX_SIZE_PER_PAGE, headers: GithubService.IF_NONE_MATCH_EMPTY}))
       .pipe(
         map(response => {
           return response['data'];


### PR DESCRIPTION
Summary:
Fixes #693 and Fixes #694

Description:
- Set number of labels retrieved in a single fetch to 100

```
Increase number of labels in a single fetch to maximum 

There is no number of labels defined in a single fetch, resulting it to 
fetch a default number of 30 labels in a single fetch

Setting the value of labels to 100 (The maximum) will allow us to fetch 
all labels in a repository and solve the label synchronization issue

Let's set the value of the number of labels to be retrieved in a single 
fetch to be the maximum
```