### PR TITLE
Increase upload limit to 11 MiB and 6 Mib

### DIFF
--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -14,7 +14,7 @@ export const FILE_TYPE_SUPPORT_ERROR = 'We don\'t support that file type.' +
  * @param size Number of MBs
  */
 export const getSizeExceedErrorMsg = (fileType: string, size: number): string =>
-  `Oops, ${fileType} is too big. Keep it under ${size}MB.`;
+  `Oops, ${fileType} is too big. Keep it under ${size}MiB.`;
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -10,10 +10,11 @@ import {
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 const BYTES_PER_MB = 1024 * 1024;
-const MAX_UPLOAD_SIZE = 11 * BYTES_PER_MB; // 11MB to allow 10.x MB
 const SHOWN_MAX_UPLOAD_SIZE_MB = 10;
-const MAX_VIDEO_UPLOAD_SIZE = 6 * BYTES_PER_MB; // 6MB to allow 5.x MB
 const SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB = 5;
+
+const MAX_UPLOAD_SIZE = (SHOWN_MAX_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 11MB to allow 10.x MB
+const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 6MB to allow 5.x MB
 
 @Component({
   selector: 'app-comment-editor',

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -9,9 +9,11 @@ import {
   UploadService } from '../../core/services/upload.service';
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
-const BYTES_PER_MB = 1000000;
-const MAX_UPLOAD_SIZE = 10 * BYTES_PER_MB; // 10MB
-const MAX_VIDEO_UPLOAD_SIZE = 5 * BYTES_PER_MB; // 5MB
+const BYTES_PER_MB = 1024 * 1024;
+const MAX_UPLOAD_SIZE = 11 * BYTES_PER_MB; // 11MB to allow 10.x MB
+const SHOWN_MAX_UPLOAD_SIZE_MB = 10;
+const MAX_VIDEO_UPLOAD_SIZE = 6 * BYTES_PER_MB; // 6MB to allow 5.x MB
+const SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB = 5;
 
 @Component({
   selector: 'app-comment-editor',
@@ -131,14 +133,12 @@ export class CommentEditorComponent implements OnInit {
     const insertedText = this.insertUploadingText(filename);
 
     if (file.size >= MAX_UPLOAD_SIZE) {
-      const uploadSizeLimitMb = MAX_UPLOAD_SIZE / BYTES_PER_MB;
-      this.handleUploadError(getSizeExceedErrorMsg('file', uploadSizeLimitMb), insertedText);
+      this.handleUploadError(getSizeExceedErrorMsg('file', SHOWN_MAX_UPLOAD_SIZE_MB), insertedText);
       return;
     }
 
     if (this.uploadService.isVideoFile(filename) && file.size >= MAX_VIDEO_UPLOAD_SIZE) {
-      const videoUploadSizeLimitMb = MAX_VIDEO_UPLOAD_SIZE / BYTES_PER_MB;
-      this.handleUploadError(getSizeExceedErrorMsg('video', videoUploadSizeLimitMb), insertedText);
+      this.handleUploadError(getSizeExceedErrorMsg('video', SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB), insertedText);
       return;
     }
 


### PR DESCRIPTION
### Summary:
Fixes #832

As seen below, it now accepts file sizes of < 11 MiB (and thus < 10 MiB instead of < 10 MB as well)
![image](https://user-images.githubusercontent.com/45702380/143517615-0f307566-00b3-484b-a69a-6a7c1e746b3f.png)


### Changes Made:
* As suggested by @dingyuchen, mb is changed to Mib which is 1024 * 1024.
* Notation in warning message is changed as well.
* Limit is also increased to allow for 10.x sizes as suggested by Prof @damithc 

### Proposed Commit Message:
```
File upload size limit might be ambiguous to some users.

Let's:
* Change notation from MB to MiB in warning message to reduce ambiguity
* Change upload limit from 10 -> 11 and 5 -> 6 to give users more leeway 
and to allow 10.x and 5.x sizes
* Use MiB sizes instead of MB sizes as they are used in Windows to avoid 
confusion
```
