### PR TITLE
Improve viewing bug report on github ui

### DIFF
--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -112,10 +112,10 @@
   <ng-container matColumnDef="actions">
     <th mat-header-cell *matHeaderCellDef> Actions </th>
     <td mat-cell *matCellDef="let issue">
-      <button mat-button matTooltip="View this issue in web-browser" *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
+      <button mat-button matTooltip="View this issue on GitHub" *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
               (click)="this.viewIssueInBrowser(issue.id)" style="
               transform: scale(0.8)">
-        <mat-icon>link</mat-icon>
+        <mat-icon>open_in_new</mat-icon>
       </button>
       <button *ngIf="this.isResponseEditable() && !issue.status
        && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryEditIssue"

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -28,7 +28,7 @@
   </button>
   <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">
     View on GitHub
-    <mat-icon>link</mat-icon>
+    <mat-icon>open_in_new</mat-icon>
   </button>
   <button *ngIf="auth.isAuthenticated() && isReloadButtonShown() && !this.isReloadButtonDisabled"
     mat-button matTooltip="Synchronize with Github data" (click)="reload()">


### PR DESCRIPTION
### Summary:
Fixes #798

### Changes Made:
* Change "copy link" icon to "open in new tab" icon for header and issue table component.
* Change tool tip for the same button from "View this issue in web-browser" to "View this issue on GitHub"
* Before (issue table component):
![before](https://user-images.githubusercontent.com/47494777/145865473-61d4ea9c-d122-4f9d-b991-fb394be3c438.png)
* After (issue table component):
![after](https://user-images.githubusercontent.com/47494777/145865499-c224502c-291f-49c3-84cb-df287bc6bc50.png)
* Before (header):
![before](https://user-images.githubusercontent.com/47494777/145865959-d0a6f23f-9bf3-42fd-9ff8-5f338125e780.png)
* After (header):
![after](https://user-images.githubusercontent.com/47494777/146006067-e0518993-5bbc-40ae-909f-b42c05772fd4.png)

### Proposed Commit Message:
```
Improve viewing bug report on github ui

Currently, the icon and the tooltip for the "view bug report on github"
button is not intuitive and can cause confusion on whether the button
copies the link into the clipboard or open the link in a new tab.

Let's change the icon to the "open in new" icon from Material Icons
and make the tooltip/label clearer.
```
