### PR TITLE
Fixed Label Icon Display for Label Definitions

### DIFF
--- a/src/app/shared/issue/label/label.component.css
+++ b/src/app/shared/issue/label/label.component.css
@@ -10,24 +10,21 @@
 }
 
 .infoPopup {
+  background: transparent;
   border: none;
   outline: none;
   text-align: center;
 }
 
 .labelLine {
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1; 
-  flex-basis: auto; 
+  display: grid;
+  grid-template-columns: auto 20%;
 }
 
 .labelInfo {
-  flex-direction: row;
-  flex-grow: 1; 
-  flex-basis: auto; 
-}
-
-.labelInfo:nth-child(2) {
-  width: 80%;
+  display: grid;
+  grid-template-columns: 20% auto;
+  align-items: center;
+  text-align: left;
+  grid-gap: 20%;
 }

--- a/src/app/shared/issue/label/label.component.css
+++ b/src/app/shared/issue/label/label.component.css
@@ -10,12 +10,24 @@
 }
 
 .infoPopup {
-  cursor: pointer;
-  background-color: Transparent;
   border: none;
-  outline:none;
+  outline: none;
   text-align: center;
-  position: absolute;
-  right: 0px;
-  top: 30%;
+}
+
+.labelLine {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1; 
+  flex-basis: auto; 
+}
+
+.labelInfo {
+  flex-direction: row;
+  flex-grow: 1; 
+  flex-basis: auto; 
+}
+
+.labelInfo:nth-child(2) {
+  width: 80%;
 }

--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -5,19 +5,20 @@
 
 <mat-menu #labelList>
   <div mat-menu-item *ngFor="let value of labelValues;" [ngStyle]="{'padding-left': '15px', 'padding-right': '15px'}">
-    <button class="option"
-            (click)="updateLabel(value.labelValue)"
-            [disabled]="value.labelValue === this.issue[attributeName]">
-          <mat-icon [ngStyle]="{'color': '#' + value.labelColor, 'font-size' : '1.8em'}">stop</mat-icon>
-          <span> {{value.labelValue}}</span>
-          
-    </button>
+    <div class="labelLine">
+      <button class="labelInfo option"
+          (click)="updateLabel(value.labelValue)"
+          [disabled]="value.labelValue === this.issue[attributeName]">
+        <mat-icon [ngStyle]="{'color': '#' + value.labelColor, 'font-size' : '1.8em'}">stop</mat-icon>
+        <span> {{value.labelValue}}</span>
+      </button>
 
-    <button *ngIf="hasLabelDefinition(value)"
-            class="infoPopup"
-            (click)="openDefinitionPage(value); $event.stopPropagation();">
-      <mat-icon style="font-size: 20px">info</mat-icon>
-    </button>
+      <button *ngIf="hasLabelDefinition(value)"
+              class="infoPopup"
+              (click)="openDefinitionPage(value); $event.stopPropagation();">
+        <mat-icon style="font-size: 20px">info</mat-icon>
+      </button>
+    </div>
 
   </div>
 </mat-menu>

--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -4,8 +4,7 @@
 </button>
 
 <mat-menu #labelList>
-  <div mat-menu-item *ngFor="let value of labelValues;" [ngStyle]="{'padding-left': '15px', 'padding-right': '15px'}">
-    <div class="labelLine">
+  <div mat-menu-item class="labelLine" *ngFor="let value of labelValues;" [ngStyle]="{'padding-left': '15px', 'padding-right': '15px'}">
       <button class="labelInfo option"
           (click)="updateLabel(value.labelValue)"
           [disabled]="value.labelValue === this.issue[attributeName]">
@@ -18,7 +17,6 @@
               (click)="openDefinitionPage(value); $event.stopPropagation();">
         <mat-icon style="font-size: 20px">info</mat-icon>
       </button>
-    </div>
 
   </div>
 </mat-menu>

--- a/src/app/shared/label-dropdown/label-dropdown.component.css
+++ b/src/app/shared/label-dropdown/label-dropdown.component.css
@@ -7,24 +7,13 @@
 }
 
 .infoPopup {
+  background: transparent;
   border: none;
   outline: none;
   text-align: center;
 }
 
 .labelLine {
-  display: flex;
-  flex-direction: row;
-  flex-grow: 1; 
-  flex-basis: auto; 
-}
-
-.labelInfo {
-  flex-direction: row;
-  flex-grow: 1; 
-  flex-basis: auto; 
-}
-
-.labelInfo:nth-child(2) {
-  width: 80%;
+  display: grid;
+  grid-template-columns: auto 20%;
 }

--- a/src/app/shared/label-dropdown/label-dropdown.component.css
+++ b/src/app/shared/label-dropdown/label-dropdown.component.css
@@ -7,12 +7,24 @@
 }
 
 .infoPopup {
-  background-color: Transparent; 
   border: none;
   outline: none;
-  padding: 2px 2px;
   text-align: center;
-  position: absolute;
-  right: 1px;
-  top: 20%;
+}
+
+.labelLine {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1; 
+  flex-basis: auto; 
+}
+
+.labelInfo {
+  flex-direction: row;
+  flex-grow: 1; 
+  flex-basis: auto; 
+}
+
+.labelInfo:nth-child(2) {
+  width: 80%;
 }

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -6,14 +6,16 @@
         {{dropdownControl.value}}
       </mat-select-trigger>
       <div mat-menu-item *ngFor="let value of labelList">
-        <mat-option  [value]="value.labelValue" [ngStyle]="{'background': 'transparent'}">
-          <mat-icon [ngStyle]="{'color': '#' + value.labelColor}">stop</mat-icon>
-          <span> {{value.labelValue}}</span>
-        </mat-option>
+        <div class="labelLine">
+          <mat-option class="labelInfo" [value]="value.labelValue" [ngStyle]="{'background': 'transparent'}">
+            <mat-icon [ngStyle]="{'color': '#' + value.labelColor}">stop</mat-icon>
+            <span> {{value.labelValue}}</span>
+          </mat-option>
 
-        <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
-          <mat-icon style="font-size: 20px">info</mat-icon>
-        </button>
+          <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
+            <mat-icon style="font-size: 20px">info</mat-icon>
+          </button>
+        </div> 
         
       </div>
     </mat-select>

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -5,17 +5,15 @@
       <mat-select-trigger>
         {{dropdownControl.value}}
       </mat-select-trigger>
-      <div mat-menu-item *ngFor="let value of labelList">
-        <div class="labelLine">
-          <mat-option class="labelInfo" [value]="value.labelValue" [ngStyle]="{'background': 'transparent'}">
-            <mat-icon [ngStyle]="{'color': '#' + value.labelColor}">stop</mat-icon>
-            <span> {{value.labelValue}}</span>
-          </mat-option>
+      <div mat-menu-item class="labelLine" *ngFor="let value of labelList">
+        <mat-option [value]="value.labelValue" [ngStyle]="{'background': 'transparent'}">
+          <mat-icon [ngStyle]="{'color': '#' + value.labelColor}">stop</mat-icon>
+          <span> {{value.labelValue}}</span>
+        </mat-option>
 
-          <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
-            <mat-icon style="font-size: 20px">info</mat-icon>
-          </button>
-        </div> 
+        <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
+          <mat-icon style="font-size: 20px">info</mat-icon>
+        </button>
         
       </div>
     </mat-select>


### PR DESCRIPTION
### Summary:
Fixes #795, #796 and #797 

### Changes Made:
* Fixes the CSS of the info button for labels to use `grid` format. 

### Proposed Commit Message:
```
Fixed Label Icon Display for Label Definitions

There are major css issues with regards to the info buttons for the 
labels in the CATcher app when creating or editing an issue. 

Let's fix the CSS layout of the entire label-definition select 
option by formatting the HTML elements into a grid.
```