### PR TITLE
Tester Response Phase: Align arrows for Issue Changes

### DIFF
--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -29,8 +29,8 @@
           <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
               {{issue.type || '-'}}
           </span>
-          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" style="display: inline; vertical-align:middle; padding: 1px 2px">
-            <mat-icon>arrow_right_alt</mat-icon>
+          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" style="display: inline; padding: 1px 2px">
+            <mat-icon style="vertical-align: middle;">arrow_right_alt</mat-icon>
           </span>
           <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))">
             {{issue.teamChosenType}}
@@ -45,8 +45,8 @@
       <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))">
         {{issue.severity || '-'}}
       </span>
-      <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" style="display: inline; vertical-align:middle; margin: 3px;">
-        <mat-icon>arrow_right_alt</mat-icon>
+      <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" style="display: inline; margin: 3px;">
+        <mat-icon style="vertical-align: middle;">arrow_right_alt</mat-icon>
       </span>
       <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenSeverity))">
         {{issue.teamChosenSeverity}}


### PR DESCRIPTION
### Summary:
Fixes #824

### Changes Made:
* Apply style to inner icon instead of the outer span
* Vertically aligns the arrow itself instead of the entire span div

Before:
![image](https://user-images.githubusercontent.com/45702380/143684778-2ceb2041-f8f2-4cea-8acc-dfb3d5815115.png)
After:
![image](https://user-images.githubusercontent.com/45702380/143684791-9f400808-d4ba-4cc3-9a29-0b9c39c2f9b1.png)

### Proposed Commit Message:
```
Tester Response Phase: Align arrows for Issue Changes

The arrows for Issue types and severity changes are not
vertically aligned.

Let's fix the alignment using vertical alignment. 
```
