### PR TITLE
Remove GitHub API Calls for Moderation Phase check

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -159,6 +159,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
     this.phaseService.setPhaseOwners(this.currentSessionOrg, username);
     this.userService.createUserModel(username).pipe(
+      flatMap(() => this.phaseService.storeSessionData()),
       flatMap(() => this.phaseService.sessionSetup()),
       flatMap(() => this.githubEventService.setLatestChangeEvent()),
       flatMap(() => this.checkAppIsOutdated()),
@@ -186,17 +187,13 @@ export class AuthComponent implements OnInit, OnDestroy {
 
     this.logger.info(`Selected Settings Repo: ${sessionInformation}`);
 
-    this.phaseService.storeSessionData().subscribe(() => {
-      try {
-        this.authService.startOAuthProcess();
-      } catch (error) {
-        this.errorHandlingService.handleError(error);
-        this.authService.changeAuthState(AuthState.NotAuthenticated);
-      }
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
+    try {
+      this.authService.startOAuthProcess();
       this.isSettingUpSession = false;
-    }, () => this.isSettingUpSession = false);
+    } catch (error) {
+      this.errorHandlingService.handleError(error);
+      this.authService.changeAuthState(AuthState.NotAuthenticated);
+    }
   }
 
   logIntoAnotherAccount() {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -118,15 +118,14 @@ export class AuthService {
    */
   startOAuthProcess() {
     this.logger.info('Starting authentication');
-    const githubRepoPermission = this.phaseService.githubRepoPermissionLevel();
     this.changeAuthState(AuthState.AwaitingAuthentication);
 
     if (this.electronService.isElectron()) {
-      this.electronService.sendIpcMessage('github-oauth', githubRepoPermission);
+      this.electronService.sendIpcMessage('github-oauth', 'public_repo');
     } else {
       this.generateStateString();
       this.redirectToOAuthPage(encodeURI(
-        `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
+        `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=public_repo,read:user&state=${this.state}`
       ));
       this.logger.info('Redirecting for Github authentication');
     }

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -317,7 +317,7 @@ export class GithubService {
    * @return Promise<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
-    const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`
+    const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`;
 
     return from(fetch(github_api_link)
     .then(rawData => rawData.json())

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -314,14 +314,14 @@ export class GithubService {
 
   /**
    * Fetches the data file that is regulates session information.
-   * @return Observable<SessionData> representing session information.
+   * @return Promise<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
-    return from(octokit.repos.getContents({owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json',
-      headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
-        map(rawData => JSON.parse(atob(rawData['data']['content']))),
-      catchError(err => throwError('Failed to fetch settings file.'))
-    );
+    const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`
+
+    return from(fetch(github_api_link)
+    .then(rawData => rawData.json())
+    .then(jsonData => JSON.parse(atob(jsonData["content"]))));
   }
 
   fetchAuthenticatedUser(): Observable<GithubUser> {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -314,7 +314,7 @@ export class GithubService {
 
   /**
    * Fetches the data file that is regulates session information.
-   * @return Promise<SessionData> representing session information.
+   * @return Observable<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
     const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`;

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -317,14 +317,11 @@ export class GithubService {
    * @return Observable<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
-    const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`;
-
-    return from(fetch(github_api_link)
-    .then(rawData => rawData.json(),
-      (err) => throwError("Failed to retrieve settings file.")
-    ).then(jsonData => JSON.parse(atob(jsonData["content"])),
-      (err) => throwError("Failed to parse settings file.")
-    ));
+    return from(octokit.repos.getContents({owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json',
+      headers: GithubService.IF_NONE_MATCH_EMPTY})).pipe(
+        map(rawData => JSON.parse(atob(rawData['data']['content']))),
+      catchError(err => throwError('Failed to fetch settings file.'))
+    );
   }
 
   fetchAuthenticatedUser(): Observable<GithubUser> {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -320,8 +320,11 @@ export class GithubService {
     const github_api_link = `https://api.github.com/repos/${MOD_ORG}/${DATA_REPO}/contents/settings.json`;
 
     return from(fetch(github_api_link)
-    .then(rawData => rawData.json())
-    .then(jsonData => JSON.parse(atob(jsonData["content"]))));
+    .then(rawData => rawData.json(),
+      (err) => throwError("Failed to retrieve settings file.")
+    ).then(jsonData => JSON.parse(atob(jsonData["content"])),
+      (err) => throwError("Failed to parse settings file.")
+    ));
   }
 
   fetchAuthenticatedUser(): Observable<GithubUser> {

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { flatMap, map, retry, tap } from 'rxjs/operators';
-import { Observable, of, pipe } from 'rxjs';
+import { from, Observable, of, pipe } from 'rxjs';
 import { GithubService } from './github.service';
 import { LabelService } from './label.service';
 import { UserService } from './user.service';
@@ -97,6 +97,19 @@ export class PhaseService {
   }
 
   /**
+   * Gets the session data from local storage and returns it. 
+   */
+  getSessionData(): Observable<SessionData> {
+    if (localStorage.getItem('sessionData') === null) {
+      return from(localStorage.getItem('sessionData')).pipe(
+        map(data => JSON.parse(data) as SessionData)
+      )
+    } else {
+      return this.fetchSessionData();
+    }
+  }
+
+  /**
    * Checks if the necessary repository is available and creates it if the permissions are available.
    * @param sessionData
    */
@@ -130,7 +143,7 @@ export class PhaseService {
       );
     };
 
-    return this.fetchSessionData().pipe(
+    return this.getSessionData().pipe(
       assertSessionDataIntegrity(),
       flatMap((sessionData: SessionData) => {
         this.updateSessionParameters(sessionData);

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -144,9 +144,7 @@ export class PhaseService {
     };
 
     return this.getSessionData().pipe(
-      assertSessionDataIntegrity(),
       flatMap((sessionData: SessionData) => {
-        this.updateSessionParameters(sessionData);
         return this.verifySessionAvailability(sessionData);
       }),
       this.repoCreatorService.requestRepoCreationPermissions(this.currentPhase, this.sessionData[this.currentPhase]),

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -97,13 +97,13 @@ export class PhaseService {
   }
 
   /**
-   * Gets the session data from local storage and returns it. 
+   * Gets the session data from local storage and returns it.
    */
   getSessionData(): Observable<SessionData> {
     if (localStorage.getItem('sessionData') === null) {
       return from(localStorage.getItem('sessionData')).pipe(
         map(data => JSON.parse(data) as SessionData)
-      )
+      );
     } else {
       return this.fetchSessionData();
     }

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -97,18 +97,6 @@ export class PhaseService {
   }
 
   /**
-   * Determines the github's level of repo permission required for the phase.
-   * Ref: https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
-   */
-  githubRepoPermissionLevel(): string {
-    if (this.sessionData.openPhases.includes(Phase.phaseModeration)) {
-      return 'repo';
-    } else {
-      return 'public_repo';
-    }
-  }
-
-  /**
    * Checks if the necessary repository is available and creates it if the permissions are available.
    * @param sessionData
    */

--- a/tests/services/phase.service.spec.ts
+++ b/tests/services/phase.service.spec.ts
@@ -42,20 +42,6 @@ describe('PhaseService', () => {
     });
   });
 
-  describe('.githubRepoPermissionLevel()', () => {
-    it('should return "repo" if phaseModeration is included in openPhases', () => {
-      phaseService.sessionData = MODERATION_PHASE_SESSION_DATA;
-      expect(phaseService.sessionData.openPhases).toContain(Phase.phaseModeration);
-      expect(phaseService.githubRepoPermissionLevel()).toEqual('repo');
-    });
-
-    it('should return "public_repo" if phaseModeration is not included in openPhases', () => {
-      phaseService.sessionData = NO_OPEN_PHASES_SESSION_DATA;
-      expect(phaseService.sessionData.openPhases).not.toContain(Phase.phaseModeration);
-      expect(phaseService.githubRepoPermissionLevel()).toEqual('public_repo');
-    });
-  });
-
   describe('.reset()', () => {
     it('should reset the currentPhase of the PhaseService', () => {
       phaseService.currentPhase = Phase.phaseBugReporting;


### PR DESCRIPTION
### Summary:
1. Remove the call of fetching the `settings.json` file from the repository using unauthenticated GItHub API Calls. 
2. Removes duplicate calls of  `this.updateSessionParameters(sessionData);` 
3. Removes the moderation phase check as `settings.json` is not fetch before the OAuth process is started. 

### Proposed Commit Message:
```
Remove GitHub API Calls for Moderation Phase check

The application is making use of unauthenticated GitHub API Calls to
fetch the settings file, settings.json to assign the necessary permissions 
for the moderation phase, which uses a private repository. 

Let's remove these checks and unauthenticated GitHub API calls. 
```
