### PR TITLE
Make Download Log Button Appear Before Login

### DIFF
--- a/e2e/spec/login/login.e2e-spec.ts
+++ b/e2e/spec/login/login.e2e-spec.ts
@@ -10,7 +10,7 @@ describe("CATcher's Login Page", () => {
   });
 
   it('displays "CATcher" in header bar', async () => {
-    expect(await page.getTitle()).toEqual(`CATcher v${AppConfig.version}`);
+    expect(await page.getTitle()).toEqual(`CATcher v${AppConfig.version}\nreceipt`);
   });
 
   it('allows users to authenticate themselves', async () => {

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -23,8 +23,7 @@
   </div>
 
   <span style="flex: 1 1 auto"></span>
-  <button *ngIf="auth.isAuthenticated()" mat-button matTooltip="Download CATcher Log" (click)="this.loggingService.exportLogFile()">
-    Download Log
+  <button mat-button matTooltip="Download CATcher Log" (click)="this.loggingService.exportLogFile()">
     <mat-icon>receipt</mat-icon>
   </button>
   <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -23,7 +23,7 @@
   </div>
 
   <span style="flex: 1 1 auto"></span>
-  <button mat-button matTooltip="Download CATcher Log" (click)="this.loggingService.exportLogFile()">
+  <button mat-button matTooltip="Download CATcher Log" (click)="this.exportLogFile()">
     <mat-icon>receipt</mat-icon>
   </button>
   <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -31,7 +31,7 @@ export class HeaderComponent implements OnInit {
               public auth: AuthService,
               public phaseService: PhaseService,
               public userService: UserService,
-              private loggingService: LoggingService,
+              public loggingService: LoggingService,
               private location: Location,
               private githubEventService: GithubEventService,
               private issueService: IssueService,

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -31,7 +31,7 @@ export class HeaderComponent implements OnInit {
               public auth: AuthService,
               public phaseService: PhaseService,
               public userService: UserService,
-              public loggingService: LoggingService,
+              private loggingService: LoggingService,
               private location: Location,
               private githubEventService: GithubEventService,
               private issueService: IssueService,
@@ -155,5 +155,9 @@ export class HeaderComponent implements OnInit {
 
   logOut() {
     this.auth.logOut();
+  }
+
+  exportLogFile() {
+    this.loggingService.exportLogFile();
   }
 }


### PR DESCRIPTION
# Summary 

Addresses #652 

## Description 

Users are only able to download logs after they are logged in, which means we will not be able to view authentication logs when they cannot login in the first place.

We could make 'Download logs' button visible before login so users can download authentication logs even if they are unable to log in.

## Changes Made 

- Remove `isAuthenticated` conditional rendering for download logs in `header.component.html`.
- Only display the logo with its tooltip.

## Proposed Commit Message 
```
Make Download Log Button Appear Before Login

Currently, download logs are only available after
the user has logged in.

Let's make the download logs button available before
the user has logged in, so that we may attain
information about errors before authentication.
```