### PR TITLE
CommentEditor: Ignore HTML input

### DIFF
--- a/src/app/shared/lib/marked.ts
+++ b/src/app/shared/lib/marked.ts
@@ -15,7 +15,7 @@ export function markedOptionsFactory(): MarkedOptions {
     tables: true,
     breaks: false,
     pedantic: false,
-    sanitize: false,
+    sanitize: true,
     smartLists: true,
     smartypants: false,
   };


### PR DESCRIPTION
### Summary:
Fixes #277 #282 

### Changes Made:
* Turn on the option for `ngx-markdown` to sanitize HTML

### Proposed Commit Message:
```
Sanitize markdown text to escape HTML tags

Currently, HTML tags are rendered as-is inside
the issue description markdown text area.
Let's sanitize the markdown text area and
escape HTML tags.
```
