### PR TITLE
Allow duplicate issues to inherit labels/assignees from parent issue

### DIFF
--- a/src/app/shared/issue/assignee/assignee.component.html
+++ b/src/app/shared/issue/assignee/assignee.component.html
@@ -1,6 +1,6 @@
 <div>
   <span class="mat-title"> Assignees </span>
-  <button *ngIf="permissions.isIssueLabelsEditable() && isEditable" style="float: right" (click)="openSelector()" mat-icon-button>
+  <button *ngIf="permissions.isIssueLabelsEditable() && isEditable && !issue.duplicateOf" style="float: right" (click)="openSelector()" mat-icon-button>
     <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> edit </mat-icon>
   </button>
 

--- a/src/app/shared/issue/assignee/assignee.component.ts
+++ b/src/app/shared/issue/assignee/assignee.component.ts
@@ -57,9 +57,9 @@ export class AssigneeComponent implements OnInit {
     }, (error) => {
       this.errorHandlingService.handleError(error);
     });
-    // Update labels of duplicate issues
-    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues) => {
-      issues.forEach((issue) => {
+    // Update assignees of duplicate issues
+    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues: Issue[]) => {
+      issues.forEach((issue: Issue) => {
         const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
         newDuplicateIssue.assignees = this.assignees;
         this.issueService.updateIssue(newDuplicateIssue);

--- a/src/app/shared/issue/assignee/assignee.component.ts
+++ b/src/app/shared/issue/assignee/assignee.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MatSelect } from '@angular/material';
+import { first } from 'rxjs/operators';
 import { Issue } from '../../../core/models/issue.model';
 import { Team } from '../../../core/models/team.model';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
@@ -55,6 +56,14 @@ export class AssigneeComponent implements OnInit {
       this.issueUpdated.emit(updatedIssue);
     }, (error) => {
       this.errorHandlingService.handleError(error);
+    });
+    // Update labels of duplicate issues
+    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues) => {
+      issues.forEach((issue) => {
+        const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
+        newDuplicateIssue.assignees = this.assignees;
+        this.issueService.updateIssue(newDuplicateIssue);
+      });
     });
   }
 }

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -124,6 +124,13 @@ export class DuplicateOfComponent implements OnInit {
     const clone = this.issue.clone(this.phaseService.currentPhase);
     clone.duplicated = !!duplicateCheckboxEvent;
     clone.duplicateOf = duplicateCheckboxEvent ? duplicateCheckboxEvent.value : null;
+    if (duplicateCheckboxEvent) {
+      const duplicatedIssue = this.issueService.issues[clone.duplicateOf];
+      clone.severity = duplicatedIssue.severity;
+      clone.type = duplicatedIssue.type;
+      clone.assignees = duplicatedIssue.assignees;
+      clone.responseTag = duplicatedIssue.responseTag;
+    }
     clone.issueComment.description = clone.createGithubTeamResponse();
     return clone;
   }

--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -1,5 +1,5 @@
 <span class="mat-title"> {{this.labelService.getLabelTitle(attributeName)}} </span>
-<button *ngIf="permissions.isIssueLabelsEditable()" style="float: right" [matMenuTriggerFor]="labelList" mat-icon-button>
+<button *ngIf="permissions.isIssueLabelsEditable() && !issue.duplicateOf" style="float: right" [matMenuTriggerFor]="labelList" mat-icon-button>
   <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> edit </mat-icon>
 </button>
 

--- a/src/app/shared/issue/label/label.component.ts
+++ b/src/app/shared/issue/label/label.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { first } from 'rxjs/operators';
 import { DialogService } from '../../..//core/services/dialog.service';
 import { Issue } from '../../../core/models/issue.model';
 import { Label } from '../../../core/models/label.model';
@@ -49,6 +50,14 @@ export class LabelComponent implements OnInit, OnChanges {
       this.labelColor = this.labelService.getColorOfLabel(updatedIssue[this.attributeName]);
     }, (error) => {
       this.errorHandlingService.handleError(error);
+    });
+    // Update labels of duplicate issues
+    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues) => {
+      issues.forEach((issue) => {
+        const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
+        newDuplicateIssue[this.attributeName] = value;
+        this.issueService.updateIssue(newDuplicateIssue);
+      });
     });
   }
 

--- a/src/app/shared/issue/label/label.component.ts
+++ b/src/app/shared/issue/label/label.component.ts
@@ -52,8 +52,8 @@ export class LabelComponent implements OnInit, OnChanges {
       this.errorHandlingService.handleError(error);
     });
     // Update labels of duplicate issues
-    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues) => {
-      issues.forEach((issue) => {
+    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues: Issue[]) => {
+      issues.forEach((issue: Issue) => {
         const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
         newDuplicateIssue[this.attributeName] = value;
         this.issueService.updateIssue(newDuplicateIssue);

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -25,7 +25,7 @@
         </div>
       </div>
 
-      <div class="container">
+      <div class="container" [style.display]="duplicated.value ? 'none' : 'grid'">
         <div class="left-half">
           <app-label-dropdown [initialValue]="this.issue.severity" attributeName="severity" [dropdownForm]="newTeamResponseForm"></app-label-dropdown>
         </div>

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -118,12 +118,20 @@ export class NewTeamResponseComponent implements OnInit {
    */
   getUpdatedIssue(): Issue {
     const clone = this.issue.clone(this.phaseService.currentPhase);
-    clone.severity = this.severity.value;
-    clone.type = this.type.value;
-    clone.assignees = this.assignees.value;
-    clone.responseTag = this.responseTag.value;
     clone.duplicated = this.duplicated.value;
     clone.duplicateOf = this.duplicateOf.value;
+    if (clone.duplicated) {
+      const duplicatedIssue = this.issueService.issues[clone.duplicateOf];
+      clone.severity = duplicatedIssue.severity;
+      clone.type = duplicatedIssue.type;
+      clone.assignees = duplicatedIssue.assignees;
+      clone.responseTag = duplicatedIssue.responseTag;
+    } else {
+      clone.severity = this.severity.value;
+      clone.type = this.type.value;
+      clone.assignees = this.assignees.value;
+      clone.responseTag = this.responseTag.value;
+    }
     clone.status = STATUS.Done;
     clone.teamResponse = Issue.updateTeamResponse(this.description.value);
     return clone;

--- a/tests/app/shared/issue/assignee/assignee.component.spec.ts
+++ b/tests/app/shared/issue/assignee/assignee.component.spec.ts
@@ -116,6 +116,24 @@ describe('AssigneeComponent', () => {
     expect(matListText.innerText).toEqual(testStudent.loginId);
   });
 
+  it('should update assignees of duplicate issues', () => {
+    const duplicateIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
+    issueService.updateIssue.and.callFake((x: Issue) => of(x));
+    issueService.getDuplicateIssuesFor.and.returnValue(of([duplicateIssue]));
+
+    openMatSelect();
+    addAssignee();
+    dispatchClosedEvent();
+
+    const updatedIssue = dummyIssue.clone(phaseService.currentPhase);
+    updatedIssue.assignees = [testStudent.loginId.toLowerCase()];
+    const updatedDuplicateIssue = duplicateIssue.clone(phaseService.currentPhase);
+    updatedDuplicateIssue.assignees = [testStudent.loginId.toLowerCase()];
+
+    expect(issueService.updateIssue).toHaveBeenCalledWith(updatedIssue);
+    expect(issueService.updateIssue).toHaveBeenCalledWith(updatedDuplicateIssue);
+  });
+
   function openMatSelect(): void {
     const matSelectButton: HTMLElement = nativeElement.querySelector('button');
     matSelectButton.click();

--- a/tests/app/shared/issue/assignee/assignee.component.spec.ts
+++ b/tests/app/shared/issue/assignee/assignee.component.spec.ts
@@ -68,6 +68,7 @@ describe('AssigneeComponent', () => {
 
   beforeEach(() => {
     permissionsService.isIssueLabelsEditable.and.callFake(() => true);
+    issueService.getDuplicateIssuesFor.and.returnValue(of([]));
     fixture = TestBed.createComponent(AssigneeComponent);
     component = fixture.componentInstance;
 

--- a/tests/app/shared/issue/assignee/assignee.component.spec.ts
+++ b/tests/app/shared/issue/assignee/assignee.component.spec.ts
@@ -51,7 +51,7 @@ describe('AssigneeComponent', () => {
   });
 
   const phaseService: any = jasmine.createSpyObj('PhaseService', [], { currentPhase: Phase.phaseTeamResponse });
-  const issueService: any = jasmine.createSpyObj('IssueService', ['getLatestIssue', 'updateIssue']);
+  const issueService: any = jasmine.createSpyObj('IssueService', ['getDuplicateIssuesFor', 'getLatestIssue', 'updateIssue']);
   const permissionsService: any = jasmine.createSpyObj('PermissionService', ['isIssueLabelsEditable']);
 
   beforeEach(async(() => {

--- a/tests/app/shared/issue/label/label.component.spec.ts
+++ b/tests/app/shared/issue/label/label.component.spec.ts
@@ -54,4 +54,26 @@ describe('LabelComponent', () => {
     expect(labelComponent.labelValues).toEqual(SEVERITY_LABELS);
     expect(labelComponent.labelColor).toEqual(COLOR_SEVERITY_HIGH);
   });
+
+  it('should update labels of duplicate issues', () => {
+    labelService.getLabelList.and.returnValue(SEVERITY_LABELS);
+    labelService.getColorOfLabel.and.returnValue(COLOR_SEVERITY_LOW);
+    labelComponent.ngOnInit();
+    labelComponent.ngOnChanges();
+
+    phaseService.currentPhase.and.returnValue(Phase.phaseTeamResponse);
+    issueService.updateIssue.and.callFake((x: Issue) => of(x));
+
+    const duplicateIssue = Issue.createPhaseBugReportingIssue(ISSUE_WITH_EMPTY_DESCRIPTION);
+    issueService.getDuplicateIssuesFor.and.returnValue(of([duplicateIssue]));
+    labelComponent.updateLabel(SEVERITY_HIGH);
+
+    const updatedIssue = thisIssue.clone(phaseService.currentPhase);
+    updatedIssue.severity = SEVERITY_HIGH;
+    const updatedDuplicateIssue = duplicateIssue.clone(phaseService.currentPhase);
+    updatedDuplicateIssue.severity = SEVERITY_HIGH;
+
+    expect(issueService.updateIssue).toHaveBeenCalledWith(updatedIssue);
+    expect(issueService.updateIssue).toHaveBeenCalledWith(updatedDuplicateIssue);
+  });
 });

--- a/tests/app/shared/issue/label/label.component.spec.ts
+++ b/tests/app/shared/issue/label/label.component.spec.ts
@@ -17,7 +17,7 @@ describe('LabelComponent', () => {
 
   beforeEach(() => {
     labelService = jasmine.createSpyObj(LabelService, ['getLabelList', 'getColorOfLabel']);
-    issueService = jasmine.createSpyObj('IssueService', ['updateIssue']);
+    issueService = jasmine.createSpyObj('IssueService', ['getDuplicateIssuesFor', 'updateIssue']);
     phaseService = jasmine.createSpyObj(PhaseService, ['currentPhase']);
 
     labelComponent = new LabelComponent(issueService, null, phaseService, labelService, null, null);
@@ -47,6 +47,7 @@ describe('LabelComponent', () => {
     labelService.getColorOfLabel.and.returnValue(COLOR_SEVERITY_HIGH);
     phaseService.currentPhase.and.returnValue(Phase.phaseBugReporting);
     issueService.updateIssue.and.callFake((x: Issue) => of(x));
+    issueService.getDuplicateIssuesFor.and.returnValue(of([]));
     labelComponent.updateLabel(SEVERITY_HIGH);
 
     expect(issueUpdatedEmit).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Summary:
Fixes #838 

### Changes Made:
* Hides the severity/bug type/assignees/response label fields in the response form when a bug is marked as a duplicate.
<img width="1141" alt="Screen Shot 2021-12-12 at 4 20 57 PM" src="https://user-images.githubusercontent.com/54243224/145705742-e611709c-bbd0-417b-ada7-ee378e496886.png">

* Disables the editing of severity/bug type/assignees/response label on the view issue page if an issue is marked as a duplicate.
<img width="229" alt="Screen Shot 2021-12-12 at 4 19 46 PM" src="https://user-images.githubusercontent.com/54243224/145705746-6759e15e-1a1d-4622-807b-ac9df24365b3.png">

* Updates the severity/bug type/assignees/response label of an issue automatically if it is marked as a duplicate of another issue, or if the parent issue is edited.

### Proposed Commit Message:
```
Allow duplicate issues to inherit response from parent issue

Currently, when an issue is marked as a duplicate,
the severity/bug type/assignees/response label
still need to be filled in manually.

Users should not need to fill in these values as duplicate issues
should inherit these values from the parent issues.

Let's,
* hide these fields in the response form
* disable the editing of these fields on the view issue page
* update these fields automatically when editing the parent issue
if an issue is marked as a duplicate.
```
