### PR TITLE
Fix Display for Dropdown Label Text

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -304,7 +304,7 @@ export class LabelService {
    * @return the style with background-color in rgb
    * @throws exception if input is an invalid color code
    */
-  setLabelStyle(color: string) {
+  setLabelStyle(color: string, display: string = 'inline-flex') {
     let textColor: string;
 
     textColor = this.isDarkColor(color) ? COLOR_LIGHT_TEXT : COLOR_DARK_TEXT;
@@ -316,7 +316,7 @@ export class LabelService {
       'padding' : '3px',
       'color' : `#${textColor}`,
       'font-weight' : '410',
-      'display': 'inline-flex'
+      'display': display
     };
 
     return styles;

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="dropdownForm">
   <mat-form-field style="width: 100%;">
     <mat-select [ngClass]="dropdownTextColor" formControlName="{{attributeName}}" placeholder="{{this.labelService.getLabelTitle(attributeName)}}"
-      (selectionChange)="setSelectedLabelColor($event.value)" [ngStyle]="this.labelService.setLabelStyle(this.selectedColor)" required>
+      (selectionChange)="setSelectedLabelColor($event.value)" [ngStyle]="this.labelService.setLabelStyle(this.selectedColor, 'inline-block')" required>
       <mat-select-trigger>
         {{dropdownControl.value}}
       </mat-select-trigger>

--- a/tests/constants/label.constants.ts
+++ b/tests/constants/label.constants.ts
@@ -89,6 +89,16 @@ export const LIGHT_BG_DARK_TEXT = {
   display: 'inline-flex'
 };
 
+export const INLINE_BLOCK_TEXT = {
+  'background-color': `#${COLOR_WHITE}`,
+  'border-radius': '3px',
+  cursor: 'default',
+  padding: '3px',
+  color: `#${COLOR_BLACK}`,
+  'font-weight': '410',
+  display: 'inline-block'
+};
+
 export const RESPONSE_REJECTED_LABEL = new Label(RESPONSE, RESPONSE_REJECTED, COLOR_RESPONSE_REJECTED);
 export const STATUS_DONE_LABEL = new Label(STATUS, STATUS_DONE, COLOR_STATUS_DONE);
 

--- a/tests/services/label.service.spec.ts
+++ b/tests/services/label.service.spec.ts
@@ -132,6 +132,10 @@ describe('LabelService: setLabelStyle()', () => {
   it('should be light color background with dark color text', () => {
     expect(labelService.setLabelStyle(LabelConstant.COLOR_WHITE)).toEqual(LabelConstant.LIGHT_BG_DARK_TEXT);
   });
+
+  it('should be light color background with dark color text', () => {
+    expect(labelService.setLabelStyle(LabelConstant.COLOR_WHITE, 'inline-block')).toEqual(LabelConstant.INLINE_BLOCK_TEXT);
+  });
 });
 
 describe('LabelService: getColorOfLabel()', () => {


### PR DESCRIPTION
### Summary:
Fixes #776 

### Changes Made:
* Fixed display of dropdown value text for **severity** and **bug type** when creating 
new bug reports during the Bug Reporting Phase 
* Edits the `setLabelStyle` method to include a new parameter with regards to the 
display for the label 

### Proposed Commit Message:
```
Fix Display for Dropdown Label Text

During the Bug Reporting Phase, users are unable to see the selected 
values with regards to severity and the bug type for the new bug 
report that they are planning to submit 

Let's modify the setLabelStyle method such that we can modify the 
display of the label as when needed to fit display in both 
dropdown selectors and in the issue tables. 
```
