### PR TITLE
Remove deprecation for Window.event

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -337,7 +337,7 @@ export class GithubService {
     return ORG_NAME.concat('/').concat(REPO);
   }
 
-  viewIssueInBrowser(id: number) {
+  viewIssueInBrowser(id: number, event: Event) {
     if (id) {
       this.electronService.openLink('https://github.com/'.concat(this.getRepoURL()).concat('/issues/').concat(String(id)));
     } else {

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -113,7 +113,7 @@
     <th mat-header-cell *matHeaderCellDef> Actions </th>
     <td mat-cell *matCellDef="let issue">
       <button mat-button matTooltip="View this issue on GitHub" *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
-              (click)="this.viewIssueInBrowser(issue.id)" style="
+              (click)="this.viewIssueInBrowser(issue.id, $event)" style="
               transform: scale(0.8)">
         <mat-icon>open_in_new</mat-icon>
       </button>
@@ -132,18 +132,18 @@
       </ng-template>
       <button *ngIf="this.isResponseEditable() && issue.status
       && this.isActionVisible(action_buttons.MARK_AS_RESPONDED)"
-              mat-button color="primary" (click)="markAsResponded(issue)"
+              mat-button color="primary" (click)="markAsResponded(issue, $event)"
               style="transform: scale(0.8)" matTooltip="Mark this issue as Responded">
         <mat-icon>check_circle</mat-icon>
       </button>
-      <button color="primary" matTooltip="Mark this issue as Pending" mat-button (click)="markAsPending(issue)"
+      <button color="primary" matTooltip="Mark this issue as Pending" mat-button (click)="markAsPending(issue, $event)"
               style="transform: scale(0.8)" *ngIf="(userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin')
               && this.isActionVisible(action_buttons.MARK_AS_PENDING)">
         <mat-icon>cancel</mat-icon>
       </button>
       <button mat-button color="warn" *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id]
           && this.isActionVisible(action_buttons.DELETE_ISSUE)"
-              (click)="openDeleteDialog(issue.id); $event.stopPropagation()" 
+              (click)="openDeleteDialog(issue.id, $event); $event.stopPropagation()" 
               matTooltip="Delete this issue" style="transform: scale(0.8)">
         <mat-icon>delete_outline</mat-icon>
       </button>

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -91,7 +91,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     return this.actions.includes(action);
   }
 
-  markAsResponded(issue: Issue) {
+  markAsResponded(issue: Issue, event: Event) {
     this.loggingService.info(`IssueTablesComponent: Marking Issue ${issue.id} as Responded`);
     const newIssue = issue.clone(this.phaseService.currentPhase);
     newIssue.status = STATUS.Done;
@@ -107,7 +107,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     return this.permissions.isTeamResponseEditable() || this.permissions.isTesterResponseEditable();
   }
 
-  markAsPending(issue: Issue) {
+  markAsPending(issue: Issue, event: Event) {
     this.loggingService.info(`IssueTablesComponent: Marking Issue ${issue.id} as Pending`);
     const newIssue = issue.clone(this.phaseService.currentPhase);
     newIssue.status = STATUS.Incomplete;
@@ -141,12 +141,12 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     return issue.issueDisputes && issue.numOfUnresolvedDisputes() === 0;
   }
 
-  viewIssueInBrowser(id: number) {
+  viewIssueInBrowser(id: number, event: Event) {
     this.loggingService.info(`IssueTablesComponent: Opening Issue ${id} on Github`);
-    this.githubService.viewIssueInBrowser(id);
+    this.githubService.viewIssueInBrowser(id, event);
   }
 
-  deleteIssue(id: number) {
+  deleteIssue(id: number, event: Event) {
     this.loggingService.info(`IssueTablesComponent: Deleting Issue ${id}`);
     this.issuesPendingDeletion = {
       ...this.issuesPendingDeletion,
@@ -162,7 +162,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     event.stopPropagation();
   }
 
-  openDeleteDialog(id: number) {
+  openDeleteDialog(id: number, event: Event) {
     const dialogRef = this.dialogService.openUserConfirmationModal(
       this.deleteIssueModalMessages, this.yesButtonModalMessage, this.noButtonModalMessage
     );
@@ -170,7 +170,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     dialogRef.afterClosed().subscribe(res => {
       if (res) {
         this.loggingService.info(`Deleting issue ${id}`);
-        this.deleteIssue(id);
+        this.deleteIssue(id, event);
       }
     });
   }


### PR DESCRIPTION
### Summary:
Fixes #772

### Changes Made:
* Remove all references to the global event variable by passing the event into the function directly.

### Proposed Commit Message:
```
Remove deprecation for Window.event

Running npm run lint with updated Angular 8.0 raises
event is deprecated error.

Let's remove all the deprecated event references and
replace them with $event.
```
