### PR TITLE
GitHub Actions: Use default GITHUB_TOKEN parameters 

### DIFF
--- a/.github/workflows/deployment-actions.yml
+++ b/.github/workflows/deployment-actions.yml
@@ -24,10 +24,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Deploy on Web
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
-          npm run deploy:web -- --repo=https://${{secrets.GH_TOKEN}}@github.com/CATcher-org/CATcher.git
+          npm run deploy:web -- --repo=https://x-access-token:$GITHUB_TOKEN@github.com/CATcher-org/CATcher.git
 
   draft_release:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Build
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:linux
@@ -101,7 +101,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Build
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:windows
@@ -130,7 +130,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Build
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:mac

--- a/.github/workflows/deployment-actions.yml
+++ b/.github/workflows/deployment-actions.yml
@@ -3,7 +3,7 @@
 # release assets for the four platforms 
 # (browser, Linux, Windows, MacOS) automatically
 
-name: Draft Deployment
+name: Version Deployment
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -71,8 +71,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:linux
@@ -100,8 +98,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:windows
@@ -129,8 +125,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Build
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
           npm run electron:mac

--- a/.github/workflows/deployment-staging.yml
+++ b/.github/workflows/deployment-staging.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Deploy on Staging Website
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
-          npm run deploy:staging -- --repo=https://${{secrets.GH_TOKEN}}@github.com/CATcher-org/CATcher-staging.git
+          npm run deploy:staging -- --repo=https://x-access-token:$GITHUB_TOKEN@github.com/seanlowjk/CATcher-staging.git

--- a/.github/workflows/deployment-staging.yml
+++ b/.github/workflows/deployment-staging.yml
@@ -27,4 +27,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install
-          npm run deploy:staging -- --repo=https://x-access-token:$GITHUB_TOKEN@github.com/seanlowjk/CATcher-staging.git
+          npm run deploy:staging -- --repo=https://x-access-token:$GITHUB_TOKEN@github.com/CATcher-org/CATcher-staging.git


### PR DESCRIPTION
### Summary:
Fixes #779

### Changes Made:
* Based on the discussion in #779, the default `$GITHUB_TOKEN` parameters can be used 
in each and every workflow. And as a result, reduce the need to generate our own personal
access tokens to be used in our GitHub Actions CI/CD Workfflow. 
* Refer to an example of a successful deployment [here](https://github.com/seanlowjk/CATcher-staging/actions/runs/1225959530)
* Refer to the modified log file in work [here](https://github.com/seanlowjk/CATcher-staging/actions/runs/1225959530/workflow)
* For desktop builds, it seems that the `GH_TOKEN` enviornment variable is not needed. 
As a result, I have removed them accordingly as well. 

### Proposed Commit Message:
```
GitHub Actions: Use default GITHUB_TOKEN parameters 

CATcher and CATcher-staging make use of Personal Access Tokens for 
regular and staging deployment. GitHub provides their own access
tokens per workflow such that organizations do not need to generate
access tokens manually.

Let's rollback to the default behavior of using Github's auto 
generated access tokens for regular and staging deployment. 
```
