### PR TITLE
AuthComponent: Extract Confirm Login Logic Into a New Component

### DIFF
--- a/src/app/auth/auth.component.css
+++ b/src/app/auth/auth.component.css
@@ -50,18 +50,6 @@
   margin: 10px;
 }
 
-.logo {
-  align-items: center;
-  display: inline-flex;
-  margin: 0 3px 3px 3px
-}
-
-.github-logo {
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-}
-
 .login-with-oauth-btn {
   width: 100%;
 }

--- a/src/app/auth/auth.component.html
+++ b/src/app/auth/auth.component.html
@@ -39,11 +39,7 @@
     </div>
 
     <div *ngIf="!isUserAuthenticating()">
-      <button mat-stroked-button class="sign-in-button" color="primary" (click)="completeLoginProcess(currentUserName)"
-              [disabled]="isUserAuthenticating()">
-        <span class="logo"> <img class="github-logo" src="./assets/images/github-logo.png" alt="github-logo"> </span>
-        <span> Continue as {{this.currentUserName}} </span>
-      </button>
+      <app-auth-confirm-login [username]="currentUserName" [currentSessionOrg]="this.currentSessionOrg"></app-auth-confirm-login>
 
       <button *ngIf="electronService.isElectron()" mat-button style="margin-top: 10px; margin-bottom: 10px;" [disabled]="isUserAuthenticating()"
               (click)="logIntoAnotherAccount()"> Log in to another account </button>

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, NgZone, OnDestroy, OnInit } from '@angular/core';
+import { Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { AuthService, AuthState } from '../core/services/auth.service';
 import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -151,26 +151,6 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.profileForm.get('session').setValue(profile.repoName);
   }
 
-  /**
-   * Will complete the process of logging in the given user.
-   * @param username - The user to log in.
-   */
-  completeLoginProcess(username: string): void {
-    this.authService.changeAuthState(AuthState.AwaitingAuthentication);
-    this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
-    this.userService.createUserModel(username).pipe(
-      flatMap(() => this.phaseService.sessionSetup()),
-      flatMap(() => this.githubEventService.setLatestChangeEvent()),
-      flatMap(() => this.checkAppIsOutdated()),
-    ).subscribe(() => {
-      this.handleAuthSuccess();
-    }, (error) => {
-      this.authService.changeAuthState(AuthState.NotAuthenticated);
-      this.errorHandlingService.handleError(error);
-      this.logger.info(`Completion of login process failed with an error: ${error}`);
-    });
-  }
-
   setupSession() {
     if (this.profileForm.invalid) {
       return;
@@ -208,15 +188,6 @@ export class AuthComponent implements OnInit, OnDestroy {
   onGithubWebsiteClicked() {
     window.open('https://github.com/', '_blank');
     window.location.reload();
-  }
-
-  /**
-   * Handles the clean up required after authentication and setting up of user data is completed.
-   */
-  handleAuthSuccess() {
-    this.authService.setTitleWithPhaseDetail();
-    this.router.navigateByUrl(this.phaseService.currentPhase);
-    this.authService.changeAuthState(AuthState.Authenticated);
   }
 
   goToSessionSelect() {

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { SharedModule } from '../shared/shared.module';
 import { ProfilesComponent } from './profiles/profiles.component';
 import { JsonParseErrorDialogComponent } from './profiles/json-parse-error-dialog/json-parse-error-dialog.component';
 import { CommonModule } from '@angular/common';
+import { ConfirmLoginComponent } from './confirm-login/confirm-login.component';
 
 
 @NgModule({
@@ -16,7 +17,8 @@ import { CommonModule } from '@angular/common';
   declarations: [
     AuthComponent,
     ProfilesComponent,
-    JsonParseErrorDialogComponent
+    JsonParseErrorDialogComponent,
+    ConfirmLoginComponent
   ],
   entryComponents: [
     JsonParseErrorDialogComponent

--- a/src/app/auth/confirm-login/confirm-login.component.css
+++ b/src/app/auth/confirm-login/confirm-login.component.css
@@ -1,0 +1,18 @@
+.sign-in-button {
+  background: #f7fcfe;
+  line-height: 45px;
+  border: 1px solid currentColor;
+  width: 100%;
+}
+
+.logo {
+  align-items: center;
+  display: inline-flex;
+  margin: 0 3px 3px 3px
+}
+
+.github-logo {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+}

--- a/src/app/auth/confirm-login/confirm-login.component.html
+++ b/src/app/auth/confirm-login/confirm-login.component.html
@@ -1,0 +1,3 @@
+<p>
+  confirm-login works!
+</p>

--- a/src/app/auth/confirm-login/confirm-login.component.html
+++ b/src/app/auth/confirm-login/confirm-login.component.html
@@ -1,3 +1,4 @@
-<p>
-  confirm-login works!
-</p>
+<button mat-stroked-button class="sign-in-button" color="primary" (click)="this.completeLoginProcess()">
+  <span class="logo"> <img class="github-logo" src="./assets/images/github-logo.png" alt="github-logo"> </span>
+  <span> Continue as {{this.username}} </span>
+</button>

--- a/src/app/auth/confirm-login/confirm-login.component.spec.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmLoginComponent } from './confirm-login.component';
+
+describe('ConfirmLoginComponent', () => {
+  let component: ConfirmLoginComponent;
+  let fixture: ComponentFixture<ConfirmLoginComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ConfirmLoginComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmLoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -1,0 +1,64 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { flatMap } from 'rxjs/operators';
+import { AuthService, AuthState } from 'src/app/core/services/auth.service';
+import { ErrorHandlingService } from 'src/app/core/services/error-handling.service';
+import { GithubEventService } from 'src/app/core/services/githubevent.service';
+import { LoggingService } from 'src/app/core/services/logging.service';
+import { PhaseService } from 'src/app/core/services/phase.service';
+import { UserService } from 'src/app/core/services/user.service';
+import Observable from 'zen-observable-ts';
+
+const APPLICATION_VERSION_OUTDATED_ERROR = "Please update to the latest version of CATcher.";
+
+@Component({
+  selector: 'app-auth-confirm-login',
+  templateUrl: './confirm-login.component.html',
+  styleUrls: ['./confirm-login.component.css']
+})
+export class ConfirmLoginComponent implements OnInit {
+  @Input() username: string;
+  @Input() currentSessionOrg: string;
+  @Input() checkAppIsOutdated: () => Observable<any>;
+
+  constructor(private authService: AuthService,
+              private phaseService: PhaseService,
+              private userService: UserService,
+              private errorHandlingService: ErrorHandlingService,
+              private githubEventService: GithubEventService,
+              private logger: LoggingService,
+              private router: Router
+  ) { }
+
+  ngOnInit() { }
+
+  /**
+   * Handles the clean up required after authentication and setting up of user data is completed.
+   */
+  handleAuthSuccess() {
+    this.authService.setTitleWithPhaseDetail();
+    this.router.navigateByUrl(this.phaseService.currentPhase);
+    this.authService.changeAuthState(AuthState.Authenticated);
+  }
+
+  /**
+   * Will complete the process of logging in the given user.
+   * @param username - The user to log in.
+   */
+  completeLoginProcess(username: string): void {
+    this.authService.changeAuthState(AuthState.AwaitingAuthentication);
+    this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
+    this.userService.createUserModel(username).pipe(
+      flatMap(() => this.phaseService.sessionSetup()),
+      flatMap(() => this.githubEventService.setLatestChangeEvent()),
+      flatMap(() => this.checkAppIsOutdated()),
+    ).subscribe(() => {
+      this.handleAuthSuccess();
+    }, (error) => {
+      this.authService.changeAuthState(AuthState.NotAuthenticated);
+      this.errorHandlingService.handleError(error);
+      this.logger.info(`Completion of login process failed with an error: ${error}`);
+    });
+  }
+
+}

--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -1,13 +1,13 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { flatMap } from 'rxjs/operators';
-import { AuthService, AuthState } from 'src/app/core/services/auth.service';
-import { ErrorHandlingService } from 'src/app/core/services/error-handling.service';
-import { GithubEventService } from 'src/app/core/services/githubevent.service';
-import { LoggingService } from 'src/app/core/services/logging.service';
-import { PhaseService } from 'src/app/core/services/phase.service';
-import { UserService } from 'src/app/core/services/user.service';
-import Observable from 'zen-observable-ts';
+import { AuthService, AuthState } from '../../core/services/auth.service';
+import { ErrorHandlingService } from '../../core/services/error-handling.service';
+import { GithubEventService } from '../../core/services/githubevent.service';
+import { LoggingService } from '../../core/services/logging.service';
+import { PhaseService } from '../../core/services/phase.service';
+import { UserService } from '../../core/services/user.service';
+import { Observable } from 'rxjs';
 
 const APPLICATION_VERSION_OUTDATED_ERROR = "Please update to the latest version of CATcher.";
 
@@ -19,7 +19,6 @@ const APPLICATION_VERSION_OUTDATED_ERROR = "Please update to the latest version 
 export class ConfirmLoginComponent implements OnInit {
   @Input() username: string;
   @Input() currentSessionOrg: string;
-  @Input() checkAppIsOutdated: () => Observable<any>;
 
   constructor(private authService: AuthService,
               private phaseService: PhaseService,
@@ -51,7 +50,6 @@ export class ConfirmLoginComponent implements OnInit {
     this.userService.createUserModel(username).pipe(
       flatMap(() => this.phaseService.sessionSetup()),
       flatMap(() => this.githubEventService.setLatestChangeEvent()),
-      flatMap(() => this.checkAppIsOutdated()),
     ).subscribe(() => {
       this.handleAuthSuccess();
     }, (error) => {

--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -7,9 +7,6 @@ import { GithubEventService } from '../../core/services/githubevent.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
-import { Observable } from 'rxjs';
-
-const APPLICATION_VERSION_OUTDATED_ERROR = "Please update to the latest version of CATcher.";
 
 @Component({
   selector: 'app-auth-confirm-login',
@@ -42,12 +39,11 @@ export class ConfirmLoginComponent implements OnInit {
 
   /**
    * Will complete the process of logging in the given user.
-   * @param username - The user to log in.
    */
-  completeLoginProcess(username: string): void {
+  completeLoginProcess(): void {
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
-    this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
-    this.userService.createUserModel(username).pipe(
+    this.phaseService.setPhaseOwners(this.currentSessionOrg, this.username);
+    this.userService.createUserModel(this.username).pipe(
       flatMap(() => this.phaseService.sessionSetup()),
       flatMap(() => this.githubEventService.setLatestChangeEvent()),
     ).subscribe(() => {
@@ -58,5 +54,4 @@ export class ConfirmLoginComponent implements OnInit {
       this.logger.info(`Completion of login process failed with an error: ${error}`);
     });
   }
-
 }


### PR DESCRIPTION
### Summary:
Fixes #755 

### Changes Made:
* Create a new component named `ConfirmLoginComponent` under the `src/app/auth/confirm-login` directory.
* Move `completeLoginProcess` and `handleAuthSuccess` method from `AuthComponent` to `ConfirmLoginComponent`.
* Extract related view to `confirm-login.component.html`. 

### Proposed Commit Message:
```
Extract confirm login logic to new component

The authentication steps done when and after the confirm
login process is initiated is not related to OAuth.
Let's refactor the logic and its related view to a new 
component. This will further enforce single responsibility
principle, which increases overall code quality and
development experience.
```
