### PR TITLE
Add confirmation dialog for cancelling edit

### DIFF
--- a/src/app/shared/issue/description/description.component.html
+++ b/src/app/shared/issue/description/description.component.html
@@ -31,7 +31,7 @@
                 mat-stroked-button color="primary">
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="cancelEditMode()">Cancel</button>
+        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="openCancelDialog()">Cancel</button>
       </div>
     </div>
   </div>

--- a/src/app/shared/issue/description/description.component.html
+++ b/src/app/shared/issue/description/description.component.html
@@ -23,6 +23,7 @@
                 mat-raised-button color="primary" (click)="viewChanges()">
           View Updated Description
         </button>
+        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="openCancelDialog()">Cancel</button>
         <button class="editor-action" *ngIf="conflict" type="submit" [disabled]="issueDescriptionForm.invalid || isSavePending"
                 mat-raised-button color="warn">
           {{ submitButtonText }}
@@ -31,7 +32,6 @@
                 mat-stroked-button color="primary">
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="openCancelDialog()">Cancel</button>
       </div>
     </div>
   </div>

--- a/src/app/shared/issue/description/description.component.ts
+++ b/src/app/shared/issue/description/description.component.ts
@@ -5,6 +5,7 @@ import { throwError } from 'rxjs';
 import { finalize, flatMap, map } from 'rxjs/operators';
 import { Conflict } from '../../../core/models/conflict/conflict.model';
 import { Issue } from '../../../core/models/issue.model';
+import { DialogService } from '../../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { IssueService } from '../../../core/services/issue.service';
 import { PermissionService } from '../../../core/services/permission.service';
@@ -29,12 +30,18 @@ export class DescriptionComponent implements OnInit {
   @Output() issueUpdated = new EventEmitter<Issue>();
   @Output() changeEditState = new EventEmitter<boolean>();
 
+  // Messages for the modal popup window upon cancelling edit
+  private readonly cancelEditModalMessages = ['Do you wish to cancel?', 'Your changes will be discarded.'];
+  private readonly yesButtonModalMessage = 'Cancel';
+  private readonly noButtonModalMessage = 'Continue editing';
+
   constructor(private issueService: IssueService,
               private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService,
               private dialog: MatDialog,
               private phaseService: PhaseService,
-              public permissions: PermissionService) {
+              public permissions: PermissionService,
+              private dialogService: DialogService) {
   }
 
   ngOnInit() {
@@ -101,6 +108,18 @@ export class DescriptionComponent implements OnInit {
     this.issueService.getIssue(this.issue.id).subscribe((issue: Issue) => {
       this.issueUpdated.emit(issue);
       this.resetToDefault();
+    });
+  }
+
+  openCancelDialog(): void {
+    const dialogRef = this.dialogService.openUserConfirmationModal(
+      this.cancelEditModalMessages, this.yesButtonModalMessage, this.noButtonModalMessage
+    );
+
+    dialogRef.afterClosed().subscribe(res => {
+      if (res) {
+        this.cancelEditMode();
+      }
     });
   }
 

--- a/src/app/shared/issue/title/title.component.html
+++ b/src/app/shared/issue/title/title.component.html
@@ -15,8 +15,8 @@
       </mat-error>
     </mat-form-field>
 
-    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="openCancelDialog()">Cancel</button>
     <button type="submit" [disabled]="issueTitleForm.invalid || isSavePending" mat-stroked-button color="primary"
             class="title-button">Save</button>
+    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="openCancelDialog()">Cancel</button>
   </form>
 </div>

--- a/src/app/shared/issue/title/title.component.html
+++ b/src/app/shared/issue/title/title.component.html
@@ -15,7 +15,7 @@
       </mat-error>
     </mat-form-field>
 
-    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="cancelEditMode()">Cancel</button>
+    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="openCancelDialog()">Cancel</button>
     <button type="submit" [disabled]="issueTitleForm.invalid || isSavePending" mat-stroked-button color="primary"
             class="title-button">Save</button>
   </form>

--- a/src/app/shared/issue/title/title.component.ts
+++ b/src/app/shared/issue/title/title.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, NgForm, Validators } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
 import { Issue } from '../../../core/models/issue.model';
+import { DialogService } from '../../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { IssueService } from '../../../core/services/issue.service';
 import { PermissionService } from '../../../core/services/permission.service';
@@ -20,11 +21,17 @@ export class TitleComponent implements OnInit {
   @Input() issue: Issue;
   @Output() issueUpdated = new EventEmitter<Issue>();
 
+  // Messages for the modal popup window upon cancelling edit
+  private readonly cancelEditModalMessages = ['Do you wish to cancel?', 'Your changes will be discarded.'];
+  private readonly yesButtonModalMessage = 'Cancel';
+  private readonly noButtonModalMessage = 'Continue editing';
+
   constructor(private issueService: IssueService,
               private formBuilder: FormBuilder,
               private errorHandlingService: ErrorHandlingService,
               public permissions: PermissionService,
-              public phaseService: PhaseService) {
+              public phaseService: PhaseService,
+              private dialogService: DialogService) {
   }
 
   ngOnInit() {
@@ -60,6 +67,18 @@ export class TitleComponent implements OnInit {
       form.resetForm();
     }, (error) => {
       this.errorHandlingService.handleError(error);
+    });
+  }
+
+  openCancelDialog(): void {
+    const dialogRef = this.dialogService.openUserConfirmationModal(
+      this.cancelEditModalMessages, this.yesButtonModalMessage, this.noButtonModalMessage
+    );
+
+    dialogRef.afterClosed().subscribe(res => {
+      if (res) {
+        this.cancelEditMode();
+      }
     });
   }
 }

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -1,7 +1,10 @@
 import { FormBuilder, NgForm } from '@angular/forms';
+import { MatDialogRef } from '@angular/material';
 import { of } from 'rxjs';
+import { UserConfirmationComponent } from '../../../../../src/app/core/guards/user-confirmation/user-confirmation.component';
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { Phase } from '../../../../../src/app/core/models/phase.model';
+import { DialogService } from '../../../../../src/app/core/services/dialog.service';
 import { PhaseService } from '../../../../../src/app/core/services/phase.service';
 import { DescriptionComponent } from '../../../../../src/app/shared/issue/description/description.component';
 import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.constants';
@@ -14,7 +17,7 @@ describe('DescriptionComponent', () => {
   let thisIssue: Issue;
   let dialog: any;
   let errorHandlingService: any;
-  let dialogService: any;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(() => {
     formBuilder = new FormBuilder();
@@ -123,11 +126,11 @@ describe('DescriptionComponent', () => {
     descriptionComponent.ngOnInit();
     descriptionComponent.changeToEditMode();
 
-    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) });
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) } as MatDialogRef<UserConfirmationComponent>);
     descriptionComponent.openCancelDialog();
     expect(cancelEditCall).toHaveBeenCalledTimes(0);
 
-    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) });
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) } as MatDialogRef<UserConfirmationComponent>);
     descriptionComponent.openCancelDialog();
     expect(cancelEditCall).toHaveBeenCalledTimes(1);
   });

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -102,7 +102,7 @@ describe('DescriptionComponent', () => {
     expect(resetCall).toHaveBeenCalledTimes(1);
   });
 
-  it('should reset updates if description edit is cancelled', () => {
+  it('should revert edits if edit mode is cancelled', () => {
     const issueUpdatedEmit = spyOn(descriptionComponent.issueUpdated, 'emit');
     const resetCall = spyOn(descriptionComponent, 'resetToDefault');
 

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -120,7 +120,7 @@ describe('DescriptionComponent', () => {
     expect(resetCall).toHaveBeenCalledTimes(1);
   });
 
-  it('should cancel editing only if confirmed on confirmation dialog', () => {
+  it('should cancel edit mode only if confirmed in confirmation dialog', () => {
     const cancelEditCall = spyOn(descriptionComponent, 'cancelEditMode');
 
     descriptionComponent.ngOnInit();

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -14,6 +14,7 @@ describe('DescriptionComponent', () => {
   let thisIssue: Issue;
   let dialog: any;
   let errorHandlingService: any;
+  let dialogService: any;
 
   beforeEach(() => {
     formBuilder = new FormBuilder();
@@ -23,8 +24,17 @@ describe('DescriptionComponent', () => {
     dialog = jasmine.createSpyObj('MatDialog', ['open']);
     errorHandlingService = jasmine.createSpyObj('ErrorHandlingService', ['handleError']);
     issueService = jasmine.createSpyObj('IssueService', ['getLatestIssue', 'updateIssue']);
+    dialogService = jasmine.createSpyObj('DialogService', ['openUserConfirmationModal']);
 
-    descriptionComponent = new DescriptionComponent(issueService, formBuilder, errorHandlingService, dialog, phaseService, null);
+    descriptionComponent = new DescriptionComponent(
+      issueService,
+      formBuilder,
+      errorHandlingService,
+      dialog,
+      phaseService,
+      null,
+      dialogService
+    );
     thisIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
     descriptionComponent.issue = thisIssue;
   });

--- a/tests/app/shared/issue/description/description.component.spec.ts
+++ b/tests/app/shared/issue/description/description.component.spec.ts
@@ -23,7 +23,7 @@ describe('DescriptionComponent', () => {
 
     dialog = jasmine.createSpyObj('MatDialog', ['open']);
     errorHandlingService = jasmine.createSpyObj('ErrorHandlingService', ['handleError']);
-    issueService = jasmine.createSpyObj('IssueService', ['getLatestIssue', 'updateIssue']);
+    issueService = jasmine.createSpyObj('IssueService', ['getIssue', 'getLatestIssue', 'updateIssue']);
     dialogService = jasmine.createSpyObj('DialogService', ['openUserConfirmationModal']);
 
     descriptionComponent = new DescriptionComponent(
@@ -100,5 +100,35 @@ describe('DescriptionComponent', () => {
     expect(formResetForm).toHaveBeenCalledTimes(1);
     expect(issueUpdatedEmit).toHaveBeenCalledTimes(1);
     expect(resetCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset updates if description edit is cancelled', () => {
+    const issueUpdatedEmit = spyOn(descriptionComponent.issueUpdated, 'emit');
+    const resetCall = spyOn(descriptionComponent, 'resetToDefault');
+
+    descriptionComponent.ngOnInit();
+    descriptionComponent.changeToEditMode();
+
+    issueService.getIssue.and.callFake((x: number) => of(thisIssue));
+    issueService.updateIssue.and.callFake((x: Issue) => of(x));
+    descriptionComponent.cancelEditMode();
+
+    expect(issueUpdatedEmit).toHaveBeenCalledTimes(1);
+    expect(resetCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cancel editing only if confirmed on confirmation dialog', () => {
+    const cancelEditCall = spyOn(descriptionComponent, 'cancelEditMode');
+
+    descriptionComponent.ngOnInit();
+    descriptionComponent.changeToEditMode();
+
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) });
+    descriptionComponent.openCancelDialog();
+    expect(cancelEditCall).toHaveBeenCalledTimes(0);
+
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) });
+    descriptionComponent.openCancelDialog();
+    expect(cancelEditCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/app/shared/issue/title/title.component.spec.ts
+++ b/tests/app/shared/issue/title/title.component.spec.ts
@@ -1,7 +1,10 @@
 import { FormBuilder, NgForm } from '@angular/forms';
+import { MatDialogRef } from '@angular/material';
 import { of } from 'rxjs';
+import { UserConfirmationComponent } from '../../../../../src/app/core/guards/user-confirmation/user-confirmation.component';
 import { Issue } from '../../../../../src/app/core/models/issue.model';
 import { Phase } from '../../../../../src/app/core/models/phase.model';
+import { DialogService } from '../../../../../src/app/core/services/dialog.service';
 import { PhaseService } from '../../../../../src/app/core/services/phase.service';
 import { TitleComponent } from '../../../../../src/app/shared/issue/title/title.component';
 import { ISSUE_WITH_EMPTY_DESCRIPTION } from '../../../../constants/githubissue.constants';
@@ -12,7 +15,7 @@ describe('TitleComponent', () => {
   let thisIssue: Issue;
   let formBuilder: any;
   let phaseService: PhaseService;
-  let dialogService: any;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(() => {
     formBuilder = new FormBuilder();
@@ -67,11 +70,11 @@ describe('TitleComponent', () => {
     titleComponent.ngOnInit();
     titleComponent.changeToEditMode();
 
-    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) });
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) } as MatDialogRef<UserConfirmationComponent>);
     titleComponent.openCancelDialog();
     expect(titleComponent.isEditing).toEqual(true);
 
-    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) });
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) } as MatDialogRef<UserConfirmationComponent>);
     titleComponent.openCancelDialog();
     expect(titleComponent.isEditing).toEqual(false);
   });

--- a/tests/app/shared/issue/title/title.component.spec.ts
+++ b/tests/app/shared/issue/title/title.component.spec.ts
@@ -62,4 +62,17 @@ describe('TitleComponent', () => {
     expect(titleComponentEmitter).toHaveBeenCalledTimes(1);
     expect(titleComponent.isEditing).toEqual(false);
   });
+
+  it('should cancel editing only if confirmed on confirmation dialog', () => {
+    titleComponent.ngOnInit();
+    titleComponent.changeToEditMode();
+
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(false) });
+    titleComponent.openCancelDialog();
+    expect(titleComponent.isEditing).toEqual(true);
+
+    dialogService.openUserConfirmationModal.and.returnValue({ afterClosed: () => of(true) });
+    titleComponent.openCancelDialog();
+    expect(titleComponent.isEditing).toEqual(false);
+  });
 });

--- a/tests/app/shared/issue/title/title.component.spec.ts
+++ b/tests/app/shared/issue/title/title.component.spec.ts
@@ -12,6 +12,7 @@ describe('TitleComponent', () => {
   let thisIssue: Issue;
   let formBuilder: any;
   let phaseService: PhaseService;
+  let dialogService: any;
 
   beforeEach(() => {
     formBuilder = new FormBuilder();
@@ -19,7 +20,8 @@ describe('TitleComponent', () => {
     phaseService.currentPhase = Phase.phaseTeamResponse;
 
     issueService = jasmine.createSpyObj('IssueService', ['updateIssue']);
-    titleComponent = new TitleComponent(issueService, formBuilder, null, null, phaseService);
+    dialogService = jasmine.createSpyObj('DialogService', ['openUserConfirmationModal']);
+    titleComponent = new TitleComponent(issueService, formBuilder, null, null, phaseService, dialogService);
     thisIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
     titleComponent.issue = thisIssue;
   });

--- a/tests/app/shared/issue/title/title.component.spec.ts
+++ b/tests/app/shared/issue/title/title.component.spec.ts
@@ -63,7 +63,7 @@ describe('TitleComponent', () => {
     expect(titleComponent.isEditing).toEqual(false);
   });
 
-  it('should cancel editing only if confirmed on confirmation dialog', () => {
+  it('should cancel edit mode only if confirmed in confirmation dialog', () => {
     titleComponent.ngOnInit();
     titleComponent.changeToEditMode();
 


### PR DESCRIPTION
### Summary:
Fixes #848 

### Changes Made:
* Adds a warning dialog that pops up when the user clicks 'Cancel' when editing an issue title/description.
<img width="314" alt="Screen Shot 2021-12-04 at 7 33 27 PM" src="https://user-images.githubusercontent.com/54243224/144708123-83d2bcd4-71a5-4dd0-aac0-1b3af3ba95d0.png">

* Swaps the positions of the 'Save' and 'Cancel' buttons.


### Proposed Commit Message:
```
Add confirmation dialog when cancelling edit

Currently, when editing an issue title/description,
clicking 'Cancel' immediately cancels the edit.

This might cause users who accidentally press 'Cancel'
to lose all their progress in writing the description.

Let's,
* add a warning dialog that pops up when users press 'Cancel'
* swap the positions of the 'Save' and 'Cancel' buttons.
```
