### PR TITLE
Team Response Phase: Fix Auto-ticking of mixed case user names

### DIFF
--- a/src/app/shared/issue/assignee/assignee.component.html
+++ b/src/app/shared/issue/assignee/assignee.component.html
@@ -10,7 +10,7 @@
               [(ngModel)]="this.assignees">
     <mat-select-trigger>
     </mat-select-trigger>
-    <mat-option *ngFor="let assignee of teamMembers" [value]="assignee">{{assignee}}</mat-option>
+    <mat-option *ngFor="let assignee of teamMembers" [value]="assignee.toLowerCase()">{{assignee}}</mat-option>
   </mat-select>
 
   <p *ngIf="issue.assignees.length === 0" style="margin-top: 5px"> - </p>

--- a/tests/app/shared/issue/assignee/assignee.component.spec.ts
+++ b/tests/app/shared/issue/assignee/assignee.component.spec.ts
@@ -100,7 +100,11 @@ describe('AssigneeComponent', () => {
     addAssignee();
     dispatchClosedEvent();
 
-    expect(component.issueUpdated.emit).toHaveBeenCalledWith(jasmine.objectContaining({ assignees: [testStudent.loginId] }));
+    expect(component.issueUpdated.emit).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        assignees: [testStudent.loginId.toLowerCase()]
+      })
+    );
   });
 
   it('should show the updated assignees upon receiving an updated issue', () => {


### PR DESCRIPTION
### Summary:
Fixes #842

The issue was with `teamMembers` and `assignees` having a case mismatch.

https://user-images.githubusercontent.com/45702380/143726309-0716ec14-d323-4f1a-8fd4-b4a0d9d65111.mp4

### Changes Made:
Change assignees to match teamMembers' _lower_ case in the HTML for `mat-select`

### Proposed Commit Message:
```
Team Response Phase: Fix Auto-ticking of mixed case user names

Mixed case user names are not auto-ticked.

Let's auto-tick them for consistency.
```
