### PR TITLE
Improve styling of no internet connection alert

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,4 @@
 <app-layout-header></app-layout-header>
-<div>
-  <p *ngIf="!(isNetworkOnline$ | async)">You are not connected to internet.</p>
-</div>
 
 <div class="container">
   <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,7 +10,7 @@ import { LoggingService } from './core/services/logging.service';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements AfterViewInit {
-  NOT_CONNECTED_ERROR: Error = {name: 'Not connected to internet', message: 'You are not connected to the internet.'};
+  NOT_CONNECTED_ERROR: Error = new Error("You are not connected to the internet.");
 
   constructor(public electronService: ElectronService, logger: LoggingService, public errorHandlingService: ErrorHandlingService) {
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { LoggingService } from './core/services/logging.service';
 })
 export class AppComponent implements AfterViewInit {
   isNetworkOnline$: Observable<boolean>;
-  NOT_CONNECTED_ERROR:Error = {name: 'Not connected to internet', message:'You are not connected to the internet.'};
+  NOT_CONNECTED_ERROR: Error = {name: 'Not connected to internet', message: 'You are not connected to the internet.'};
 
   constructor(public electronService: ElectronService, logger: LoggingService, public errorHandlingService: ErrorHandlingService) {
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,4 @@
 import { AfterViewInit, Component } from '@angular/core';
-import { fromEvent, merge, Observable, of } from 'rxjs';
-import { mapTo } from 'rxjs/operators';
 import { AppConfig } from '../environments/environment';
 import { ElectronService } from './core/services/electron.service';
 import { ErrorHandlingService } from './core/services/error-handling.service';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,6 @@ import { LoggingService } from './core/services/logging.service';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements AfterViewInit {
-  isNetworkOnline$: Observable<boolean>;
   NOT_CONNECTED_ERROR: Error = {name: 'Not connected to internet', message: 'You are not connected to the internet.'};
 
   constructor(public electronService: ElectronService, logger: LoggingService, public errorHandlingService: ErrorHandlingService) {
@@ -24,11 +23,6 @@ export class AppComponent implements AfterViewInit {
     } else {
       logger.info('Mode web');
     }
-    this.isNetworkOnline$ = merge(
-      of(navigator.onLine),
-      fromEvent(window, 'online').pipe(mapTo(true)),
-      fromEvent(window, 'offline').pipe(mapTo(false))
-    );
    }
 
   ngAfterViewInit() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { fromEvent, merge, Observable, of } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
 import { AppConfig } from '../environments/environment';
 import { ElectronService } from './core/services/electron.service';
+import { ErrorHandlingService } from './core/services/error-handling.service';
 import { LoggingService } from './core/services/logging.service';
 
 @Component({
@@ -12,8 +13,9 @@ import { LoggingService } from './core/services/logging.service';
 })
 export class AppComponent implements AfterViewInit {
   isNetworkOnline$: Observable<boolean>;
+  NOT_CONNECTED_ERROR:Error = {name: 'Not connected to internet', message:'You are not connected to the internet.'};
 
-  constructor(public electronService: ElectronService, logger: LoggingService) {
+  constructor(public electronService: ElectronService, logger: LoggingService, public errorHandlingService: ErrorHandlingService) {
 
     logger.info('AppConfig', AppConfig);
 
@@ -31,6 +33,7 @@ export class AppComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.addListenerForHttpLinks();
+    this.addListenerForNetworkOffline();
   }
 
   /**
@@ -45,6 +48,15 @@ export class AppComponent implements AfterViewInit {
         event.stopPropagation();
         this.electronService.openLink(elem.href);
       }
+    }, false);
+  }
+
+  /**
+   * This listener checks if CATcher has a connection to a network, and will show an error snackbar if it does not.
+   */
+  addListenerForNetworkOffline() {
+    window.addEventListener('offline', (event) => {
+      this.errorHandlingService.handleError(this.NOT_CONNECTED_ERROR);
     }, false);
   }
 }


### PR DESCRIPTION
### Summary:
Fixes #754

### Changes Made:
* Add listener for the offline event, and show an error snackbar when that happens
* Remove previous alert text

### Proposed Commit Message:
```
Improve styling of no internet connection alert

Currently, having no internet connection is indicated by a paragraph 
below the app header

Let's remove it, and instead trigger an error via the 
ErrorHandlingService to show an Error Snackbar
```