### PR TITLE
Fix cursor position after pasting image

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -238,6 +238,8 @@ export class CommentEditorComponent implements OnInit {
     const startIndexOfString = this.commentField.value.indexOf(`[Uploading ${filename}...]`);
     const endIndexOfString = startIndexOfString + `[Uploading ${filename}...]`.length;
     const endOfInsertedString = startIndexOfString + `[${filename}](${uploadUrl})`.length;
+    const differenceInLength = endOfInsertedString - endIndexOfString;
+    const newCursorPosition = cursorPosition + differenceInLength;
 
     this.commentField.setValue(
       this.commentField.value.replace(`[Uploading ${filename}...]`, `[${filename}](${uploadUrl})`));
@@ -245,7 +247,7 @@ export class CommentEditorComponent implements OnInit {
     if (cursorPosition > startIndexOfString - 1 && cursorPosition <= endIndexOfString) { // within the range of uploading text
       this.commentTextArea.nativeElement.setSelectionRange(endOfInsertedString, endOfInsertedString);
     } else {
-      this.commentTextArea.nativeElement.setSelectionRange(cursorPosition, cursorPosition);
+      this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
     }
   }
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -239,16 +239,17 @@ export class CommentEditorComponent implements OnInit {
     const endIndexOfString = startIndexOfString + `[Uploading ${filename}...]`.length;
     const endOfInsertedString = startIndexOfString + `[${filename}](${uploadUrl})`.length;
     const differenceInLength = endOfInsertedString - endIndexOfString;
-    const newCursorPosition = cursorPosition + differenceInLength;
+    const newCursorPosition =
+      cursorPosition > startIndexOfString - 1 && cursorPosition <= endIndexOfString // within the range of uploading text
+        ? endOfInsertedString
+        : cursorPosition < startIndexOfString // before the uploading text
+        ? cursorPosition
+        : cursorPosition + differenceInLength; // after the uploading text
 
     this.commentField.setValue(
       this.commentField.value.replace(`[Uploading ${filename}...]`, `[${filename}](${uploadUrl})`));
 
-    if (cursorPosition > startIndexOfString - 1 && cursorPosition <= endIndexOfString) { // within the range of uploading text
-      this.commentTextArea.nativeElement.setSelectionRange(endOfInsertedString, endOfInsertedString);
-    } else {
-      this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
-    }
+    this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
   }
 
   private removeHighlightBorderStyle() {


### PR DESCRIPTION
### Summary:
Fixes #840 

### Changes Made:
* If the user continues typing after pasting an image, the cursor will not jump to the image url. Instead, it will remain as it is and it will not disrupt the user's typing. This is done by moving the cursor to the previous cursor position, but offset it by the difference between the length of the "Uploading" string and the actual image URL.

![changes](https://user-images.githubusercontent.com/47494777/146628188-78b2f839-9400-4d53-b90d-0c1d587e396f.gif)


### Proposed Commit Message:
```
Fix cursor position after pasting image

Currently, the user may experience inconvenience after pasting an image
into the comment editor, since the cursor may jump to the image url
after a successful upload. This occurs if the user continues to type
after pasting the image.

Let's fix this issue by changing the logic of calculating the new
position of the cursor after uploading an image.
```
