### PR TITLE
Fix assignees names displayed lowercase

### DIFF
--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -107,7 +107,10 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Tutor.toLowerCase())) {
         return;
       }
-      const tutor = entry[DataService.NAME].toLowerCase() in tutors ? tutors[entry[DataService.NAME].toLowerCase()] : {};
+      const tutor = entry[DataService.NAME].toLowerCase() in tutors 
+        ? tutors[entry[DataService.NAME].toLowerCase()] 
+        : {};
+
       tutor[entry[DataService.TEAM]] = 'true';
       tutors[entry[DataService.NAME].toLowerCase()] = tutor;
     });
@@ -155,7 +158,10 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
-      const team = entry[DataService.TEAM] in teams ? teams[entry[DataService.TEAM]] : {};
+      const team = entry[DataService.TEAM] in teams 
+        ? teams[entry[DataService.TEAM]] 
+        : {};
+        
       team[entry[DataService.NAME].toLowerCase()] = entry[DataService.NAME];
       teams[entry[DataService.TEAM]] = team;
     });

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -158,7 +158,7 @@ export class DataService {
         return;
       }
       const team = entry[TEAM] in teams ? teams[entry[TEAM]] : {};
-      team[entry[NAME].toLowerCase()] = 'true';
+      team[entry[NAME].toLowerCase()] = entry[NAME];
       teams[entry[TEAM]] = team;
     });
 
@@ -246,7 +246,7 @@ export class DataService {
     const teamIds = Object.keys(jsonTeamStructure);
     for (const teamId of teamIds) {
       const teamMembers = new Array<User>();
-      const teamMemberIds = Object.keys(jsonTeamStructure[teamId]);
+      const teamMemberIds = Object.values(jsonTeamStructure[teamId]);
       for (const teamMemberId of teamMemberIds) {
         teamMembers.push(<User>{loginId: teamMemberId, role: UserRole.Student});
       }

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -107,9 +107,7 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Tutor.toLowerCase())) {
         return;
       }
-      const tutor = entry[DataService.NAME].toLowerCase() in tutors
-        ? tutors[entry[DataService.NAME].toLowerCase()]
-        : {};
+      const tutor = tutors[entry[DataService.NAME].toLowerCase()] || {};
 
       tutor[entry[DataService.TEAM]] = 'true';
       tutors[entry[DataService.NAME].toLowerCase()] = tutor;
@@ -158,9 +156,7 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
-      const team = entry[DataService.TEAM] in teams
-        ? teams[entry[DataService.TEAM]]
-        : {};
+      const team = teams[entry[DataService.TEAM]] || {};
 
       team[entry[DataService.NAME].toLowerCase()] = entry[DataService.NAME];
       teams[entry[DataService.TEAM]] = team;

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -107,8 +107,8 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Tutor.toLowerCase())) {
         return;
       }
-      const tutor = entry[DataService.NAME].toLowerCase() in tutors 
-        ? tutors[entry[DataService.NAME].toLowerCase()] 
+      const tutor = entry[DataService.NAME].toLowerCase() in tutors
+        ? tutors[entry[DataService.NAME].toLowerCase()]
         : {};
 
       tutor[entry[DataService.TEAM]] = 'true';
@@ -158,10 +158,10 @@ export class DataService {
       if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
-      const team = entry[DataService.TEAM] in teams 
-        ? teams[entry[DataService.TEAM]] 
+      const team = entry[DataService.TEAM] in teams
+        ? teams[entry[DataService.TEAM]]
         : {};
-        
+
       team[entry[DataService.NAME].toLowerCase()] = entry[DataService.NAME];
       teams[entry[DataService.TEAM]] = team;
     });

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -12,6 +12,24 @@ import { Observable } from 'rxjs';
 export class DataService {
   public dataFile: DataFile;
 
+  public static ROLES: string = 'roles';
+  public static TEAM_STRUCTURE: string = 'team-structure';
+  public static STUDENTS_ALLOCATION: string = 'students-allocation';
+  public static TUTORS_ALLOCATION: string = 'tutors-allocation';
+  public static ADMINS_ALLOCATION: string = 'admins-allocation';
+
+  // CSV Headers
+  public static NAME = 'name';
+  public static TEAM = 'team';
+  public static ROLE = 'role';
+
+  // Team Notation
+  public static TEAM_ID = 'teamId';
+
+  public static STUDENTS =  'students';
+  public static TUTORS = 'tutors';
+  public static ADMINS = 'admins';
+
   constructor(private githubService: GithubService) {}
 
   /**
@@ -42,11 +60,11 @@ export class DataService {
     const jsonData: {} = {};
     const allCsvData: string = allCsvDataWrapper['data'];
 
-    jsonData['roles'] = this.parseRolesData(allCsvData);
-    jsonData['team-structure'] = this.parseTeamStructureData(allCsvData);
-    jsonData['students-allocation'] = this.parseStudentAllocation(allCsvData);
-    jsonData['tutors-allocation'] = this.parseTutorAllocation(allCsvData);
-    jsonData['admins-allocation'] = this.parseAdminAllocation(allCsvData);
+    jsonData[DataService.ROLES] = this.parseRolesData(allCsvData);
+    jsonData[DataService.TEAM_STRUCTURE] = this.parseTeamStructureData(allCsvData);
+    jsonData[DataService.STUDENTS_ALLOCATION] = this.parseStudentAllocation(allCsvData);
+    jsonData[DataService.TUTORS_ALLOCATION] = this.parseTutorAllocation(allCsvData);
+    jsonData[DataService.ADMINS_ALLOCATION] = this.parseAdminAllocation(allCsvData);
 
     return jsonData;
   }
@@ -58,9 +76,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseAdminAllocation(csvInput: string): {} {
-    // CSV Headers
-    const NAME = 'name';
-    const ROLE = 'role';
 
     const admins = {};
     let parsedCSV: {}[];
@@ -68,8 +83,8 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === UserRole.Admin.toLowerCase()) {
-        admins[entry[NAME].toLowerCase()] = {};
+      if (entry[DataService.ROLE] === UserRole.Admin.toLowerCase()) {
+        admins[entry[DataService.NAME].toLowerCase()] = {};
       }
     });
 
@@ -83,10 +98,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseTutorAllocation(csvInput: string): {} {
-    // CSV Headers
-    const NAME = 'name';
-    const TEAM = 'team';
-    const ROLE = 'role';
 
     const tutors = {};
     let parsedCSV: {}[];
@@ -94,12 +105,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (!(entry[ROLE] === UserRole.Tutor.toLowerCase())) {
+      if (!(entry[DataService.ROLE] === UserRole.Tutor.toLowerCase())) {
         return;
       }
-      const tutor = entry[NAME].toLowerCase() in tutors ? tutors[entry[NAME].toLowerCase()] : {};
-      tutor[entry[TEAM]] = 'true';
-      tutors[entry[NAME].toLowerCase()] = tutor;
+      const tutor = entry[DataService.NAME].toLowerCase() in tutors ? tutors[entry[DataService.NAME].toLowerCase()] : {};
+      tutor[entry[DataService.TEAM]] = 'true';
+      tutors[entry[DataService.NAME].toLowerCase()] = tutor;
     });
 
     return tutors;
@@ -112,12 +123,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseStudentAllocation(csvInput: string): {} {
-    // CSV Headers
-    const TEAM = 'team';
-    const NAME = 'name';
-    const ROLE = 'role';
-    // Team Notation
-    const TEAM_ID = 'teamId';
 
     const students = {};
     let parsedCSV: {}[];
@@ -125,12 +130,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (!(entry[ROLE] === UserRole.Student.toLowerCase())) {
+      if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
       const newStudent = {};
-      newStudent[TEAM_ID] = entry[TEAM];
-      students[entry[NAME].toLowerCase()] = newStudent;
+      newStudent[DataService.TEAM_ID] = entry[DataService.TEAM];
+      students[entry[DataService.NAME].toLowerCase()] = newStudent;
     });
 
     return students;
@@ -143,10 +148,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseTeamStructureData(csvInput: string): {} {
-    // CSV Headers
-    const TEAM = 'team';
-    const NAME = 'name';
-    const ROLE = 'role';
 
     const teams = {};
     let parsedCSV: {}[];
@@ -154,12 +155,12 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (!(entry[ROLE] === UserRole.Student.toLowerCase())) {
+      if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
-      const team = entry[TEAM] in teams ? teams[entry[TEAM]] : {};
-      team[entry[NAME].toLowerCase()] = entry[NAME];
-      teams[entry[TEAM]] = team;
+      const team = entry[DataService.TEAM] in teams ? teams[entry[DataService.TEAM]] : {};
+      team[entry[DataService.NAME].toLowerCase()] = entry[DataService.NAME];
+      teams[entry[DataService.TEAM]] = team;
     });
 
     return teams;
@@ -172,9 +173,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseRolesData(csvInput: string): {} {
-    // CSV Headers
-    const ROLE = 'role';
-    const NAME = 'name';
 
     const roles = {};
     const students = {};
@@ -185,18 +183,18 @@ export class DataService {
 
     // Formats the parsed information for easier app reading
     parsedCSV.forEach(entry => {
-      if (entry[ROLE] === UserRole.Student.toLowerCase()) {
-        students[entry[NAME].toLowerCase()] = 'true';
-      } else if (entry[ROLE] === UserRole.Tutor.toLowerCase()) {
-        tutors[entry[NAME].toLowerCase()] = 'true';
-      } else if (entry[ROLE] === UserRole.Admin.toLowerCase()) {
-        admins[entry[NAME].toLowerCase()] = 'true';
+      if (entry[DataService.ROLE] === UserRole.Student.toLowerCase()) {
+        students[entry[DataService.NAME].toLowerCase()] = 'true';
+      } else if (entry[DataService.ROLE] === UserRole.Tutor.toLowerCase()) {
+        tutors[entry[DataService.NAME].toLowerCase()] = 'true';
+      } else if (entry[DataService.ROLE] === UserRole.Admin.toLowerCase()) {
+        admins[entry[DataService.NAME].toLowerCase()] = 'true';
       }
     });
 
-    roles['students'] = students;
-    roles['tutors'] = tutors;
-    roles['admins'] = admins;
+    roles[DataService.STUDENTS] = students;
+    roles[DataService.TUTORS] = tutors;
+    roles[DataService.ADMINS] = admins;
 
     return roles;
   }
@@ -242,7 +240,7 @@ export class DataService {
   // returns a mapping from teamId to their respective team structure.
   private extractTeamStructure(jsonData: {}): Map<string, Team> {
     const teamStructure = new Map<string, Team>();
-    const jsonTeamStructure = jsonData['team-structure'];
+    const jsonTeamStructure = jsonData[DataService.TEAM_STRUCTURE];
     const teamIds = Object.keys(jsonTeamStructure);
     for (const teamId of teamIds) {
       const teamMembers = new Array<User>();

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -7,16 +7,15 @@ import { User, UserRole } from '../models/user.model';
 import { Observable } from 'rxjs';
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class DataService {
-  public dataFile: DataFile;
 
-  public static ROLES: string = 'roles';
-  public static TEAM_STRUCTURE: string = 'team-structure';
-  public static STUDENTS_ALLOCATION: string = 'students-allocation';
-  public static TUTORS_ALLOCATION: string = 'tutors-allocation';
-  public static ADMINS_ALLOCATION: string = 'admins-allocation';
+  public static ROLES = 'roles';
+  public static TEAM_STRUCTURE  = 'team-structure';
+  public static STUDENTS_ALLOCATION = 'students-allocation';
+  public static TUTORS_ALLOCATION = 'tutors-allocation';
+  public static ADMINS_ALLOCATION = 'admins-allocation';
 
   // CSV Headers
   public static NAME = 'name';
@@ -26,9 +25,11 @@ export class DataService {
   // Team Notation
   public static TEAM_ID = 'teamId';
 
-  public static STUDENTS =  'students';
+  public static STUDENTS = 'students';
   public static TUTORS = 'tutors';
   public static ADMINS = 'admins';
+
+  public dataFile: DataFile;
 
   constructor(private githubService: GithubService) {}
 
@@ -76,13 +77,12 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseAdminAllocation(csvInput: string): {} {
-
     const admins = {};
     let parsedCSV: {}[];
     parsedCSV = this.csvParser(csvInput);
 
     // Formats the parsed information for easier app reading
-    parsedCSV.forEach(entry => {
+    parsedCSV.forEach((entry) => {
       if (entry[DataService.ROLE] === UserRole.Admin.toLowerCase()) {
         admins[entry[DataService.NAME].toLowerCase()] = {};
       }
@@ -98,13 +98,12 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseTutorAllocation(csvInput: string): {} {
-
     const tutors = {};
     let parsedCSV: {}[];
     parsedCSV = this.csvParser(csvInput);
 
     // Formats the parsed information for easier app reading
-    parsedCSV.forEach(entry => {
+    parsedCSV.forEach((entry) => {
       if (!(entry[DataService.ROLE] === UserRole.Tutor.toLowerCase())) {
         return;
       }
@@ -123,13 +122,12 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseStudentAllocation(csvInput: string): {} {
-
     const students = {};
     let parsedCSV: {}[];
     parsedCSV = this.csvParser(csvInput);
 
     // Formats the parsed information for easier app reading
-    parsedCSV.forEach(entry => {
+    parsedCSV.forEach((entry) => {
       if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
@@ -148,13 +146,12 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseTeamStructureData(csvInput: string): {} {
-
     const teams = {};
     let parsedCSV: {}[];
     parsedCSV = this.csvParser(csvInput);
 
     // Formats the parsed information for easier app reading
-    parsedCSV.forEach(entry => {
+    parsedCSV.forEach((entry) => {
       if (!(entry[DataService.ROLE] === UserRole.Student.toLowerCase())) {
         return;
       }
@@ -173,7 +170,6 @@ export class DataService {
    * @return admins - object that represents parsed csv data.
    */
   private parseRolesData(csvInput: string): {} {
-
     const roles = {};
     const students = {};
     const tutors = {};
@@ -182,7 +178,7 @@ export class DataService {
     parsedCSV = this.csvParser(csvInput);
 
     // Formats the parsed information for easier app reading
-    parsedCSV.forEach(entry => {
+    parsedCSV.forEach((entry) => {
       if (entry[DataService.ROLE] === UserRole.Student.toLowerCase()) {
         students[entry[DataService.NAME].toLowerCase()] = 'true';
       } else if (entry[DataService.ROLE] === UserRole.Tutor.toLowerCase()) {
@@ -207,15 +203,15 @@ export class DataService {
    * @return - Subjects that tracks the parsed data.
    */
   private csvParser(csvText: string): {}[] {
-    const lines = csvText.split('\n').filter(v => v.trim());
-    const headers = lines[0].split(',').map(h => h.trim());
+    const lines = csvText.split('\n').filter((v) => v.trim());
+    const headers = lines[0].split(',').map((h) => h.trim());
     const result = [];
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (!line) {
         continue;
       }
-      const lineValues = line.split(',').map(v => v.trim());
+      const lineValues = line.split(',').map((v) => v.trim());
       const lineObj = {};
       for (let j = 0; j < headers.length; j++) {
         if (!lineValues[j]) {
@@ -242,14 +238,14 @@ export class DataService {
     const teamStructure = new Map<string, Team>();
     const jsonTeamStructure = jsonData[DataService.TEAM_STRUCTURE];
     const teamIds = Object.keys(jsonTeamStructure);
-    for (const teamId of teamIds) {
-      const teamMembers = new Array<User>();
+
+    teamIds.forEach((teamId: string) => {
       const teamMemberIds = Object.values(jsonTeamStructure[teamId]);
-      for (const teamMemberId of teamMemberIds) {
-        teamMembers.push(<User>{loginId: teamMemberId, role: UserRole.Student});
-      }
-      teamStructure.set(teamId, new Team({id: teamId, teamMembers: teamMembers}));
-    }
+      const teamMembers: Array<User> = teamMemberIds.map((teamMemberId: string) => <User>{ loginId: teamMemberId, role: UserRole.Student });
+
+      teamStructure.set(teamId, new Team({ id: teamId, teamMembers: teamMembers }));
+    });
+
     return teamStructure;
   }
 

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -47,21 +47,21 @@ export class UserService {
     const userRole = this.parseUserRole(data, lowerCaseUserLoginId);
     switch (userRole) {
       case UserRole.Student:
-        const teamId = data['students-allocation'][lowerCaseUserLoginId]['teamId'];
-        const studentTeam = this.createTeamModel(data['team-structure'], teamId);
+        const teamId = data[DataService.STUDENTS_ALLOCATION][lowerCaseUserLoginId][DataService.TEAM_ID];
+        const studentTeam = this.createTeamModel(data[DataService.TEAM_STRUCTURE], teamId);
         return <User>{loginId: userLoginId, role: userRole, team: studentTeam};
 
       case UserRole.Tutor:
         const tutorTeams = new Array<Team>();
-        for (const allocatedTeamId of Object.keys(data['tutors-allocation'][lowerCaseUserLoginId])) {
-          tutorTeams.push(this.createTeamModel(data['team-structure'], allocatedTeamId));
+        for (const allocatedTeamId of Object.keys(data[DataService.TUTORS_ALLOCATION][lowerCaseUserLoginId])) {
+          tutorTeams.push(this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
         }
         return <User>{loginId: userLoginId, role: userRole, allocatedTeams: tutorTeams};
 
       case UserRole.Admin:
         const studentTeams = new Array<Team>();
-        for (const allocatedTeamId of Object.keys(data['admins-allocation'][lowerCaseUserLoginId])) {
-          studentTeams.push(this.createTeamModel(data['team-structure'], allocatedTeamId));
+        for (const allocatedTeamId of Object.keys(data[DataService.ADMINS_ALLOCATION][lowerCaseUserLoginId])) {
+          studentTeams.push(this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
         }
         return <User>{loginId: userLoginId, role: userRole, allocatedTeams: studentTeams};
       default:
@@ -85,13 +85,13 @@ export class UserService {
    */
   private parseUserRole(data: {}, userLoginId: string): UserRole {
     let userRole: UserRole;
-    if (data['roles']['students'] && data['roles']['students'][[userLoginId]]) {
+    if (data[DataService.ROLES][DataService.STUDENTS] && data[DataService.ROLES][DataService.STUDENTS][[userLoginId]]) {
       userRole = UserRole.Student;
     }
-    if (data['roles']['tutors'] && data['roles']['tutors'][[userLoginId]]) {
+    if (data[DataService.ROLES][DataService.TUTORS] && data[DataService.ROLES][DataService.TUTORS][[userLoginId]]) {
       userRole = UserRole.Tutor;
     }
-    if (data['roles']['admins'] && data['roles']['admins'][[userLoginId]]) {
+    if (data[DataService.ROLES][DataService.ADMINS] && data[DataService.ROLES][DataService.ADMINS][[userLoginId]]) {
       userRole = UserRole.Admin;
     }
     return userRole;

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -8,7 +8,7 @@ import { DataService } from './data.service';
 import { GithubUser } from '../models/github-user.model';
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class UserService {
   public currentUser: User;
@@ -32,7 +32,7 @@ export class UserService {
         this.currentUser = this.createUser(jsonData, userLoginId);
         return this.currentUser;
       }),
-      filter(user => user !== null),
+      filter((user) => user !== null),
       throwIfEmpty(() => new Error('Unauthorized user.'))
     );
   }
@@ -49,32 +49,32 @@ export class UserService {
       case UserRole.Student:
         const teamId = data[DataService.STUDENTS_ALLOCATION][lowerCaseUserLoginId][DataService.TEAM_ID];
         const studentTeam = this.createTeamModel(data[DataService.TEAM_STRUCTURE], teamId);
-        return <User>{loginId: userLoginId, role: userRole, team: studentTeam};
+        return <User>{ loginId: userLoginId, role: userRole, team: studentTeam };
 
       case UserRole.Tutor:
-        const tutorTeams = new Array<Team>();
-        for (const allocatedTeamId of Object.keys(data[DataService.TUTORS_ALLOCATION][lowerCaseUserLoginId])) {
-          tutorTeams.push(this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
-        }
-        return <User>{loginId: userLoginId, role: userRole, allocatedTeams: tutorTeams};
+        const tutorTeams: Array<Team> = Object.keys(
+          data[DataService.TUTORS_ALLOCATION][lowerCaseUserLoginId]
+        ).map((allocatedTeamId: string) => this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
+
+        return <User>{ loginId: userLoginId, role: userRole, allocatedTeams: tutorTeams };
 
       case UserRole.Admin:
-        const studentTeams = new Array<Team>();
-        for (const allocatedTeamId of Object.keys(data[DataService.ADMINS_ALLOCATION][lowerCaseUserLoginId])) {
-          studentTeams.push(this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
-        }
-        return <User>{loginId: userLoginId, role: userRole, allocatedTeams: studentTeams};
+        const studentTeams: Array<Team> = Object.keys(
+          data[DataService.ADMINS_ALLOCATION][lowerCaseUserLoginId]
+        ).map((allocatedTeamId: string) => this.createTeamModel(data[DataService.TEAM_STRUCTURE], allocatedTeamId));
+
+        return <User>{ loginId: userLoginId, role: userRole, allocatedTeams: studentTeams };
       default:
         return null;
     }
   }
 
   private createTeamModel(teamData: {}, teamId: string): Team {
-    const teammates = new Array<User>();
-    for (const teammate of Object.values(teamData[teamId])) {
-      teammates.push(<User>{loginId: teammate, role: UserRole.Student});
-    }
-    return new Team({id: teamId, teamMembers: teammates});
+    const teammates: Array<User> = Object.values(teamData[teamId]).map(
+      (teammate: string) => <User>{ loginId: teammate, role: UserRole.Student }
+    );
+
+    return new Team({ id: teamId, teamMembers: teammates });
   }
 
   /**

--- a/tests/constants/data.constants.ts
+++ b/tests/constants/data.constants.ts
@@ -34,12 +34,12 @@ export const jsonData = {
   },
   'team-structure': {
     'CS2103T-W12-3': {
-      junwei96: 'true',
-      '003-samuel': 'true',
-      damithc: 'true',
-      ptvrajsk: 'true'
+      junwei96: 'JunWei96',
+      '003-samuel': '003-samuel',
+      damithc: 'damithc',
+      ptvrajsk: 'ptvrajsk'
     },
-    'CS2103T-W12-4': { ronaklakhotia: 'true' }
+    'CS2103T-W12-4': { ronaklakhotia: 'RonakLakhotia' }
   },
   'students-allocation': {
     junwei96: { teamId: 'CS2103T-W12-3' },
@@ -60,7 +60,7 @@ export const jsonData = {
 export const TEAM_3 = new Team({
   id: 'CS2103T-W12-3',
   teamMembers: [
-    { loginId: 'junwei96', role: UserRole.Student },
+    { loginId: 'JunWei96', role: UserRole.Student },
     { loginId: '003-samuel', role: UserRole.Student },
     { loginId: 'damithc', role: UserRole.Student },
     { loginId: 'ptvrajsk', role: UserRole.Student }
@@ -69,11 +69,11 @@ export const TEAM_3 = new Team({
 
 export const TEAM_4 = new Team({
   id: 'CS2103T-W12-4',
-  teamMembers: [{ loginId: 'ronaklakhotia', role: UserRole.Student }]
+  teamMembers: [{ loginId: 'RonakLakhotia', role: UserRole.Student }]
 });
 
 export const USER_JUNWEI = {
-  loginId: 'junwei96',
+  loginId: 'JunWei96',
   role: UserRole.Student,
   team: TEAM_3
 };
@@ -109,13 +109,13 @@ export const dataFileTeamStructure: DataFile = {
       new Team({
         id: 'CS2103T-W12-3',
         teamMembers: [
-          { loginId: 'junwei96', role: UserRole.Student },
+          { loginId: 'JunWei96', role: UserRole.Student },
           { loginId: '003-samuel', role: UserRole.Student },
           { loginId: 'damithc', role: UserRole.Student },
           { loginId: 'ptvrajsk', role: UserRole.Student }
         ]
       })
     ],
-    ['CS2103T-W12-4', new Team({ id: 'CS2103T-W12-4', teamMembers: [{ loginId: 'ronaklakhotia', role: UserRole.Student }] })]
+    ['CS2103T-W12-4', new Team({ id: 'CS2103T-W12-4', teamMembers: [{ loginId: 'RonakLakhotia', role: UserRole.Student }] })]
   ])
 };

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -24,12 +24,15 @@ describe('UserService', () => {
       await createAndVerifyUser(USER_SHUMING.loginId, USER_SHUMING);
     });
 
-    it('treats the loginId in a case insensitive manner', async () => {
-      await createAndVerifyUser('JUNWEi96', USER_JUNWEI);
-    });
-
     it('assigns highest possible role to a user who has multiple roles in data.csv', async () => {
       await createAndVerifyUser(USER_WITH_TWO_ROLES.loginId, USER_WITH_TWO_ROLES);
+    });
+
+    it('User should should despite valid loginId not cast to lowercasing', () => {
+      const userService = new UserService(null, dataService);
+      userService.createUserModel(USER_JUNWEI.loginId).subscribe((user) => {
+        expect(user).toBeDefined();
+      });
     });
 
     it('throws an error if the user is unauthorized', (done) => {

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -28,7 +28,7 @@ describe('UserService', () => {
       await createAndVerifyUser(USER_WITH_TWO_ROLES.loginId, USER_WITH_TWO_ROLES);
     });
 
-    it('User should should authorized despite loginId being of different casing', () => {
+    it('should authorize User despite loginId being of different casing', () => {
       const userService = new UserService(null, dataService);
       userService.createUserModel(USER_JUNWEI.loginId).subscribe((user) => {
         expect(user).toBeDefined();

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -28,9 +28,13 @@ describe('UserService', () => {
       await createAndVerifyUser(USER_WITH_TWO_ROLES.loginId, USER_WITH_TWO_ROLES);
     });
 
-    it('User should should despite valid loginId not cast to lowercasing', () => {
+    it('User should should authorized despite loginId being of different casing', () => {
       const userService = new UserService(null, dataService);
       userService.createUserModel(USER_JUNWEI.loginId).subscribe((user) => {
+        expect(user).toBeDefined();
+      });
+
+      userService.createUserModel('JUNWEi96').subscribe((user) => {
         expect(user).toBeDefined();
       });
     });


### PR DESCRIPTION
### Summary:
Fixes #731

### Changes Made:
* Change parsing of csv file to store to store loginId in its original casing as value instead 
of dummy value of "true"
* Change loginId of users to use original casing only
* Remove casting to lower casing before createUser and do the casting under createUserModel
* Remove test case of loginId of irrelevant casing
* Add test case of user loginId with different casing still being authorized
* Refactoring of magic literals to be constatns
* Refactoring of for loops to use map and forEach

### Proposed Commit Message:
```
Fix casing of team members under assignees drop-down list

loginIds are casted to lowercase before being stored as keys in an 
javascript object to represent the teams structure after it is parsed 
by data.service.

The dropdown list under assignees is dependent on these keys to obtain 
the list of possible assignees, making it displayed in lowercase.

Let's obtain the list of possible assignees by using the original casing of
loginId in User.

This will allow us to display the assignee names under the dropdown 
list in its original casing.

Let's also add test cases to ensure the user is created regardless of 
letter case. 
```
