### PR TITLE
Fix response tag overlapping with assignee

### DIFF
--- a/src/app/shared/issue-tables/issue-tables.component.css
+++ b/src/app/shared/issue-tables/issue-tables.component.css
@@ -1,4 +1,6 @@
 .mat-table {
+  display: flex;
+  flex-wrap: wrap;
   min-width: 1000px;
 }
 
@@ -44,13 +46,11 @@
 }
 
 .mat-header-row {
-  display: inline-flex;
   column-gap: 10px;
   min-width: 100%;
 }
 
 .mat-row {
-  display: inline-flex;
   column-gap: 10px;
   min-width: 100%;
 }

--- a/src/app/shared/issue-tables/issue-tables.component.css
+++ b/src/app/shared/issue-tables/issue-tables.component.css
@@ -28,7 +28,7 @@
 }
 
 .mat-column-duplicatedIssues {
-  overflow-x: normal;
+  overflow-x: auto;
 }
 
 .mat-column-assignees {

--- a/src/app/shared/issue-tables/issue-tables.component.css
+++ b/src/app/shared/issue-tables/issue-tables.component.css
@@ -22,6 +22,7 @@
 }
 
 .mat-column-responseTag {
+  width: 12%;
 }
 
 .mat-column-severity {
@@ -29,6 +30,7 @@
 }
 
 .mat-column-duplicatedIssues {
+  width: 10%;
   padding-left: 25px;
 }
 

--- a/src/app/shared/issue-tables/issue-tables.component.css
+++ b/src/app/shared/issue-tables/issue-tables.component.css
@@ -10,33 +10,28 @@
 }
 
 .mat-column-id {
-  width: 6%;
+  flex: 0 1 5%;
 }
 
 .mat-column-title {
-  width: 20%;
-  padding: 0 10px 0 10px;
 }
 
 .mat-column-type {
+  overflow-x: auto;
 }
 
 .mat-column-responseTag {
-  width: 12%;
+  overflow-x: auto;
 }
 
 .mat-column-severity {
-  padding-left: 20px;
 }
 
 .mat-column-duplicatedIssues {
-  width: 10%;
-  padding-left: 25px;
+  overflow-x: normal;
 }
 
 .mat-column-assignees {
-  padding-left: 25px;
-  padding-right: 20px;
   word-wrap: normal;
 }
 
@@ -44,6 +39,18 @@
 }
 
 .mat-column-actions {
-  width: 20%;
+  overflow-x: auto;
   text-align: center !important;
+}
+
+.mat-header-row {
+  display: inline-flex;
+  column-gap: 10px;
+  min-width: 100%;
+}
+
+.mat-row {
+  display: inline-flex;
+  column-gap: 10px;
+  min-width: 100%;
 }

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -24,7 +24,7 @@
 
   <!-- Type Column -->
   <ng-container matColumnDef="type">
-    <mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '10%' : '15%'" *matHeaderCellDef mat-sort-header> Type </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Type </mat-header-cell>
     <mat-cell *matCellDef="let issue">
           <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
               {{issue.type || '-'}}
@@ -40,7 +40,7 @@
 
   <!-- Severity Column -->
   <ng-container matColumnDef="severity">
-    <mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '9%' : '12%'" *matHeaderCellDef mat-sort-header> Severity </mat-header-cell>
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Severity </mat-header-cell>
     <mat-cell *matCellDef="let issue">
       <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))">
         {{issue.severity || '-'}}
@@ -70,7 +70,7 @@
 
   <!--Assignee Column-->
   <ng-container matColumnDef="assignees">
-    <mat-header-cell [style.width]="userService.currentUser.role === 'Student' ? '15%' : '10%'" mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </mat-header-cell>
+    <mat-header-cell mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </mat-header-cell>
     <mat-cell *matCellDef="let issue">
         <span (click)="$event.stopPropagation()" style="cursor: default;" *ngIf="issue.assignees.length !== 0">
           {{issue.assignees.join(', ')}}

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -56,7 +56,7 @@
 
   <!--Response Tag Column-->
   <ng-container matColumnDef="responseTag">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
+    <th [style.width]="'12%'" mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
     <td mat-cell *matCellDef="let issue">
         <span (click)="$event.stopPropagation()" *ngIf="issue.responseTag"
               [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))">

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -1,31 +1,31 @@
-<table mat-table [dataSource]="this.issues" matSort class="mat-elevation-z8">
+<mat-table [dataSource]="this.issues" matSort class="mat-elevation-z8">
 
   <!-- ID Column -->
   <ng-container matColumnDef="id">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> ID </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> ID </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <span (click)="$event.stopPropagation()" style="cursor: default;">{{issue.id}}</span>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!-- Title Column -->
   <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Title </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Title </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <a class="no-underline link-grey-dark" [routerLink]="'issues/' + issue.id"> {{this.fitTitleText(issue.title)}} </a>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!-- Team Assigned Column -->
   <ng-container *ngIf="userService.currentUser.role !== 'Student'" matColumnDef="teamAssigned">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Team </th>
-    <td mat-cell *matCellDef="let issue"> {{ issue.teamAssigned && issue.teamAssigned.id || '-'}} </td>
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Team </mat-header-cell>
+    <mat-cell *matCellDef="let issue"> {{ issue.teamAssigned && issue.teamAssigned.id || '-'}} </mat-cell>
   </ng-container>
 
   <!-- Type Column -->
   <ng-container matColumnDef="type">
-    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '10%' : '15%'" *matHeaderCellDef mat-sort-header> Type </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '10%' : '15%'" *matHeaderCellDef mat-sort-header> Type </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
           <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
               {{issue.type || '-'}}
           </span>
@@ -35,13 +35,13 @@
           <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))">
             {{issue.teamChosenType}}
           </span>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!-- Severity Column -->
   <ng-container matColumnDef="severity">
-    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '9%' : '12%'" *matHeaderCellDef mat-sort-header> Severity </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '9%' : '12%'" *matHeaderCellDef mat-sort-header> Severity </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))">
         {{issue.severity || '-'}}
       </span>
@@ -51,13 +51,13 @@
       <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenSeverity))">
         {{issue.teamChosenSeverity}}
       </span>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!--Response Tag Column-->
   <ng-container matColumnDef="responseTag">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Response </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
         <span (click)="$event.stopPropagation()" *ngIf="issue.responseTag"
               [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))">
           {{issue.responseTag}}
@@ -65,12 +65,13 @@
       <span *ngIf="!issue.responseTag" style="margin-left: 10%">
           <mat-icon matTooltip="Should not be empty" matTooltipPosition="above" color="warn">warning</mat-icon>
         </span>
+    </mat-cell>
   </ng-container>
 
   <!--Assignee Column-->
   <ng-container matColumnDef="assignees">
-    <th [style.width]="userService.currentUser.role === 'Student' ? '15%' : '10%'" mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell [style.width]="userService.currentUser.role === 'Student' ? '15%' : '10%'" mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
         <span (click)="$event.stopPropagation()" style="cursor: default;" *ngIf="issue.assignees.length !== 0">
           {{issue.assignees.join(', ')}}
         </span>
@@ -78,12 +79,13 @@
           <mat-icon matTooltip="We strongly recommend assigning all issues to someone"
                     matTooltipPosition="above" style="color: #FFAB40;">warning</mat-icon>
         </span>
+    </mat-cell>
   </ng-container>
 
   <!-- Duplicated Issues Column -->
   <ng-container matColumnDef="duplicatedIssues">
-    <th mat-header-cell *matHeaderCellDef> Duplicates </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef> Duplicates </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <div *ngIf="(issueService.getDuplicateIssuesFor(issue) | async).length === 0">
         -
       </div>
@@ -94,24 +96,24 @@
           #{{duplicateIssue.id}}
         </mat-chip>
       </mat-chip-list>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!-- To do Column -->
   <ng-container matColumnDef="Todo Remaining">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Todo Remaining </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef mat-sort-header> Todo Remaining </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <span *ngIf="isTodoListChecked(issue) && issue.issueDisputes.length > 0"> <font color="green">All tasks are completed</font> </span>
       <span *ngIf="!isTodoListChecked(issue)"> <font color="red">{{ issue.issueDisputes.length - todoFinished(issue) }}/{{ issue.issueDisputes.length }} tasks pending.</font></span>
       <progress *ngIf="issue.issueDisputes.length > 0" value={{todoFinished(issue)}} max={{issue.issueDisputes.length}} role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></progress>
       <span *ngIf="issue.issueDisputes.length === 0"> No Todo List for this issue </span>
-    </td>
+    </mat-cell>
   </ng-container>
 
   <!-- Action Buttons Column -->
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef> Actions </th>
-    <td mat-cell *matCellDef="let issue">
+    <mat-header-cell *matHeaderCellDef> Actions </mat-header-cell>
+    <mat-cell *matCellDef="let issue">
       <button mat-button matTooltip="View this issue on GitHub" *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
               (click)="this.viewIssueInBrowser(issue.id)" style="
               transform: scale(0.8)">
@@ -149,12 +151,12 @@
       </button>
       <mat-spinner color="warn" [diameter]="25" style="display: inline; padding-right: 30px; margin-left: 5px"
                    *ngIf="issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)" ></mat-spinner>
-    </td>
+    </mat-cell>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="this.headers"></tr>
-  <tr mat-row *matRowDef="let issue; columns: this.headers;" (click)="this.logIssueEditRouting(issue.id)" [routerLink]="'issues/' + issue.id" style="cursor: pointer"></tr>
-</table>
+  <mat-header-row *matHeaderRowDef="this.headers"></mat-header-row>>
+  <mat-row *matRowDef="let issue; columns: this.headers;" (click)="this.logIssueEditRouting(issue.id)" [routerLink]="'issues/' + issue.id" style="cursor: pointer"></mat-row>
+</mat-table>
 <mat-card *ngIf="this.issues.isLoading$ | async"
           style="display: flex; justify-content: center; align-items: center">
   <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -56,7 +56,7 @@
 
   <!--Response Tag Column-->
   <ng-container matColumnDef="responseTag">
-    <th [style.width]="'12%'" mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
     <td mat-cell *matCellDef="let issue">
         <span (click)="$event.stopPropagation()" *ngIf="issue.responseTag"
               [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))">


### PR DESCRIPTION
### Summary:
Fixes #812 

### Changes Made:
* Remove native HTML table tags
* Remove width parameters for table
* Use flexbox to manage column widths
* Add horizontal scroll bars for columns that do not have enough space

Previously when the browser width is too narrow, the response column will overlap with the assignee column, as per the picture below:
<img width="1053" alt="Screenshot 2022-01-15 at 12 15 27 PM" src="https://user-images.githubusercontent.com/68138671/149608576-c1ca0c1f-a8f2-488a-b02c-5fc856c9bb37.png">

This PR makes it such that all columns (apart from the ID column which starts from a width of 5%) are evenly spaced within the table, and will resize accordingly to the window size:

![catcher resizing](https://user-images.githubusercontent.com/68138671/150070741-d4ebe94a-5fdf-43d8-8457-eaba2f5a91bf.gif)


Interestingly, this bug does not occur when using Safari. Also, there's more minor UI stuff to fix in the screenshots, e.g. the "DocumentationBug" label overlapping with the "Low" severity. If you want me to fix that that's fine too.

### Proposed Commit Message:
```
Fix response column overlapping with assignee

Currently, when the window size is too narrow, the response column will
overlap with the assignee column

Let's use flexbox to adjust the column widths, and add horizontal scroll
bars for columns that don't have enough space
```
