### PR TITLE
Include release branch in GH actions workflow

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -6,9 +6,9 @@ name: Get Code Coverage Report
 
 on:
   push:
-    branches: [master]
+    branches: [ master, release ]
   pull_request:
-    branches: [master]
+    branches: [ master, release ]
 
 jobs:
   code-coverage:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,9 +6,9 @@ name: Setup Builds and Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release ]
 
 jobs:
   linux-setup-and-tests:


### PR DESCRIPTION
### Summary:
This doesn't fix any issue as this is a hot fix PR 

### Changes Made:
* Added the target branches of  `release` to the GitHub Actions Pipeline 

### Proposed Commit Message:
```
Include release branch in GH actions workflow

The GitHub Actions pipeline on CATcher runs only on PRs targeted to
the master branch. 

Let's modify the configuration settings for the coverage-report and 
github-actions workflow files such that they both run for PRs 
targeted for merge into the release branch.
```