### PR TITLE
Allow HTML Tags in Sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/node": "~12.12.6",
     "angular-cli-ghpages": "^1.0.0-rc.1",
     "codelyzer": "~5.2.1",
+    "dompurify": "^2.3.1",
     "electron": "11.4.8",
     "electron-builder": "22.2.0",
     "electron-reload": "1.5.0",

--- a/src/app/shared/lib/marked.ts
+++ b/src/app/shared/lib/marked.ts
@@ -1,4 +1,5 @@
 import { MarkedOptions, MarkedRenderer } from "ngx-markdown";
+import DOMPurify from 'dompurify';
 
 export function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -16,6 +17,7 @@ export function markedOptionsFactory(): MarkedOptions {
     breaks: false,
     pedantic: false,
     sanitize: true,
+    sanitizer: DOMPurify.sanitize,
     smartLists: true,
     smartypants: false,
   };

--- a/src/app/shared/lib/marked.ts
+++ b/src/app/shared/lib/marked.ts
@@ -1,5 +1,5 @@
 import { MarkedOptions, MarkedRenderer } from "ngx-markdown";
-import DOMPurify from 'dompurify';
+import * as DOMPurify from 'dompurify';
 
 export function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();


### PR DESCRIPTION
### Summary:
Fixes #747 

### Changes Made:
* Add `DOMPurify` to the `sanitizer` entry in `MarkedOptions`.

### Proposed Commit Message:
```
Allow certain HTML tags in markdown

Currently, our markdown sanitizer blocks every HTML tags.
Let's change our sanitizer to those that allow safe HTML.
```
