### PR TITLE
Unhide assignee/response fields for duplicate bugs

### DIFF
--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      <div class="container" [style.display]="duplicated.value ? 'none' : 'grid'">
+      <div class="container">
         <mat-form-field class="left-half">
           <mat-select placeholder="Assignees" formControlName="assignees" multiple>
             <mat-option *ngFor="let member of teamMembers" [value]="member">{{member}}</mat-option>


### PR DESCRIPTION
### Summary:
Fixes #838

### Changes Made:
* Unhides the assignee and response fields when the duplicate checkbox is checked.
<img width="1136" alt="Screen Shot 2021-12-01 at 11 23 32 PM" src="https://user-images.githubusercontent.com/54243224/144262248-3fce654f-18da-4897-9993-6cb791fd0904.png">

### Proposed Commit Message:
```
Unhide assignee and response fields for duplicate issues

Currently, when an issue is marked as a duplicate,
the assignee and response fields are hidden.

Users have to click into the issue again after submitting
the response before they can edit these values.

Let's unhide the assignee and response fields
when the duplicate checkbox is checked.
```
