### PR TITLE
Disable marking duplicated issue as duplicate

### DIFF
--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -25,6 +25,20 @@
         </div>
       </div>
 
+      <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length !== 0" class="container">
+        <span>
+          <mat-chip-list style="display: inline-block; margin-left: 5px;">
+            Duplicated by:
+            <mat-chip *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(this.issue) | async)"
+                      [routerLink]="['../' + duplicateIssue.id]"
+                      [matTooltip]="duplicateIssue.title" matTooltipPosition="above"
+                      style="font-size: 12px; cursor: pointer">
+              #{{duplicateIssue.id}}
+            </mat-chip>
+          </mat-chip-list>
+        </span>
+      </div>
+
       <div class="container">
         <div class="left-half">
           <app-label-dropdown [initialValue]="this.issue.severity" attributeName="severity" [dropdownForm]="newTeamResponseForm"></app-label-dropdown>

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -5,7 +5,7 @@
     </div>
 
     <div>
-      <div class="container">
+      <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length === 0" class="container">
         <div>
           <mat-checkbox style="display: inline-block; width: 20%" formControlName="duplicated" (change)="handleChangeOfDuplicateCheckbox($event)">
             A Duplicate Of:

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -26,15 +26,7 @@
       </div>
 
       <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length !== 0" class="container">
-        <mat-chip-list style="display: inline-block; margin-left: 5px;">
-          Duplicated by:
-          <mat-chip *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(this.issue) | async)"
-                    [routerLink]="['../' + duplicateIssue.id]"
-                    [matTooltip]="duplicateIssue.title" matTooltipPosition="above"
-                    style="font-size: 12px; cursor: pointer">
-            #{{duplicateIssue.id}}
-          </mat-chip>
-        </mat-chip-list>
+        <app-duplicated-issues-component  [issue]="this.issue"></app-duplicated-issues-component>
       </div>
 
       <div class="container">

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -26,17 +26,15 @@
       </div>
 
       <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length !== 0" class="container">
-        <span>
-          <mat-chip-list style="display: inline-block; margin-left: 5px;">
-            Duplicated by:
-            <mat-chip *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(this.issue) | async)"
-                      [routerLink]="['../' + duplicateIssue.id]"
-                      [matTooltip]="duplicateIssue.title" matTooltipPosition="above"
-                      style="font-size: 12px; cursor: pointer">
-              #{{duplicateIssue.id}}
-            </mat-chip>
-          </mat-chip-list>
-        </span>
+        <mat-chip-list style="display: inline-block; margin-left: 5px;">
+          Duplicated by:
+          <mat-chip *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(this.issue) | async)"
+                    [routerLink]="['../' + duplicateIssue.id]"
+                    [matTooltip]="duplicateIssue.title" matTooltipPosition="above"
+                    style="font-size: 12px; cursor: pointer">
+            #{{duplicateIssue.id}}
+          </mat-chip>
+        </mat-chip-list>
       </div>
 
       <div class="container">

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -5,7 +5,7 @@
     </div>
 
     <div>
-      <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length === 0" class="container">
+      <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length === 0; else displayDuplicates" class="container">
         <div>
           <mat-checkbox style="display: inline-block; width: 20%" formControlName="duplicated" (change)="handleChangeOfDuplicateCheckbox($event)">
             A Duplicate Of:
@@ -25,9 +25,11 @@
         </div>
       </div>
 
-      <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length !== 0" class="container">
-        <app-duplicated-issues-component  [issue]="this.issue"></app-duplicated-issues-component>
-      </div>
+      <ng-template #displayDuplicates>
+        <div class="container">
+          <app-duplicated-issues-component [issue]="this.issue"></app-duplicated-issues-component>
+        </div>
+      </ng-template>
 
       <div class="container">
         <div class="left-half">

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -32,7 +32,7 @@ export class NewTeamResponseComponent implements OnInit {
   @Input() issue: Issue;
   @Output() issueUpdated = new EventEmitter<Issue>();
 
-  constructor(private issueService: IssueService,
+  constructor(public issueService: IssueService,
               private formBuilder: FormBuilder,
               public labelService: LabelService,
               private errorHandlingService: ErrorHandlingService,


### PR DESCRIPTION
### Summary:
Fixes #851

### Changes Made:
* Disable marking a duplicated issue as a duplicate of another issue
* Use the duplicated-issues component to show the issues that are duplicates of the original issue

In this example, issues 7 and 8 are duplicates of issue 6:
<img width="1111" alt="Screenshot 2021-12-14 at 10 12 09 AM" src="https://user-images.githubusercontent.com/68138671/145921584-53872dbc-e436-42d8-8a58-929684e6d919.png">

Before:
<img width="935" alt="Screenshot 2021-12-14 at 10 19 32 AM" src="https://user-images.githubusercontent.com/68138671/145921961-56610324-ab62-4b2e-936b-42477f22f2cf.png">

After:
<img width="923" alt="Screenshot 2021-12-14 at 10 12 27 AM" src="https://user-images.githubusercontent.com/68138671/145921978-afb15e4b-c001-450e-8f41-339f9a240526.png">

Note that issues that have been responded to already disable marking them as duplicate, and already use the duplicated-issues component:
<img width="1106" alt="Screenshot 2021-12-14 at 10 18 43 AM" src="https://user-images.githubusercontent.com/68138671/145922430-14248e2a-10d4-46bc-9691-5b5cf632692d.png">

### Proposed Commit Message:
```
Disable marking duplicated issue as duplicate

Currently, it is possible to mark an already duplicated issue as a
duplicate of another issue, which causes the first issue to be
marked as faulty

Let's disable marking a duplicated issue as a duplicate, and instead
show the issues that are duplicating it
```
