### PR TITLE
Update Access Tokens URL

### DIFF
--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -7,7 +7,7 @@ const Logger = require('electron-log');
 
 const CLIENT_ID = '6750652c0c9001314434';
 const BASE_URL = 'https://github.com';
-const ACCESS_TOKEN_URL = 'https://catcher-proxy.herokuapp.com/authenticate';
+const ACCESS_TOKEN_URL = 'https://catcher-auth.herokuapp.com/authenticate';
 const CALLBACK_URL = 'http://localhost:4200';
 
 let authWindow;

--- a/src/environments/environment.gen.ts
+++ b/src/environments/environment.gen.ts
@@ -1,6 +1,6 @@
 const BaseConfig = {
   githubUrl: 'https://github.com',
-  accessTokenUrl: 'https://catcher-proxy.herokuapp.com/authenticate',
+  accessTokenUrl: 'https://catcher-auth.herokuapp.com/authenticate',
   clientDataUrl: 'https://raw.githubusercontent.com/CATcher-org/client_data/master/profiles-dev.json'
 };
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,7 +6,7 @@ export const AppConfig = {
   test: false,
   clientId: '5e1ed08cff7f0de1d68d',
   githubUrl: 'https://github.com',
-  accessTokenUrl: 'https://catcher-proxy.herokuapp.com/authenticate',
+  accessTokenUrl: 'https://catcher-auth.herokuapp.com/authenticate',
   clientDataUrl: 'https://raw.githubusercontent.com/CATcher-org/client_data/master/profiles.json',
   origin: 'https://catcher-org.github.io'
 };


### PR DESCRIPTION
### Summary:
Fixes #785

### Changes Made:
* Changes all instances of `catcher-proxy.herokuapp.com` to `catcher-auth.herokuapp.com`  
for new Access Token URL endpoints 

### Proposed Commit Message:
```
Update Access Tokens URL

As part of team restructuring, the old Access Tokens URL endpoint
should be deprecated. 

Let's update the Access Tokens URL endpoint so future developers
of CATcher are able to access and add features to this endpoint.
```
