### PR TITLE
Web version auth: redirect to GitHub, instead of using pop-up

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -176,10 +176,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const org = window.localStorage.getItem('org');
     const dataRepo = window.localStorage.getItem('dataRepo');
     this.githubService.storeOrganizationDetails(org, dataRepo);
-    this.phaseService.storeSessionData().pipe(
-      throwIfFalse(isValidSession => isValidSession,
-                   () => new Error('Invalid Session'))
-    ).subscribe(() => {
+    this.phaseService.storeSessionData().subscribe(() => {
       this.authService.changeAuthState(AuthState.AwaitingAuthentication);
       this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
       this.userService.createUserModel(username).pipe(
@@ -211,7 +208,6 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.logger.info(`Selected Settings Repo: ${sessionInformation}`);
 
     this.phaseService.storeSessionData().subscribe(() => {
-
       try {
         this.authService.startOAuthProcess();
       } catch (error) {

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -98,8 +98,7 @@ export class AuthComponent implements OnInit, OnDestroy {
    */
   fetchAccessToken(oauthCode: string, state: string) {
     if (!this.authService.isReturnedStateSame(state)) {
-      this.logger.info(`Received incorrect state ${state}`);
-      this.authService.changeAuthState(AuthState.NotAuthenticated);
+      this.logger.info(`Received incorrect state ${state}, continue waiting for correct state`);
       return;
     }
 

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -84,8 +84,9 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.initAccessTokenSubscription();
     this.initAuthStateSubscription();
     this.initProfileForm();
-    if (oauthCode) { // In the web's oauth page
+    if (oauthCode) { // runs upon receiving oauthCode from the redirect
       this.authService.changeAuthState(AuthState.AwaitingAuthentication);
+      this.restoreOrgDetailsFromLocalStorage();
       this.logger.info('Obtained authorisation code from Github');
       this.fetchAccessToken(oauthCode, state);
     }
@@ -112,7 +113,6 @@ export class AuthComponent implements OnInit, OnDestroy {
           }
           this.authService.storeOAuthAccessToken(data.token);
           this.logger.info('Sucessfully obtained access token');
-          this.isReady = true;
         }
       )
       .catch(err => {
@@ -160,10 +160,6 @@ export class AuthComponent implements OnInit, OnDestroy {
    * @param username - The user to log in.
    */
   completeLoginProcess(username: string): void {
-    const org = window.localStorage.getItem('org');
-    const dataRepo = window.localStorage.getItem('dataRepo');
-    this.githubService.storeOrganizationDetails(org, dataRepo);
-    this.phaseService.setSessionData();
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
     this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
     this.userService.createUserModel(username).pipe(
@@ -249,6 +245,17 @@ export class AuthComponent implements OnInit, OnDestroy {
       return window.localStorage.getItem('org');
     }
     return this.getOrgDetails(sessionInformation);
+  }
+
+  /**
+   * Extracts organization and data repository details from local storage
+   * and restores them to CATcher.
+   */
+  private restoreOrgDetailsFromLocalStorage() {
+    const org = window.localStorage.getItem('org');
+    const dataRepo = window.localStorage.getItem('dataRepo');
+    this.githubService.storeOrganizationDetails(org, dataRepo);
+    this.phaseService.setSessionData();
   }
 
   /**

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -95,7 +95,6 @@ export class AuthService {
     this.authStateSource.next(newAuthState);
   }
 
-
   /**
    * Generates and assigns an unguessable random 'state' string to pass to Github for protection against cross-site request forgery attacks
    */
@@ -119,55 +118,20 @@ export class AuthService {
       this.electronService.sendIpcMessage('github-oauth', githubRepoPermission);
     } else {
       this.generateStateString();
-      this.createOauthWindow(encodeURI(
+      this.redirectToOAuthPage(encodeURI(
         `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
       ));
-      this.logger.info('Opening window for Github authentication');
+      this.logger.info('Redirecting for Github authentication');
     }
   }
 
   /**
-   * Will do a poll on whether the given window is closed.
-   * If it is closed and user is still not authenticated, change the auth status to not authenticated.
+   * Will redirect to GitHub OAuth page
    */
-  private confirmWindowClosed(window: Window): void {
-    const authService = this;
-    const pollTimer = window.setInterval(function() {
-      if (window.closed) {
-        window.clearInterval(pollTimer);
-        if (!authService.accessToken) {
-          authService.changeAuthState(AuthState.NotAuthenticated);
-        }
-      }
-    }, 1000);
-  }
-
-  /**
-   * Will create a web version of oauth window.
-   */
-  private createOauthWindow(
-    url: string,
-    width: number = 500,
-    height: number = 600,
-    left: number = 0,
-    top: number = 0
-  ): void {
+  private redirectToOAuthPage(url: string): void {
     if (url == null) {
       return;
     }
-    const options = `width=${width},height=${height},left=${left},top=${top}`;
-    const oauthWindow = window.open(`${url}`, 'Authorization', options);
-    const authService = this;
-
-    if (oauthWindow == null) {
-      throw new Error(this.ENABLE_POPUP_MESSAGE);
-    }
-
-    oauthWindow.addEventListener('unload', () => {
-      if (!oauthWindow.closed) {
-        // unload event could be triggered when there is a redirection, hence, a confirmation needed.
-        authService.confirmWindowClosed(oauthWindow);
-      }
-    });
+    window.location.href = url;
   }
 }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -100,10 +100,12 @@ export class AuthService {
    */
   generateStateString() {
     this.state = uuid();
+    sessionStorage.setItem('state', this.state);
   }
 
   isReturnedStateSame(returnedState: string): boolean {
-    return returnedState === this.state;
+    const state = sessionStorage.getItem('state');
+    return returnedState === state;
   }
 
   /**

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -77,9 +77,18 @@ export class PhaseService {
     return this.fetchSessionData().pipe(
       assertSessionDataIntegrity(),
       map((sessionData: SessionData) => {
+        localStorage.setItem('sessionData', JSON.stringify(sessionData));
         this.updateSessionParameters(sessionData);
       })
     );
+  }
+
+  /**
+   * Retrieves session data from local storage and update phase service with it.
+   */
+  setSessionData() {
+    const sessionData = JSON.parse(localStorage.getItem('sessionData'));
+    this.updateSessionParameters(sessionData);
   }
 
   /**


### PR DESCRIPTION
# Summary 

Addresses #710  

## Description 

On the web version, let's redirect users to the GitHub login within the same window, rather than opening a pop-up window for this.

This would make the app simpler and would eliminate conflicts arising from browser settings / pop-up blockers on the user's computers.

## Changes Made 

- Removed methods that correspond to opening or handling new windows (`listenForCloseOAuthWindowMessage`, `confirmWindowClosed`) as they are no longer necessary.
- Rewrite log messages to be more appropriate.
- Implement `redirectToOAuthPage` method as replacement for `createOauthWindow`.
- Persist `sessionInformation` in `localStorage` as the information is lost when we redirect to `GitHub` and then back to `CATcher`.
- Adapt existing methods to fit with the new workflow.

## Proposed Commit Message 
```
GitHub OAuth Redirect in The Same Window

Currently, CATcher will open a new window to visit
the OAuth authentication link, which will automatically
close when the authentication process has finished.

Let's make CATcher redirect to the authentication link
within the same window. This will make the workflow and
app simpler while also eliminate conflicts arising from
browser settings or pop-up blockers.
```