### PR TITLE
Apply prettier across the codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # Ignore everything
 /*
 
-# Except tests and e2e
+# Except src, tests and e2e
+!src
 !tests
 !e2e

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,0 @@
-# Ignore everything
-/*
-
-# Except src, tests and e2e
-!src
-!tests
-!e2e

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "scuri": "^0.9.4",
     "ts-node": "^7.0.1",
     "tslint": "5.20.1",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "3.5.3",
     "wait-on": "3.3.0",
     "webdriver-manager": "12.1.7"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,15 +8,15 @@ import { PhaseTeamResponseModule } from './phase-team-response/phase-team-respon
 import { PhaseTesterResponseModule } from './phase-tester-response/phase-tester-response.module';
 
 const routes: Routes = [
-  { path: '', loadChildren: () => AuthModule},
-  { path: 'phaseBugReporting', loadChildren: () => PhaseBugReportingModule, canLoad: [AuthGuard]},
-  { path: 'phaseTeamResponse', loadChildren: () => PhaseTeamResponseModule, canLoad: [AuthGuard]},
-  { path: 'phaseTesterResponse', loadChildren: () => PhaseTesterResponseModule, canLoad: [AuthGuard]},
-  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard]},
+  { path: '', loadChildren: () => AuthModule },
+  { path: 'phaseBugReporting', loadChildren: () => PhaseBugReportingModule, canLoad: [AuthGuard] },
+  { path: 'phaseTeamResponse', loadChildren: () => PhaseTeamResponseModule, canLoad: [AuthGuard] },
+  { path: 'phaseTesterResponse', loadChildren: () => PhaseTesterResponseModule, canLoad: [AuthGuard] },
+  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] }
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,10 +10,9 @@ import { LoggingService } from './core/services/logging.service';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent implements AfterViewInit {
-  NOT_CONNECTED_ERROR: Error = new Error("You are not connected to the internet.");
+  NOT_CONNECTED_ERROR: Error = new Error('You are not connected to the internet.');
 
   constructor(public electronService: ElectronService, logger: LoggingService, public errorHandlingService: ErrorHandlingService) {
-
     logger.info('AppConfig', AppConfig);
 
     if (electronService.isElectron()) {
@@ -21,7 +20,7 @@ export class AppComponent implements AfterViewInit {
     } else {
       logger.info('Mode web');
     }
-   }
+  }
 
   ngAfterViewInit() {
     this.addListenerForHttpLinks();
@@ -33,22 +32,30 @@ export class AppComponent implements AfterViewInit {
    * Will use the client's default OS browser to open the link.
    */
   addListenerForHttpLinks() {
-    document.addEventListener('click', (event) => {
-      const elem = (<HTMLLinkElement>(<HTMLElement>event.target).closest('a[href^="http"]'));
-      if (elem) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.electronService.openLink(elem.href);
-      }
-    }, false);
+    document.addEventListener(
+      'click',
+      (event) => {
+        const elem = <HTMLLinkElement>(<HTMLElement>event.target).closest('a[href^="http"]');
+        if (elem) {
+          event.preventDefault();
+          event.stopPropagation();
+          this.electronService.openLink(elem.href);
+        }
+      },
+      false
+    );
   }
 
   /**
    * This listener checks if CATcher has a connection to a network, and will show an error snackbar if it does not.
    */
   addListenerForNetworkOffline() {
-    window.addEventListener('offline', (event) => {
-      this.errorHandlingService.handleError(this.NOT_CONNECTED_ERROR);
-    }, false);
+    window.addEventListener(
+      'offline',
+      (event) => {
+        this.errorHandlingService.handleError(this.NOT_CONNECTED_ERROR);
+      },
+      false
+    );
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,13 +40,7 @@ import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    HeaderComponent,
-    UserConfirmationComponent,
-    LabelDefinitionPopupComponent,
-    SessionFixConfirmationComponent
-  ],
+  declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],
   imports: [
     BrowserModule,
     PhaseTesterResponseModule,
@@ -61,11 +55,11 @@ import { SharedModule } from './shared/shared.module';
       markedOptions: {
         provide: MarkedOptions,
         useFactory: markedOptionsFactory
-      },
+      }
     }),
     AppRoutingModule,
     ApolloModule,
-    HttpLinkModule,
+    HttpLinkModule
   ],
   providers: [
     {
@@ -76,16 +70,24 @@ import { SharedModule } from './shared/shared.module';
     {
       provide: AuthService,
       useFactory: AuthServiceFactory,
-      deps: [ElectronService, Router, NgZone,
-      GithubService, UserService, IssueService,
-      PhaseService, DataService, GithubEventService,
-      Title, LoggingService]
+      deps: [
+        ElectronService,
+        Router,
+        NgZone,
+        GithubService,
+        UserService,
+        IssueService,
+        PhaseService,
+        DataService,
+        GithubEventService,
+        Title,
+        LoggingService
+      ]
     },
     {
       provide: IssueService,
       useFactory: IssueServiceFactory,
-      deps: [GithubService, UserService, PhaseService,
-      ElectronService, DataService]
+      deps: [GithubService, UserService, PhaseService, ElectronService, DataService]
     },
     {
       provide: ErrorHandler,
@@ -93,19 +95,13 @@ import { SharedModule } from './shared/shared.module';
     }
   ],
   bootstrap: [AppComponent],
-  entryComponents: [
-    UserConfirmationComponent,
-    SessionFixConfirmationComponent,
-    LabelDefinitionPopupComponent
-  ]
+  entryComponents: [UserConfirmationComponent, SessionFixConfirmationComponent, LabelDefinitionPopupComponent]
 })
-
 export class AppModule {
   constructor(private apollo: Apollo, private httpLink: HttpLink, private authService: AuthService) {
-
     const URI = 'https://api.github.com/graphql';
     const basic = setContext(() => {
-      return { headers: {Accept: 'charset=utf-8' }};
+      return { headers: { Accept: 'charset=utf-8' } };
     });
     const auth = setContext(() => {
       return { headers: { Authorization: `Token ${this.authService.accessToken.getValue()}` } };
@@ -117,7 +113,7 @@ export class AppModule {
     const cache = new InMemoryCache({ fragmentMatcher });
     this.apollo.create({
       link: link,
-      cache: cache,
+      cache: cache
     });
   }
 }

--- a/src/app/auth/auth-routing.module.ts
+++ b/src/app/auth/auth-routing.module.ts
@@ -5,7 +5,7 @@ import { AuthComponent } from './auth.component';
 const routes: Routes = [
   {
     path: '',
-    component: AuthComponent,
+    component: AuthComponent
   }
 ];
 

--- a/src/app/auth/auth.component.css
+++ b/src/app/auth/auth.component.css
@@ -75,7 +75,6 @@
   cursor: pointer;
 }
 
-
 .centralize {
   display: flex;
   justify-content: center;

--- a/src/app/auth/auth.component.html
+++ b/src/app/auth/auth.component.html
@@ -1,19 +1,29 @@
 <div *ngIf="isUserNotAuthenticated()" class="login-page">
   <mat-card class="login-card">
-    <mat-card-header style="margin-bottom: 20px;">
+    <mat-card-header style="margin-bottom: 20px">
       <mat-card-title class="login-title"> Select Your Session </mat-card-title>
     </mat-card-header>
 
     <form [formGroup]="profileForm" (ngSubmit)="setupSession()">
-      <app-profiles class="login-field" [urlEncodedSessionName]="this.urlEncodedSessionName" (selectedProfileEmitter)="onProfileSelect($event)"></app-profiles>
+      <app-profiles
+        class="login-field"
+        [urlEncodedSessionName]="this.urlEncodedSessionName"
+        (selectedProfileEmitter)="onProfileSelect($event)"
+      ></app-profiles>
       <mat-card-content>
         <mat-form-field class="login-field">
-          <input matInput placeholder="Settings Location (Org/Repo)" formControlName="session" required>
+          <input matInput placeholder="Settings Location (Org/Repo)" formControlName="session" required />
         </mat-form-field>
 
         <mat-card-actions>
-          <button *ngIf="!isSettingUpSession" class="sign-in-button" type="submit"
-                  [disabled]="profileForm.invalid || isSettingUpSession" mat-stroked-button color="primary">
+          <button
+            *ngIf="!isSettingUpSession"
+            class="sign-in-button"
+            type="submit"
+            [disabled]="profileForm.invalid || isSettingUpSession"
+            mat-stroked-button
+            color="primary"
+          >
             <div>Submit</div>
           </button>
           <div *ngIf="isSettingUpSession" class="spinner-centralize">
@@ -27,9 +37,9 @@
 
 <div *ngIf="isUserAuthenticating() || isAwaitingOAuthUserConfirm()" class="login-page">
   <mat-card class="login-card">
-    <mat-card-header style="margin-bottom: 20px;">
+    <mat-card-header style="margin-bottom: 20px">
       <mat-card-title class="login-title"> Confirm Login Account </mat-card-title>
-      <mat-card-subtitle> Session on {{currentSessionOrg}} </mat-card-subtitle>
+      <mat-card-subtitle> Session on {{ currentSessionOrg }} </mat-card-subtitle>
     </mat-card-header>
 
     <div style="position: absolute; top: 15px; left: 15px">

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -15,7 +15,7 @@ import { LoggingService } from '../core/services/logging.service';
 import { PhaseService } from '../core/services/phase.service';
 import { UserService } from '../core/services/user.service';
 
-const APPLICATION_VERSION_OUTDATED_ERROR = "Please update to the latest version of CATcher.";
+const APPLICATION_VERSION_OUTDATED_ERROR = 'Please update to the latest version of CATcher.';
 
 @Component({
   selector: 'app-auth',
@@ -33,21 +33,21 @@ export class AuthComponent implements OnInit, OnDestroy {
   currentUserName: string;
   urlEncodedSessionName: string;
 
-  constructor(public appService: ApplicationService,
-              public electronService: ElectronService,
-              private githubService: GithubService,
-              private authService: AuthService,
-              private userService: UserService,
-              private formBuilder: FormBuilder,
-              private errorHandlingService: ErrorHandlingService,
-              private router: Router,
-              private phaseService: PhaseService,
-              private ngZone: NgZone,
-              private activatedRoute: ActivatedRoute,
-              private logger: LoggingService
+  constructor(
+    public appService: ApplicationService,
+    public electronService: ElectronService,
+    private githubService: GithubService,
+    private authService: AuthService,
+    private userService: UserService,
+    private formBuilder: FormBuilder,
+    private errorHandlingService: ErrorHandlingService,
+    private router: Router,
+    private phaseService: PhaseService,
+    private ngZone: NgZone,
+    private activatedRoute: ActivatedRoute,
+    private logger: LoggingService
   ) {
-    this.electronService.registerIpcListener('github-oauth-reply',
-      (event, {token, error, isWindowClosed}) => {
+    this.electronService.registerIpcListener('github-oauth-reply', (event, { token, error, isWindowClosed }) => {
       this.ngZone.run(() => {
         if (error) {
           if (!isWindowClosed) {
@@ -78,7 +78,8 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.initAuthStateSubscription();
     this.initProfileForm();
     this.createProfileFromUrlQueryParams();
-    if (oauthCode) { // runs upon receiving oauthCode from the redirect
+    if (oauthCode) {
+      // runs upon receiving oauthCode from the redirect
       this.authService.changeAuthState(AuthState.AwaitingAuthentication);
       this.restoreOrgDetailsFromLocalStorage();
       this.logger.info('Obtained authorisation code from Github');
@@ -100,16 +101,16 @@ export class AuthComponent implements OnInit, OnDestroy {
     this.logger.info('Retrieving access token from Github');
 
     const accessTokenUrl = `${AppConfig.accessTokenUrl}/${oauthCode}/client_id/${AppConfig.clientId}`;
-    fetch(accessTokenUrl).then(res => res.json())
-      .then(data => {
-          if (data.error) {
-            throw(new Error(data.error));
-          }
-          this.authService.storeOAuthAccessToken(data.token);
-          this.logger.info('Sucessfully obtained access token');
+    fetch(accessTokenUrl)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          throw new Error(data.error);
         }
-      )
-      .catch(err => {
+        this.authService.storeOAuthAccessToken(data.token);
+        this.logger.info('Sucessfully obtained access token');
+      })
+      .catch((err) => {
         this.logger.info(`Error in data fetched from access token URL: ${err}`);
         this.errorHandlingService.handleError(err);
         this.authService.changeAuthState(AuthState.NotAuthenticated);
@@ -135,7 +136,7 @@ export class AuthComponent implements OnInit, OnDestroy {
         if (isOutdated) {
           throw new Error(APPLICATION_VERSION_OUTDATED_ERROR);
         }
-      }),
+      })
     );
   }
 
@@ -162,17 +163,21 @@ export class AuthComponent implements OnInit, OnDestroy {
 
     this.logger.info(`Selected Settings Repo: ${sessionInformation}`);
 
-    this.phaseService.storeSessionData().subscribe(() => {
-      try {
-        this.authService.startOAuthProcess();
-      } catch (error) {
+    this.phaseService.storeSessionData().subscribe(
+      () => {
+        try {
+          this.authService.startOAuthProcess();
+        } catch (error) {
+          this.errorHandlingService.handleError(error);
+          this.authService.changeAuthState(AuthState.NotAuthenticated);
+        }
+      },
+      (error) => {
         this.errorHandlingService.handleError(error);
-        this.authService.changeAuthState(AuthState.NotAuthenticated);
-      }
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-      this.isSettingUpSession = false;
-    }, () => this.isSettingUpSession = false);
+        this.isSettingUpSession = false;
+      },
+      () => (this.isSettingUpSession = false)
+    );
   }
 
   goToSessionSelect() {
@@ -229,7 +234,7 @@ export class AuthComponent implements OnInit, OnDestroy {
 
   private initProfileForm() {
     this.profileForm = this.formBuilder.group({
-      session: ['', Validators.required],
+      session: ['', Validators.required]
     });
   }
 
@@ -242,15 +247,17 @@ export class AuthComponent implements OnInit, OnDestroy {
   }
 
   private initAccessTokenSubscription() {
-    this.accessTokenSubscription = this.authService.accessToken.pipe(
-      filter((token: string) => !!token),
-      flatMap(() => this.userService.getAuthenticatedUser())
-    ).subscribe((user: GithubUser) => {
-      this.ngZone.run(() => {
-        this.currentUserName = user.login;
-        this.authService.changeAuthState(AuthState.ConfirmOAuthUser);
+    this.accessTokenSubscription = this.authService.accessToken
+      .pipe(
+        filter((token: string) => !!token),
+        flatMap(() => this.userService.getAuthenticatedUser())
+      )
+      .subscribe((user: GithubUser) => {
+        this.ngZone.run(() => {
+          this.currentUserName = user.login;
+          this.authService.changeAuthState(AuthState.ConfirmOAuthUser);
+        });
       });
-    });
   }
 
   private createProfileFromUrlQueryParams() {

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -7,21 +7,9 @@ import { ConfirmLoginComponent } from './confirm-login/confirm-login.component';
 import { JsonParseErrorDialogComponent } from './profiles/json-parse-error-dialog/json-parse-error-dialog.component';
 import { ProfilesComponent } from './profiles/profiles.component';
 
-
 @NgModule({
-  imports: [
-    AuthRoutingModule,
-    SharedModule,
-    CommonModule
-  ],
-  declarations: [
-    AuthComponent,
-    ProfilesComponent,
-    JsonParseErrorDialogComponent,
-    ConfirmLoginComponent
-  ],
-  entryComponents: [
-    JsonParseErrorDialogComponent
-  ],
+  imports: [AuthRoutingModule, SharedModule, CommonModule],
+  declarations: [AuthComponent, ProfilesComponent, JsonParseErrorDialogComponent, ConfirmLoginComponent],
+  entryComponents: [JsonParseErrorDialogComponent]
 })
 export class AuthModule {}

--- a/src/app/auth/confirm-login/confirm-login.component.css
+++ b/src/app/auth/confirm-login/confirm-login.component.css
@@ -8,7 +8,7 @@
 .logo {
   align-items: center;
   display: inline-flex;
-  margin: 0 3px 3px 3px
+  margin: 0 3px 3px 3px;
 }
 
 .github-logo {

--- a/src/app/auth/confirm-login/confirm-login.component.html
+++ b/src/app/auth/confirm-login/confirm-login.component.html
@@ -1,12 +1,12 @@
 <button mat-stroked-button class="sign-in-button" color="primary" (click)="this.completeLoginProcess()">
-  <span class="logo"> <img class="github-logo" src="./assets/images/github-logo.png" alt="github-logo"> </span>
-  <span> Continue as {{this.username}} </span>
+  <span class="logo"> <img class="github-logo" src="./assets/images/github-logo.png" alt="github-logo" /> </span>
+  <span> Continue as {{ this.username }} </span>
 </button>
 
-<button *ngIf="electronService.isElectron()" mat-button style="margin-top: 10px; margin-bottom: 10px;" (click)="logIntoAnotherAccount()">
-  Log in to another account 
+<button *ngIf="electronService.isElectron()" mat-button style="margin-top: 10px; margin-bottom: 10px" (click)="logIntoAnotherAccount()">
+  Log in to another account
 </button>
-<div *ngIf="!electronService.isElectron()" class="mat-body-1" style="margin-top: 20px;">
+<div *ngIf="!electronService.isElectron()" class="mat-body-1" style="margin-top: 20px">
   To change account, please sign into the desired account from the
   <a href="https://github.com/" (click)="onGithubWebsiteClicked()">official Github website</a>.
 </div>

--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -18,17 +18,18 @@ export class ConfirmLoginComponent implements OnInit {
   @Input() username: string;
   @Input() currentSessionOrg: string;
 
-  constructor(public electronService: ElectronService,
-              private authService: AuthService,
-              private phaseService: PhaseService,
-              private userService: UserService,
-              private errorHandlingService: ErrorHandlingService,
-              private githubEventService: GithubEventService,
-              private logger: LoggingService,
-              private router: Router
-  ) { }
+  constructor(
+    public electronService: ElectronService,
+    private authService: AuthService,
+    private phaseService: PhaseService,
+    private userService: UserService,
+    private errorHandlingService: ErrorHandlingService,
+    private githubEventService: GithubEventService,
+    private logger: LoggingService,
+    private router: Router
+  ) {}
 
-  ngOnInit() { }
+  ngOnInit() {}
 
   onGithubWebsiteClicked() {
     window.open('https://github.com/', '_blank');
@@ -56,15 +57,21 @@ export class ConfirmLoginComponent implements OnInit {
   completeLoginProcess(): void {
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
     this.phaseService.setPhaseOwners(this.currentSessionOrg, this.username);
-    this.userService.createUserModel(this.username).pipe(
-      flatMap(() => this.phaseService.sessionSetup()),
-      flatMap(() => this.githubEventService.setLatestChangeEvent()),
-    ).subscribe(() => {
-      this.handleAuthSuccess();
-    }, (error) => {
-      this.authService.changeAuthState(AuthState.NotAuthenticated);
-      this.errorHandlingService.handleError(error);
-      this.logger.info(`Completion of login process failed with an error: ${error}`);
-    });
+    this.userService
+      .createUserModel(this.username)
+      .pipe(
+        flatMap(() => this.phaseService.sessionSetup()),
+        flatMap(() => this.githubEventService.setLatestChangeEvent())
+      )
+      .subscribe(
+        () => {
+          this.handleAuthSuccess();
+        },
+        (error) => {
+          this.authService.changeAuthState(AuthState.NotAuthenticated);
+          this.errorHandlingService.handleError(error);
+          this.logger.info(`Completion of login process failed with an error: ${error}`);
+        }
+      );
   }
 }

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.html
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.html
@@ -1,9 +1,8 @@
 <h1 mat-dialog-title>Error in "profiles.json" format</h1>
 <div mat-dialog-content>
-  <p align="center" style="max-width: 390px;" >
-    The format of the "profiles.json" file is not as required.
-    You might not have included <code>profileName</code> and <code>repoName</code> keys.
-    Please refer to our User Guide for the correct format.
+  <p align="center" style="max-width: 390px">
+    The format of the "profiles.json" file is not as required. You might not have included <code>profileName</code> and
+    <code>repoName</code> keys. Please refer to our User Guide for the correct format.
   </p>
 </div>
 <div mat-dialog-actions align="center">

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
@@ -13,11 +13,9 @@ import { ProfilesComponent } from '../profiles.component';
   styleUrls: ['./json-parse-error-dialog.component.css']
 })
 export class JsonParseErrorDialogComponent implements OnInit {
+  constructor(public dialogRef: MatDialogRef<ProfilesComponent>) {}
 
-  constructor(public dialogRef: MatDialogRef<ProfilesComponent>) { }
-
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   /**
    * Closes the Dialog
@@ -25,5 +23,4 @@ export class JsonParseErrorDialogComponent implements OnInit {
   onClick(): void {
     this.dialogRef.close();
   }
-
 }

--- a/src/app/auth/profiles/profiles.component.html
+++ b/src/app/auth/profiles/profiles.component.html
@@ -2,12 +2,20 @@
   <mat-label>Select Session</mat-label>
   <mat-select [value]="this.selectedProfile.profileName">
     <mat-option (click)="selectProfile(this.blankProfile)">None</mat-option>
-    <mat-option *ngFor="let profile of profiles" (click)="selectProfile(profile)"
-                [value]="profile.profileName">{{ profile.profileName }}</mat-option>
+    <mat-option *ngFor="let profile of profiles" (click)="selectProfile(profile)" [value]="profile.profileName">{{
+      profile.profileName
+    }}</mat-option>
   </mat-select>
 </mat-form-field>
-<input #fileInput type="file" style="display: none;" accept=".json" (change)="this.fileSelected($event)"/>
-<button class="profile-input" type="button" mat-icon-button (click)="this.fileSelectorInitiation(fileInput)" disableRipple="true" (mousedown)="this.animationActivated = true"
-        (mouseleave)="this.animationActivated = false">
+<input #fileInput type="file" style="display: none" accept=".json" (change)="this.fileSelected($event)" />
+<button
+  class="profile-input"
+  type="button"
+  mat-icon-button
+  (click)="this.fileSelectorInitiation(fileInput)"
+  disableRipple="true"
+  (mousedown)="this.animationActivated = true"
+  (mouseleave)="this.animationActivated = false"
+>
   <mat-icon [@triggerFileInput]="this.animationActivated ? 'pressed' : 'normal'">folder_open</mat-icon>
 </button>

--- a/src/app/auth/profiles/profiles.component.ts
+++ b/src/app/auth/profiles/profiles.component.ts
@@ -1,10 +1,4 @@
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger
-} from '@angular/animations';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { isValidProfile, Profile } from '../../core/models/profile.model';
@@ -20,15 +14,14 @@ import { JsonParseErrorDialogComponent } from './json-parse-error-dialog/json-pa
     // animation triggers go here
     trigger('triggerFileInput', [
       state('normal', style({})),
-      state('pressed', style({
-        color: 'orange'
-      })),
-      transition('normal => pressed', [
-        animate('0.25s ease')
-      ]),
-      transition('pressed => normal', [
-        animate('0.25s ease')
-      ])
+      state(
+        'pressed',
+        style({
+          color: 'orange'
+        })
+      ),
+      transition('normal => pressed', [animate('0.25s ease')]),
+      transition('pressed => normal', [animate('0.25s ease')])
     ])
   ]
 })
@@ -36,7 +29,7 @@ export class ProfilesComponent implements OnInit {
   private readonly ANIMATION_DURATION: number = 250;
 
   profiles: Profile[] = []; // List of profiles taken from profiles.json
-  blankProfile: Profile = {profileName: '', repoName: ''}; // A blank profile to reset values
+  blankProfile: Profile = { profileName: '', repoName: '' }; // A blank profile to reset values
   animationActivated = false; // Assists color change animations.
 
   selectedProfile: Profile = this.blankProfile;
@@ -49,11 +42,7 @@ export class ProfilesComponent implements OnInit {
     fileDirectory: null
   };
 
-  constructor(
-    public errorDialog: MatDialog,
-    public profileService: ProfileService,
-    public errorHandlingService: ErrorHandlingService
-  ) { }
+  constructor(public errorDialog: MatDialog, public profileService: ProfileService, public errorHandlingService: ErrorHandlingService) {}
 
   ngOnInit() {
     this.initProfiles();
@@ -98,18 +87,19 @@ export class ProfilesComponent implements OnInit {
    * Processes available Profiles information from the external repository.
    */
   initProfiles(): void {
-    this.profileService.fetchExternalProfiles().then(externalProfiles => {
-      this.profiles = this.profiles
-      .concat(externalProfiles)
-      .filter((p) => !!p);
-    }).then(() => this.setUrlEncodedProfile(this.profiles))
-    .catch(e => {
-      if (e === MALFORMED_PROFILES_ERROR) {
-        this.openErrorDialog();
-      } else {
-        this.errorHandlingService.handleError(e);
-      }
-    });
+    this.profileService
+      .fetchExternalProfiles()
+      .then((externalProfiles) => {
+        this.profiles = this.profiles.concat(externalProfiles).filter((p) => !!p);
+      })
+      .then(() => this.setUrlEncodedProfile(this.profiles))
+      .catch((e) => {
+        if (e === MALFORMED_PROFILES_ERROR) {
+          this.openErrorDialog();
+        } else {
+          this.errorHandlingService.handleError(e);
+        }
+      });
   }
 
   /**
@@ -135,7 +125,7 @@ export class ProfilesComponent implements OnInit {
       return;
     }
 
-    const profile = validProfiles.find(profile => profile.profileName === this.urlEncodedSessionName);
+    const profile = validProfiles.find((profile) => profile.profileName === this.urlEncodedSessionName);
     if (profile) {
       this.selectedProfile.profileName = this.urlEncodedSessionName;
       this.selectProfile(profile);

--- a/src/app/core/directives/form-disable-control.directive.ts
+++ b/src/app/core/directives/form-disable-control.directive.ts
@@ -5,12 +5,9 @@ import { NgControl } from '@angular/forms';
   selector: '[disableControl]'
 })
 export class FormDisableControlDirective {
-
   @Input() set disableControl(condition: boolean) {
     condition ? this.ngControl.control.disable() : this.ngControl.control.enable();
   }
 
-  constructor( private ngControl: NgControl ) {
-  }
-
+  constructor(private ngControl: NgControl) {}
 }

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -7,12 +7,9 @@ import { AuthService } from '../services/auth.service';
   providedIn: 'root'
 })
 export class AuthGuard implements CanActivate, CanLoad {
-  constructor(private auth: AuthService, private router: Router) { }
+  constructor(private auth: AuthService, private router: Router) {}
 
-  canActivate(
-    next: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
-
+  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
     if (this.auth.isAuthenticated()) {
       return true;
     } else {

--- a/src/app/core/guards/can-deactivate-issue-guard.service.ts
+++ b/src/app/core/guards/can-deactivate-issue-guard.service.ts
@@ -8,14 +8,12 @@ import { DialogService } from '../services/dialog.service';
   providedIn: 'root'
 })
 export class CanDeactivateIssueGuard implements CanDeactivate<any> {
-
   // Messages for the modal dialog view
-  private readonly modalDialogMessages = ["Do you wish to leave the page?", "You have unsaved changes that will be discarded."];
-  private readonly yesButtonDialogMessage = "Yes, I wish to leave";
+  private readonly modalDialogMessages = ['Do you wish to leave the page?', 'You have unsaved changes that will be discarded.'];
+  private readonly yesButtonDialogMessage = 'Yes, I wish to leave';
   private readonly noButtonDialogMessage = "No, I don't wish to leave";
 
-  constructor(private location: Location, private router: Router,
-              private dialogService: DialogService) {}
+  constructor(private location: Location, private router: Router, private dialogService: DialogService) {}
 
   /**
    * Makes the dialog visible to the user.
@@ -23,23 +21,26 @@ export class CanDeactivateIssueGuard implements CanDeactivate<any> {
    */
   openDialog(): Observable<boolean> {
     const dialogRef = this.dialogService.openUserConfirmationModal(
-      this.modalDialogMessages, this.yesButtonDialogMessage, this.noButtonDialogMessage);
+      this.modalDialogMessages,
+      this.yesButtonDialogMessage,
+      this.noButtonDialogMessage
+    );
 
     return dialogRef.afterClosed();
   }
 
-  canDeactivate(component: any, currentRoute: ActivatedRouteSnapshot,
-                currentState: RouterStateSnapshot,
-                nextState?: RouterStateSnapshot): Observable<boolean> {
-    if (component.canDeactivate && !component.canDeactivate()
-      && nextState.url !== '/') {
-      const currentUrlTree =
-        this.router.createUrlTree([], currentRoute);
+  canDeactivate(
+    component: any,
+    currentRoute: ActivatedRouteSnapshot,
+    currentState: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot
+  ): Observable<boolean> {
+    if (component.canDeactivate && !component.canDeactivate() && nextState.url !== '/') {
+      const currentUrlTree = this.router.createUrlTree([], currentRoute);
       const currentUrl = currentUrlTree.toString();
       this.location.go(currentUrl);
       return this.openDialog();
     }
     return of(true);
   }
-
 }

--- a/src/app/core/guards/user-confirmation/user-confirmation.component.ts
+++ b/src/app/core/guards/user-confirmation/user-confirmation.component.ts
@@ -13,15 +13,11 @@ import { CanDeactivateIssueGuard } from '../can-deactivate-issue-guard.service';
   styleUrls: ['./user-confirmation.component.css']
 })
 export class UserConfirmationComponent implements OnInit {
-
   // Injection of a reference to Dialog from the Service that it is to be
   // displayed in.
-  constructor(public dialogRef: MatDialogRef<CanDeactivateIssueGuard>,
-    @Inject(MAT_DIALOG_DATA) public data,
-  ) { }
+  constructor(public dialogRef: MatDialogRef<CanDeactivateIssueGuard>, @Inject(MAT_DIALOG_DATA) public data) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   /**
    * Closes the dialog.
@@ -29,5 +25,4 @@ export class UserConfirmationComponent implements OnInit {
   onNoClick(): void {
     this.dialogRef.close(false);
   }
-
 }

--- a/src/app/core/models/generators/github-issue.generator.ts
+++ b/src/app/core/models/generators/github-issue.generator.ts
@@ -2,22 +2,21 @@ import { GithubIssue } from '../github/github-issue.model';
 
 export default function generateGithubIssuesArray(numberOfElements: number = 1): Array<GithubIssue> {
   const created_and_updated_date: string = getRandomDate().toISOString();
-  return new Array<GithubIssue>(10)
-    .map((value: GithubIssue, index: number, array: GithubIssue[]) => {
-      return new GithubIssue({
-        id: index,
-        number: Math.random(),
-        assignees: undefined,
-        body: `Automatically Generated Issue No id: ${index}.`,
-        created_at: created_and_updated_date,
-        labels: undefined,
-        title:  `Autogen Issue ${index}`,
-        updated_at: created_and_updated_date,
-        url: '',
-        user: undefined,
-        comments: undefined
-      });
+  return new Array<GithubIssue>(10).map((value: GithubIssue, index: number, array: GithubIssue[]) => {
+    return new GithubIssue({
+      id: index,
+      number: Math.random(),
+      assignees: undefined,
+      body: `Automatically Generated Issue No id: ${index}.`,
+      created_at: created_and_updated_date,
+      labels: undefined,
+      title: `Autogen Issue ${index}`,
+      updated_at: created_and_updated_date,
+      url: '',
+      user: undefined,
+      comments: undefined
     });
+  });
 }
 
 /**
@@ -25,6 +24,6 @@ export default function generateGithubIssuesArray(numberOfElements: number = 1):
  * @param start - Date representing the start of the date range. Default: 1/1/2018
  * @param end - Date representing the end of the date range. Default: Current Date
  */
-function getRandomDate(start: Date = new Date(2018, 1, 1) , end: Date = new Date()): Date {
+function getRandomDate(start: Date = new Date(2018, 1, 1), end: Date = new Date()): Date {
   return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
 }

--- a/src/app/core/models/github/github-comment.model.ts
+++ b/src/app/core/models/github/github-comment.model.ts
@@ -6,9 +6,9 @@ export class GithubComment {
   updated_at: string;
   url: string; // api url
   user: {
-    login: string,
-    id: number,
-    avatar_url: string,
-    url: string,
+    login: string;
+    id: number;
+    avatar_url: string;
+    url: string;
   };
 }

--- a/src/app/core/models/github/github-graphql.issue.ts
+++ b/src/app/core/models/github/github-graphql.issue.ts
@@ -16,14 +16,14 @@ export class GithubGraphqlIssue extends GithubIssue {
       user: {
         login: issue.author.login,
         url: issue.author.url,
-        avatar_url: issue.author.avatarUrl,
+        avatar_url: issue.author.avatarUrl
       },
       assignees: flattenEdges(issue.assignees.edges),
       labels: flattenEdges(issue.labels.edges),
-      comments: flattenEdges(issue.comments.edges, node => ({
+      comments: flattenEdges(issue.comments.edges, (node) => ({
         ...node,
-        id: node.databaseId,
-      })),
+        id: node.databaseId
+      }))
     });
   }
 }

--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -42,7 +42,7 @@ export default class RestGithubIssueFilter implements RestGithubIssueFilterData 
       mentioned: this.mentioned,
       milestone: this.milestone,
       since: this.since,
-      states: [this.state === 'close' ? IssueState.Closed : IssueState.Open],
+      states: [this.state === 'close' ? IssueState.Closed : IssueState.Open]
     };
   }
 }

--- a/src/app/core/models/github/github-issue.model.ts
+++ b/src/app/core/models/github/github-issue.model.ts
@@ -6,9 +6,9 @@ export class GithubIssue {
   id: string; // Github's backend's id
   number: number; // Issue's display id
   assignees: Array<{
-    id: number,
-    login: string,
-    url: string,
+    id: number;
+    login: string;
+    url: string;
   }>;
   body: string;
   created_at: string;
@@ -17,10 +17,11 @@ export class GithubIssue {
   title: string;
   updated_at: string;
   url: string;
-  user: { // Author of the issue
-    login: string,
-    avatar_url: string,
-    url: string,
+  user: {
+    // Author of the issue
+    login: string;
+    avatar_url: string;
+    url: string;
   };
   comments: Array<GithubComment>;
 
@@ -39,12 +40,12 @@ export class GithubIssue {
    */
   findLabel(name: string, isCategorical: boolean = true): string {
     if (!isCategorical) {
-      const label = this.labels.find(l => (!l.isCategorical() && l.name === name));
+      const label = this.labels.find((l) => !l.isCategorical() && l.name === name);
       return label ? label.getValue() : undefined;
     }
 
     // Find labels with the same category name as what is specified in the parameter.
-    const labels = this.labels.filter(l => (l.isCategorical() && l.getCategory() === name));
+    const labels = this.labels.filter((l) => l.isCategorical() && l.getCategory() === name);
     if (labels.length === 0) {
       return undefined;
     } else if (labels.length === 1) {
@@ -56,9 +57,11 @@ export class GithubIssue {
         return labels[0].getValue();
       } else {
         const order = GithubLabel.LABEL_ORDER[name];
-        return labels.reduce((result, currLabel) => {
-          return order[currLabel.getValue()] > order[result.getValue()] ? currLabel : result;
-        }).getValue();
+        return labels
+          .reduce((result, currLabel) => {
+            return order[currLabel.getValue()] > order[result.getValue()] ? currLabel : result;
+          })
+          .getValue();
       }
     }
   }

--- a/src/app/core/models/github/github-label.model.ts
+++ b/src/app/core/models/github/github-label.model.ts
@@ -1,7 +1,7 @@
 export class GithubLabel {
   static readonly LABEL_ORDER = {
     severity: { Low: 0, Medium: 1, High: 2 },
-    type: { DocumentationBug: 0, FunctionalityBug: 1 },
+    type: { DocumentationBug: 0, FunctionalityBug: 1 }
   };
   static readonly LABELS = {
     severity: 'severity',

--- a/src/app/core/models/hidden-data.model.ts
+++ b/src/app/core/models/hidden-data.model.ts
@@ -17,7 +17,7 @@ export class HiddenData {
     for (const match of matches) {
       let info = match.replace('<!--', '').trim();
       info = info.replace('-->', '').trim();
-      const keyValuePair = info.split(':').map(v => v.trim());
+      const keyValuePair = info.split(':').map((v) => v.trim());
       if (keyValuePair.length !== 2) {
         this.originalStringWithoutHiddenData += `\n${match}`;
         continue;

--- a/src/app/core/models/issue-dispute.model.ts
+++ b/src/app/core/models/issue-dispute.model.ts
@@ -42,7 +42,7 @@ export class IssueDispute {
 
   toString(): string {
     let toString = '';
-    toString += this.TITLE_PREFIX +  this.title + '\n\n';
+    toString += this.TITLE_PREFIX + this.title + '\n\n';
     toString += this.description + '\n\n';
     toString += this.LINE_BREAK;
     return toString;

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -14,7 +14,6 @@ import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-t
 import { TesterResponse } from './tester-response.model';
 
 export class Issue {
-
   /** Basic Fields */
   readonly globalId: string;
   readonly id: number;
@@ -64,7 +63,7 @@ export class Issue {
 
     const newLinesRegex = /[\n\r]/gi;
     const textSplitArray = text.split(newLinesRegex);
-    if (textSplitArray.filter(split => split.trim() !== '').length > 0) {
+    if (textSplitArray.filter((split) => split.trim() !== '').length > 0) {
       return `${text}\n\n`;
     } else {
       return text;
@@ -131,7 +130,7 @@ export class Issue {
     issue.teamResponse = template.teamResponse && Issue.updateTeamResponse(template.teamResponse.content);
     issue.duplicateOf = template.duplicateOf && template.duplicateOf.issueNumber;
     issue.duplicated = issue.duplicateOf !== undefined && issue.duplicateOf !== null;
-    issue.assignees = githubIssue.assignees.map(assignee => assignee.login);
+    issue.assignees = githubIssue.assignees.map((assignee) => assignee.login);
     return issue;
   }
 
@@ -250,8 +249,10 @@ export class Issue {
 
   // Template url: https://github.com/CATcher-org/templates#dev-response-phase
   createGithubTeamResponse(): string {
-    return `# Team\'s Response\n${this.teamResponse}\n` +
-      `## Duplicate status (if any):\n${this.duplicateOf ? `Duplicate of #${this.duplicateOf}` : `--`}`;
+    return (
+      `# Team\'s Response\n${this.teamResponse}\n` +
+      `## Duplicate status (if any):\n${this.duplicateOf ? `Duplicate of #${this.duplicateOf}` : `--`}`
+    );
   }
 
   // Template url: https://github.com/CATcher-org/templates#tutor-moderation
@@ -265,8 +266,10 @@ export class Issue {
 
   // Template url: https://github.com/CATcher-org/templates#teams-response-1
   createGithubTesterResponse(): string {
-    return `# Team\'s Response\n${this.teamResponse}\n` +
-      `# Items for the Tester to Verify\n${this.getTesterResponsesString(this.testerResponses)}`;
+    return (
+      `# Team\'s Response\n${this.teamResponse}\n` +
+      `# Items for the Tester to Verify\n${this.getTesterResponsesString(this.testerResponses)}`
+    );
   }
 
   /**
@@ -293,34 +296,34 @@ export interface Issues {
   [id: number]: Issue;
 }
 
-export const SEVERITY_ORDER = { '-': 0 , VeryLow: 1, Low: 2, Medium: 3, High: 4 };
+export const SEVERITY_ORDER = { '-': 0, VeryLow: 1, Low: 2, Medium: 3, High: 4 };
 
-export const ISSUE_TYPE_ORDER = { '-': 0 , DocumentationBug: 1, FeatureFlaw: 2, FunctionalityBug: 3  };
+export const ISSUE_TYPE_ORDER = { '-': 0, DocumentationBug: 1, FeatureFlaw: 2, FunctionalityBug: 3 };
 
 export enum STATUS {
   Incomplete = 'Incomplete',
-  Done = 'Done',
+  Done = 'Done'
 }
 
 export const IssuesFilter = {
   phaseBugReporting: {
     Student: 'FILTER_BY_CREATOR',
     Tutor: 'NO_FILTER',
-    Admin: 'NO_FILTER',
+    Admin: 'NO_FILTER'
   },
   phaseTeamResponse: {
     Student: 'FILTER_BY_TEAM',
     Tutor: 'FILTER_BY_TEAM_ASSIGNED',
-    Admin: 'NO_FILTER',
+    Admin: 'NO_FILTER'
   },
   phaseTesterResponse: {
     Student: 'NO_FILTER',
     Tutor: 'NO_ACCESS',
-    Admin: 'NO_FILTER',
+    Admin: 'NO_FILTER'
   },
   phaseModeration: {
     Student: 'NO_ACCESS',
     Tutor: 'FILTER_BY_TEAM_ASSIGNED',
-    Admin: 'NO_FILTER',
+    Admin: 'NO_FILTER'
   }
 };

--- a/src/app/core/models/label.model.ts
+++ b/src/app/core/models/label.model.ts
@@ -1,5 +1,4 @@
 export class Label {
-
   labelCategory: string;
   labelValue: string;
   labelColor: string;
@@ -18,13 +17,12 @@ export class Label {
    * 'value' if the category does not exist.
    */
   public getFormattedName(): string {
-    return (this.labelCategory === undefined || this.labelCategory === '')
+    return this.labelCategory === undefined || this.labelCategory === ''
       ? this.labelValue
-      : (this.labelCategory.concat('.', this.labelValue));
+      : this.labelCategory.concat('.', this.labelValue);
   }
 
   public equals(label: Label) {
-    return this.labelValue === label.labelValue
-        && this.labelColor === label.labelColor && this.labelCategory === label.labelCategory;
+    return this.labelValue === label.labelValue && this.labelColor === label.labelColor && this.labelCategory === label.labelCategory;
   }
 }

--- a/src/app/core/models/parser/admins.model.ts
+++ b/src/app/core/models/parser/admins.model.ts
@@ -1,4 +1,3 @@
 export interface Admins {
   [name: string]: Object;
 }
-

--- a/src/app/core/models/parser/parsed-user-data.model.ts
+++ b/src/app/core/models/parser/parsed-user-data.model.ts
@@ -3,4 +3,3 @@ export interface ParsedUserData {
   name?: string;
   team?: string;
 }
-

--- a/src/app/core/models/parser/roles.model.ts
+++ b/src/app/core/models/parser/roles.model.ts
@@ -1,11 +1,11 @@
 export interface Roles {
-  'students'?: {
-    [loginId: string]: string
+  students?: {
+    [loginId: string]: string;
   };
-  'tutors'?: {
-    [loginId: string]: string
+  tutors?: {
+    [loginId: string]: string;
   };
-  'admins'?: {
-    [loginId: string]: string
+  admins?: {
+    [loginId: string]: string;
   };
 }

--- a/src/app/core/models/parser/students.model.ts
+++ b/src/app/core/models/parser/students.model.ts
@@ -1,5 +1,5 @@
 export interface Students {
   [studentname: string]: {
-    teamId?: string
+    teamId?: string;
   };
 }

--- a/src/app/core/models/parser/tabulated-user-data.model.ts
+++ b/src/app/core/models/parser/tabulated-user-data.model.ts
@@ -1,13 +1,13 @@
-import { Admins } from "./admins.model";
-import { Roles } from "./roles.model";
-import { Students } from "./students.model";
-import { Teams } from "./teams.model";
-import { Tutors } from "./tutors.model";
+import { Admins } from './admins.model';
+import { Roles } from './roles.model';
+import { Students } from './students.model';
+import { Teams } from './teams.model';
+import { Tutors } from './tutors.model';
 
 export interface TabulatedUserData {
-  "admins-allocation"?: Admins;
+  'admins-allocation'?: Admins;
   roles?: Roles;
-  "students-allocation"?: Students;
-  "team-structure"?: Teams;
-  "tutors-allocation"?: Tutors;
+  'students-allocation'?: Students;
+  'team-structure'?: Teams;
+  'tutors-allocation'?: Tutors;
 }

--- a/src/app/core/models/parser/teams.model.ts
+++ b/src/app/core/models/parser/teams.model.ts
@@ -1,5 +1,5 @@
 export interface Teams {
   [teamId: string]: {
-    [teamMember: string]: string
+    [teamMember: string]: string;
   };
 }

--- a/src/app/core/models/parser/tutors.model.ts
+++ b/src/app/core/models/parser/tutors.model.ts
@@ -1,5 +1,5 @@
 export interface Tutors {
   [name: string]: {
-    [tutorialGroup: string]: string
+    [tutorialGroup: string]: string;
   };
 }

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -11,23 +11,21 @@ export interface SessionData {
 }
 
 export const SESSION_DATA_UNAVAILABLE = 'Session Data Unavailable';
-export const SESSION_DATA_MISSING_OPENPHASES_KEY = 'Session data does not define an \'openPhases\' key';
+export const SESSION_DATA_MISSING_OPENPHASES_KEY = "Session data does not define an 'openPhases' key";
 export const NO_ACCESSIBLE_PHASES = 'There are no accessible phases';
 export const NO_VALID_OPEN_PHASES = 'Invalid Open Phases detected';
 export const OPENED_PHASE_REPO_UNDEFINED = 'Opened Phase has no repo defined';
 
 export function assertSessionDataIntegrity() {
   return pipe(
-    throwIfFalse(sessionData => sessionData !== undefined,
-      () => new Error(SESSION_DATA_UNAVAILABLE)),
-    throwIfFalse(isOpenPhasesKeyPresent,
-      () => new Error(SESSION_DATA_MISSING_OPENPHASES_KEY)),
-    throwIfFalse(hasOpenPhases,
-      () => new Error(NO_ACCESSIBLE_PHASES)),
-    throwIfFalse(areOpenPhasesValid,
-      () => new Error(NO_VALID_OPEN_PHASES)),
-    throwIfFalse(isOpenPhasesRepoDefined,
-      () => new Error(OPENED_PHASE_REPO_UNDEFINED)),
+    throwIfFalse(
+      (sessionData) => sessionData !== undefined,
+      () => new Error(SESSION_DATA_UNAVAILABLE)
+    ),
+    throwIfFalse(isOpenPhasesKeyPresent, () => new Error(SESSION_DATA_MISSING_OPENPHASES_KEY)),
+    throwIfFalse(hasOpenPhases, () => new Error(NO_ACCESSIBLE_PHASES)),
+    throwIfFalse(areOpenPhasesValid, () => new Error(NO_VALID_OPEN_PHASES)),
+    throwIfFalse(isOpenPhasesRepoDefined, () => new Error(OPENED_PHASE_REPO_UNDEFINED))
   );
 }
 
@@ -44,9 +42,10 @@ function isOpenPhasesKeyPresent(sessionData: SessionData): boolean {
  * @param sessionData
  */
 function areOpenPhasesValid(sessionData: SessionData): boolean {
-  return sessionData.openPhases.reduce((isOpenPhasesValidSoFar: boolean, currentOpenPhase: string) =>
-    isOpenPhasesValidSoFar && currentOpenPhase in Phase,
-    true);
+  return sessionData.openPhases.reduce(
+    (isOpenPhasesValidSoFar: boolean, currentOpenPhase: string) => isOpenPhasesValidSoFar && currentOpenPhase in Phase,
+    true
+  );
 }
 
 /**
@@ -54,9 +53,10 @@ function areOpenPhasesValid(sessionData: SessionData): boolean {
  * @param sessionData
  */
 function isOpenPhasesRepoDefined(sessionData: SessionData): boolean {
-  return sessionData.openPhases.reduce((isOpenPhasesRepoDefinedSoFar: boolean, currentOpenPhase: string) =>
-    isOpenPhasesRepoDefinedSoFar && !!sessionData[currentOpenPhase],
-    true);
+  return sessionData.openPhases.reduce(
+    (isOpenPhasesRepoDefinedSoFar: boolean, currentOpenPhase: string) => isOpenPhasesRepoDefinedSoFar && !!sessionData[currentOpenPhase],
+    true
+  );
 }
 
 function hasOpenPhases(sessionData: SessionData): boolean {

--- a/src/app/core/models/templates/sections/issue-dispute-section.model.ts
+++ b/src/app/core/models/templates/sections/issue-dispute-section.model.ts
@@ -9,7 +9,7 @@ export class IssueDisputeSection extends Section {
     if (!this.parseError) {
       let matches;
       const regex = /#{2} *:question: *(.*)[\r\n]*([\s\S]*?(?=-{19}))/gi;
-      while (matches = regex.exec(this.content)) {
+      while ((matches = regex.exec(this.content))) {
         if (matches) {
           const [_regexString, title, description] = matches;
           this.disputes.push(new IssueDispute(title, description.trim()));

--- a/src/app/core/models/templates/sections/moderation-section.model.ts
+++ b/src/app/core/models/templates/sections/moderation-section.model.ts
@@ -10,7 +10,7 @@ export class ModerationSection extends Section {
     if (!this.parseError) {
       let matches;
       const regex = /#{2} *:question: *(.*)[\n\r]*(.*)[\n\r]*([\s\S]*?(?=-{19}))/gi;
-      while (matches = regex.exec(this.content)) {
+      while ((matches = regex.exec(this.content))) {
         if (matches) {
           const [_regexString, title, todo, tutorResponse] = matches;
           const description = `${todo}\n${tutorResponse}`;
@@ -25,7 +25,7 @@ export class ModerationSection extends Section {
   }
 
   get todoList(): Checkbox[] {
-    return this.disputesToResolve.map(e => e.todo);
+    return this.disputesToResolve.map((e) => e.todo);
   }
 
   toString(): string {

--- a/src/app/core/models/templates/sections/section.model.ts
+++ b/src/app/core/models/templates/sections/section.model.ts
@@ -26,8 +26,8 @@ export class Section {
   constructor(sectionalDependency: SectionalDependency, unprocessedContent: string) {
     this.header = sectionalDependency.sectionHeader;
     // If length === 0, match till end of string else match till regex hits another section
-    const matchTillRegex = sectionalDependency.remainingTemplateHeaders.length === 0 ? '$'
-      : sectionalDependency.remainingTemplateHeaders.join('|');
+    const matchTillRegex =
+      sectionalDependency.remainingTemplateHeaders.length === 0 ? '$' : sectionalDependency.remainingTemplateHeaders.join('|');
     this.sectionRegex = new RegExp(`(${this.header})\\s+([\\s\\S]*?)(?=${matchTillRegex}|$)`, 'i');
     const matches = this.sectionRegex.exec(unprocessedContent);
     if (matches) {

--- a/src/app/core/models/templates/sections/tester-response-section.model.ts
+++ b/src/app/core/models/templates/sections/tester-response-section.model.ts
@@ -26,7 +26,7 @@ export class TesterResponseSection extends Section {
     if (!this.parseError) {
       let matches;
       const regex: RegExp = new RegExp([matchTitle, matchDescription, matchDisagreement].join('[\\r\\n]*') + matchLinebreak, 'gi');
-      while (matches = regex.exec(this.content)) {
+      while ((matches = regex.exec(this.content))) {
         if (matches) {
           const [_, title, description, disagreeCheckbox, reasonForDisagreement] = matches;
 
@@ -36,8 +36,15 @@ export class TesterResponseSection extends Section {
             this.teamChosenType = this.parseTeamChosenType(description);
           }
 
-          this.testerResponses.push(new TesterResponse(title, description, this.parseCheckboxDescription(disagreeCheckbox),
-            this.parseCheckboxValue(disagreeCheckbox), reasonForDisagreement.trim()));
+          this.testerResponses.push(
+            new TesterResponse(
+              title,
+              description,
+              this.parseCheckboxDescription(disagreeCheckbox),
+              this.parseCheckboxValue(disagreeCheckbox),
+              reasonForDisagreement.trim()
+            )
+          );
         }
       }
     }
@@ -60,13 +67,15 @@ export class TesterResponseSection extends Section {
   }
 
   parseTeamChosenSeverity(description: string): string {
-    return extractStringBetween(description, this.TEAM_RESPONSE_DESCRIPTION_SEVERITY_VALUE_PREFIX,
-      this.TEAM_RESPONSE_DESCRIPTION_VALUE_SUFFIX);
+    return extractStringBetween(
+      description,
+      this.TEAM_RESPONSE_DESCRIPTION_SEVERITY_VALUE_PREFIX,
+      this.TEAM_RESPONSE_DESCRIPTION_VALUE_SUFFIX
+    );
   }
 
   parseTeamChosenType(description: string): string {
-    return extractStringBetween(description, this.TEAM_RESPONSE_DESCRIPTION_TYPE_VALUE_PREFIX,
-      this.TEAM_RESPONSE_DESCRIPTION_VALUE_SUFFIX);
+    return extractStringBetween(description, this.TEAM_RESPONSE_DESCRIPTION_TYPE_VALUE_PREFIX, this.TEAM_RESPONSE_DESCRIPTION_VALUE_SUFFIX);
   }
 
   parseCheckboxValue(checkboxString: string): boolean {

--- a/src/app/core/models/templates/team-response-template.model.ts
+++ b/src/app/core/models/templates/team-response-template.model.ts
@@ -5,8 +5,8 @@ import { Section } from './sections/section.model';
 import { Header, Template } from './template.model';
 
 export const TeamResponseHeaders = {
-  teamResponse: new Header('Team\'s Response', 1),
-  duplicateOf: new Header('Duplicate status \\(if any\\):', 2),
+  teamResponse: new Header("Team's Response", 1),
+  duplicateOf: new Header('Duplicate status \\(if any\\):', 2)
 };
 
 export class TeamResponseTemplate extends Template {
@@ -17,8 +17,7 @@ export class TeamResponseTemplate extends Template {
   constructor(githubComments: GithubComment[]) {
     super(Object.values(TeamResponseHeaders));
 
-    const comment = githubComments.find(
-      (githubComment: GithubComment) => this.test(githubComment.body));
+    const comment = githubComments.find((githubComment: GithubComment) => this.test(githubComment.body));
     if (comment === undefined) {
       return;
     }

--- a/src/app/core/models/templates/template.model.ts
+++ b/src/app/core/models/templates/template.model.ts
@@ -12,7 +12,7 @@ export abstract class Template {
   }
 
   getSectionalDependency(header: Header): SectionalDependency {
-    const otherHeaders = this.headers.filter(e => !e.equals(header));
+    const otherHeaders = this.headers.filter((e) => !e.equals(header));
     return <SectionalDependency>{
       sectionHeader: header,
       remainingTemplateHeaders: otherHeaders
@@ -39,12 +39,12 @@ export class Header {
 
   constructor(name, headerSize, prefix: string = '') {
     this.name = name;
-    this.headerHash = '\#'.repeat(headerSize);
+    this.headerHash = '#'.repeat(headerSize);
     this.prefix = prefix;
   }
 
   toString(): string {
-    return this.headerHash.concat(this.prefix === '' ? ' ' : (' ' + this.prefix + ' ')).concat(this.name);
+    return this.headerHash.concat(this.prefix === '' ? ' ' : ' ' + this.prefix + ' ').concat(this.name);
   }
 
   equals(section: Header): boolean {

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -4,10 +4,9 @@ import { Section } from './sections/section.model';
 import { TesterResponseSection } from './sections/tester-response-section.model';
 import { Header, Template } from './template.model';
 
-
 export const TesterResponseHeaders = {
-  teamResponse: new Header('Team\'s Response', 1),
-  testerResponses: new Header('Items for the Tester to Verify', 1),
+  teamResponse: new Header("Team's Response", 1),
+  testerResponses: new Header('Items for the Tester to Verify', 1)
 };
 
 export class TesterResponseTemplate extends Template {
@@ -20,7 +19,7 @@ export class TesterResponseTemplate extends Template {
   constructor(githubIssueComments: GithubComment[]) {
     super(Object.values(TesterResponseHeaders));
 
-    const templateConformingComment = githubIssueComments.find(comment => this.test(comment.body));
+    const templateConformingComment = githubIssueComments.find((comment) => this.test(comment.body));
     if (templateConformingComment) {
       this.comment = <IssueComment>{
         ...templateConformingComment,
@@ -30,7 +29,6 @@ export class TesterResponseTemplate extends Template {
       this.testerResponse = this.parseTesterResponse(this.comment.description);
       this.teamChosenSeverity = this.testerResponse.getTeamChosenSeverity();
       this.teamChosenType = this.testerResponse.getTeamChosenType();
-
     }
   }
 

--- a/src/app/core/models/templates/tutor-moderation-issue-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-issue-template.model.ts
@@ -3,10 +3,9 @@ import { IssueDisputeSection } from './sections/issue-dispute-section.model';
 import { Section } from './sections/section.model';
 import { Header, Template } from './template.model';
 
-
 const tutorModerationIssueDescriptionHeaders = {
   description: new Header('Issue Description', 1),
-  teamResponse: new Header('Team\'s Response', 1),
+  teamResponse: new Header("Team's Response", 1),
   disputes: new Header('Disputes', 1)
 };
 

--- a/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
@@ -3,9 +3,8 @@ import { GithubComment } from '../github/github-comment.model';
 import { ModerationSection } from './sections/moderation-section.model';
 import { Header, Template } from './template.model';
 
-
 const tutorModerationTodoHeaders = {
-  todo: new Header('Tutor Moderation', 1),
+  todo: new Header('Tutor Moderation', 1)
 };
 
 export class TutorModerationTodoTemplate extends Template {
@@ -15,7 +14,7 @@ export class TutorModerationTodoTemplate extends Template {
   constructor(githubComments: GithubComment[]) {
     super(Object.values(tutorModerationTodoHeaders));
 
-    const templateConformingComment = githubComments.find(comment => this.test(comment.body));
+    const templateConformingComment = githubComments.find((comment) => this.test(comment.body));
     if (templateConformingComment) {
       this.comment = <IssueComment>{
         ...templateConformingComment,

--- a/src/app/core/models/tester-response.model.ts
+++ b/src/app/core/models/tester-response.model.ts
@@ -1,4 +1,4 @@
-import { Checkbox } from "./checkbox.model";
+import { Checkbox } from './checkbox.model';
 
 export class TesterResponse {
   readonly TITLE_PREFIX = '## :question: ';

--- a/src/app/core/services/application.service.ts
+++ b/src/app/core/services/application.service.ts
@@ -62,7 +62,7 @@ export class ApplicationService {
 
     const v1IntArr: number[] = [];
     const v2IntArr: number[] = [];
-    for (let i = 0; i < k; ++ i) {
+    for (let i = 0; i < k; ++i) {
       v1IntArr[i] = parseInt(v1Arr[i], 10);
       v2IntArr[i] = parseInt(v2Arr[i], 10);
       if (v1IntArr[i] > v2IntArr[i]) {
@@ -72,6 +72,6 @@ export class ApplicationService {
         return -1;
       }
     }
-    return v1.length === v2.length ? 0 : (v1.length < v2.length ? -1 : 1);
+    return v1.length === v2.length ? 0 : v1.length < v2.length ? -1 : 1;
   }
 }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -15,7 +15,12 @@ import { LoggingService } from './logging.service';
 import { PhaseService } from './phase.service';
 import { UserService } from './user.service';
 
-export enum AuthState { 'NotAuthenticated', 'AwaitingAuthentication', 'ConfirmOAuthUser', 'Authenticated'}
+export enum AuthState {
+  'NotAuthenticated',
+  'AwaitingAuthentication',
+  'ConfirmOAuthUser',
+  'Authenticated'
+}
 
 @Injectable({
   providedIn: 'root'
@@ -33,15 +38,19 @@ export class AuthService {
 
   ENABLE_POPUP_MESSAGE = 'Please enable pop-ups in your browser';
 
-  constructor(private electronService: ElectronService, private router: Router, private ngZone: NgZone,
-              private githubService: GithubService,
-              private userService: UserService,
-              private issueService: IssueService,
-              private phaseService: PhaseService,
-              private dataService: DataService,
-              private githubEventService: GithubEventService,
-              private titleService: Title,
-              private logger: LoggingService) {}
+  constructor(
+    private electronService: ElectronService,
+    private router: Router,
+    private ngZone: NgZone,
+    private githubService: GithubService,
+    private userService: UserService,
+    private issueService: IssueService,
+    private phaseService: PhaseService,
+    private dataService: DataService,
+    private githubEventService: GithubEventService,
+    private titleService: Title,
+    private logger: LoggingService
+  ) {}
 
   /**
    * Will store the OAuth token.
@@ -120,9 +129,11 @@ export class AuthService {
       this.electronService.sendIpcMessage('github-oauth', githubRepoPermission);
     } else {
       this.generateStateString();
-      this.redirectToOAuthPage(encodeURI(
-        `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
-      ));
+      this.redirectToOAuthPage(
+        encodeURI(
+          `${AppConfig.githubUrl}/login/oauth/authorize?client_id=${AppConfig.clientId}&scope=${githubRepoPermission},read:user&state=${this.state}`
+        )
+      );
       this.logger.info('Redirecting for Github authentication');
     }
   }

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -13,7 +13,6 @@ import { Team } from '../models/team.model';
 import { User, UserRole } from '../models/user.model';
 import { GithubService } from './github.service';
 
-
 @Injectable({
   providedIn: 'root'
 })
@@ -23,9 +22,8 @@ import { GithubService } from './github.service';
  * and student information for the current session in CATcher.
  */
 export class DataService {
-
   public static ROLES = 'roles';
-  public static TEAM_STRUCTURE  = 'team-structure';
+  public static TEAM_STRUCTURE = 'team-structure';
   public static STUDENTS_ALLOCATION = 'students-allocation';
   public static TUTORS_ALLOCATION = 'tutors-allocation';
   public static ADMINS_ALLOCATION = 'admins-allocation';
@@ -213,12 +211,12 @@ export class DataService {
    * @return - Subjects that tracks the parsed data.
    */
   private parseUsersData(csvText: string): ParsedUserData[] {
-    const lines = csvText.split('\n').filter(v => v.trim());
-    const headers = lines[0].split(',').map(h => h.trim());
+    const lines = csvText.split('\n').filter((v) => v.trim());
+    const headers = lines[0].split(',').map((h) => h.trim());
     const result: ParsedUserData[] = [];
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
-      const lineValues = line.split(',').map(v => v.trim());
+      const lineValues = line.split(',').map((v) => v.trim());
       const lineObj: ParsedUserData = {};
       for (let j = 0; j < headers.length; j++) {
         if (!lineValues[j]) {

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -1,32 +1,30 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import { LabelDefinitionPopupComponent } from "../../shared/label-definition-popup/label-definition-popup.component";
+import { LabelDefinitionPopupComponent } from '../../shared/label-definition-popup/label-definition-popup.component';
 import { UserConfirmationComponent } from '../guards/user-confirmation/user-confirmation.component';
 
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root'
 })
-
 export class DialogService {
+  constructor(private dialog: MatDialog) {}
 
-    constructor(private dialog: MatDialog) { }
+  openUserConfirmationModal(messages: string[], yesButtonMessage: string, noButtonMessage: string) {
+    return this.dialog.open(UserConfirmationComponent, {
+      data: {
+        messages: messages,
+        yesMessage: yesButtonMessage,
+        noMessage: noButtonMessage
+      }
+    });
+  }
 
-    openUserConfirmationModal(messages: string[], yesButtonMessage: string, noButtonMessage: string) {
-        return this.dialog.open(UserConfirmationComponent, {
-            data: {
-                messages: messages,
-                yesMessage: yesButtonMessage,
-                noMessage: noButtonMessage
-            }
-        });
-    }
-
-    openLabelDefinitionDialog(labelName: String, labelDefinition: String) {
-        return this.dialog.open(LabelDefinitionPopupComponent, {
-            data: {
-                header: labelName,
-                body: labelDefinition
-            }
-        });
-    }
+  openLabelDefinitionDialog(labelName: String, labelDefinition: String) {
+    return this.dialog.open(LabelDefinitionPopupComponent, {
+      data: {
+        header: labelName,
+        body: labelDefinition
+      }
+    });
+  }
 }

--- a/src/app/core/services/electron.service.ts
+++ b/src/app/core/services/electron.service.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 
 /**
@@ -29,7 +29,6 @@ export class ElectronService {
   isElectron(): boolean {
     return window && window.process && window.process.type;
   }
-
 
   clearCookies() {
     if (this.isElectron()) {

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -11,10 +11,9 @@ export const ERRORCODE_NOT_FOUND = 404;
 const FILTERABLE = ['node_modules'];
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class ErrorHandlingService implements ErrorHandler {
-
   constructor(private snackBar: MatSnackBar, private logger: LoggingService) {}
 
   handleError(error: HttpErrorResponse | Error | RequestError, actionCallback?: () => void) {
@@ -31,9 +30,9 @@ export class ErrorHandlingService implements ErrorHandler {
 
   private cleanStack(stacktrace: string): string {
     return stacktrace
-            .split('\n')
-            .filter(line => !FILTERABLE.some(word => line.includes(word))) // exclude lines that contain words in FILTERABLE
-            .join('\n');
+      .split('\n')
+      .filter((line) => !FILTERABLE.some((word) => line.includes(word))) // exclude lines that contain words in FILTERABLE
+      .join('\n');
   }
 
   // Ref: https://developer.github.com/v3/#client-errors
@@ -50,23 +49,23 @@ export class ErrorHandlingService implements ErrorHandler {
 
     switch (error.status) {
       case 500: // Internal Server Error.
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, { data: error });
         break;
       case 422: // Form errors
-        this.snackBar.openFromComponent(FormErrorComponent, {data: error});
+        this.snackBar.openFromComponent(FormErrorComponent, { data: error });
         break;
       case 400: // Bad request
       case 401: // Unauthorized
       case 404: // Not found
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, { data: error });
         break;
       default:
-        this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: error});
+        this.snackBar.openFromComponent(GeneralMessageErrorComponent, { data: error });
         return;
     }
   }
 
   private handleGeneralError(error: string): void {
-    this.snackBar.openFromComponent(GeneralMessageErrorComponent, {data: {message: error}});
+    this.snackBar.openFromComponent(GeneralMessageErrorComponent, { data: { message: error } });
   }
 }

--- a/src/app/core/services/factories/factory.auth.service.ts
+++ b/src/app/core/services/factories/factory.auth.service.ts
@@ -13,22 +13,45 @@ import { MockAuthService } from '../mocks/mock.auth.service';
 import { PhaseService } from '../phase.service';
 import { UserService } from '../user.service';
 
-export function AuthServiceFactory(electronService: ElectronService, router: Router, ngZone: NgZone,
-                                   githubService: GithubService,
-                                   userService: UserService,
-                                   issueService: IssueService,
-                                   phaseService: PhaseService,
-                                   dataService: DataService,
-                                   githubEventService: GithubEventService,
-                                   titleService: Title,
-                                   logger: LoggingService) {
+export function AuthServiceFactory(
+  electronService: ElectronService,
+  router: Router,
+  ngZone: NgZone,
+  githubService: GithubService,
+  userService: UserService,
+  issueService: IssueService,
+  phaseService: PhaseService,
+  dataService: DataService,
+  githubEventService: GithubEventService,
+  titleService: Title,
+  logger: LoggingService
+) {
   if (AppConfig.test) {
-      return new MockAuthService(router, ngZone, githubService,
-        userService, issueService, phaseService, dataService,
-        githubEventService, titleService, logger);
+    return new MockAuthService(
+      router,
+      ngZone,
+      githubService,
+      userService,
+      issueService,
+      phaseService,
+      dataService,
+      githubEventService,
+      titleService,
+      logger
+    );
   }
   console.log(logger);
-  return new AuthService(electronService, router, ngZone,
-    githubService, userService, issueService, phaseService,
-    dataService, githubEventService, titleService, logger);
+  return new AuthService(
+    electronService,
+    router,
+    ngZone,
+    githubService,
+    userService,
+    issueService,
+    phaseService,
+    dataService,
+    githubEventService,
+    titleService,
+    logger
+  );
 }

--- a/src/app/core/services/factories/factory.github.service.ts
+++ b/src/app/core/services/factories/factory.github.service.ts
@@ -7,7 +7,7 @@ import { MockGithubService } from '../mocks/mock.github.service';
 
 export function GithubServiceFactory(handling: ErrorHandlingService, apollo: Apollo, electron: ElectronService) {
   if (AppConfig.test) {
-      return new MockGithubService();
+    return new MockGithubService();
   }
   return new GithubService(handling, apollo, electron);
 }

--- a/src/app/core/services/factories/factory.issue.service.ts
+++ b/src/app/core/services/factories/factory.issue.service.ts
@@ -7,11 +7,15 @@ import { MockIssueService } from '../mocks/mock.issue.service';
 import { PhaseService } from '../phase.service';
 import { UserService } from '../user.service';
 
-export function IssueServiceFactory(githubService: GithubService, userService: UserService, phaseService: PhaseService,
-                                    electronService: ElectronService, dataService: DataService) {
+export function IssueServiceFactory(
+  githubService: GithubService,
+  userService: UserService,
+  phaseService: PhaseService,
+  electronService: ElectronService,
+  dataService: DataService
+) {
   if (AppConfig.test) {
-      return new MockIssueService(githubService, phaseService, dataService);
+    return new MockIssueService(githubService, phaseService, dataService);
   }
-  return new IssueService(githubService, userService, phaseService,
-    electronService, dataService);
+  return new IssueService(githubService, userService, phaseService, electronService, dataService);
 }

--- a/src/app/core/services/githubevent.service.ts
+++ b/src/app/core/services/githubevent.service.ts
@@ -8,27 +8,26 @@ import { IssueService } from './issue.service';
   providedIn: 'root'
 })
 export class GithubEventService {
-
   private lastModified: string; // The timestamp when the title or label of an issue is changed
   private lastModifiedComment: string; // The timestamp when the comment of an issue is changed
 
-  constructor(private githubService: GithubService, private issueService: IssueService) { }
+  constructor(private githubService: GithubService, private issueService: IssueService) {}
 
   /**
    * Calls the Github service api to return the latest github event (e.g renaming an issue's title)
    * of current repository and store the timestamps of the event in this service
    */
   setLatestChangeEvent(): Observable<any> {
-      return this.githubService.fetchEventsForRepo().pipe(
-        map((response) => {
-          if (response.length === 0) {
-            return response;
-          }
-          this.setLastModifiedTime(response[0]['created_at']);
-          this.setLastModifiedCommentTime(response[0]['issue']['updated_at']);
+    return this.githubService.fetchEventsForRepo().pipe(
+      map((response) => {
+        if (response.length === 0) {
           return response;
-        })
-      );
+        }
+        this.setLastModifiedTime(response[0]['created_at']);
+        this.setLastModifiedCommentTime(response[0]['issue']['updated_at']);
+        return response;
+      })
+    );
   }
 
   /**
@@ -45,8 +44,7 @@ export class GithubEventService {
         const eventResponse = response[0];
         // Will only allow page to reload if the latest modify time is different
         // from last modified, meaning that some changes to the repo has occured.
-        if (eventResponse['created_at'] !== this.lastModified ||
-        eventResponse['issue']['updated_at'] !== this.lastModifiedComment) {
+        if (eventResponse['created_at'] !== this.lastModified || eventResponse['issue']['updated_at'] !== this.lastModifiedComment) {
           this.setLastModifiedTime(eventResponse['created_at']);
           this.setLastModifiedCommentTime(eventResponse['issue']['updated_at']);
           return this.issueService.reloadAllIssues().pipe(map((response: any[]) => true));

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -10,50 +10,54 @@ W3C recommendation is 0.179, but 0.184 is chosen so that some colors (like brigh
 are considered dark (Github too consider them dark) */
 const COLOR_DARKNESS_THRESHOLD = 0.184;
 
-const COLOR_DARK_TEXT  = '000000'; // Dark color for text with light background
-const COLOR_LIGHT_TEXT  = 'FFFFFF'; // Light color for text with dark background
+const COLOR_DARK_TEXT = '000000'; // Dark color for text with light background
+const COLOR_LIGHT_TEXT = 'FFFFFF'; // Light color for text with dark background
 
 const DISPLAY_NAME_SEVERITY = 'Severity';
 const DISPLAY_NAME_BUG_TYPE = 'Bug Type';
 const DISPLAY_NAME_RESPONSE = 'Response';
 
 // The HTML template definition of selected labels are hard-coded here, move to a config file in the future
-const VERY_LOW_DEFINITION = '<p>A flaw that is <mark>purely cosmetic</mark> and <mark>does not affect usage</mark>. For example, '
-  + '<ul>'
-  + '<li>typo issues</li>'
-  + '<li>spacing issues</li>'
-  + '<li>layout issues</li>'
-  + '<li>color issues</li>'
-  + '<li>font issues</li>'
-  + '</ul>'
-  + 'in the docs or the UI that doesn\'t affect usage.</p>';
-const LOW_DEFINITION = '<p>A flaw that is unlikely to affect normal operations of the product. '
-  + 'Appears only in very rare situations and causes a minor inconvenience only.</p>';
-const MEDIUM_DEFINITION = '<p>A flaw that causes occasional inconvenience to some users but they can '
-  + 'continue to use the product.</p>';
-const HIGH_DEFINITION = '<p>A flaw that affects most users and causes major problems for users.'
-  + 'i.e., makes the product almost unusable for most users.</p>';
+const VERY_LOW_DEFINITION =
+  '<p>A flaw that is <mark>purely cosmetic</mark> and <mark>does not affect usage</mark>. For example, ' +
+  '<ul>' +
+  '<li>typo issues</li>' +
+  '<li>spacing issues</li>' +
+  '<li>layout issues</li>' +
+  '<li>color issues</li>' +
+  '<li>font issues</li>' +
+  '</ul>' +
+  "in the docs or the UI that doesn't affect usage.</p>";
+const LOW_DEFINITION =
+  '<p>A flaw that is unlikely to affect normal operations of the product. ' +
+  'Appears only in very rare situations and causes a minor inconvenience only.</p>';
+const MEDIUM_DEFINITION = '<p>A flaw that causes occasional inconvenience to some users but they can ' + 'continue to use the product.</p>';
+const HIGH_DEFINITION =
+  '<p>A flaw that affects most users and causes major problems for users.' + 'i.e., makes the product almost unusable for most users.</p>';
 
 const FUNCTIONALITY_BUG_DEFINITION = '<p>A functionality does not work as specified/expected.</p>';
-const FEATURE_FLAW_DEFINITION = '<p>Some functionality missing from a feature delivered in the current version in '
-  + 'a way that the feature becomes less useful to the intended target user for <i>normal</i> usage. '
-  + 'i.e., the feature is not \'complete\'.\nIn other words, an acceptance-testing bug that falls within '
-  + 'the scope of the current version features. These issues are counted against the <i>product design</i> aspect '
-  + 'of the project.</p>';
-const DOCUMENTATION_BUG_DEFINITION = '<p>A flaw in the documentation '
-  + '<span style="color:grey;">e.g., a missing step, a wrong instruction, typos</span></p>';
+const FEATURE_FLAW_DEFINITION =
+  '<p>Some functionality missing from a feature delivered in the current version in ' +
+  'a way that the feature becomes less useful to the intended target user for <i>normal</i> usage. ' +
+  "i.e., the feature is not 'complete'.\nIn other words, an acceptance-testing bug that falls within " +
+  'the scope of the current version features. These issues are counted against the <i>product design</i> aspect ' +
+  'of the project.</p>';
+const DOCUMENTATION_BUG_DEFINITION =
+  '<p>A flaw in the documentation ' + '<span style="color:grey;">e.g., a missing step, a wrong instruction, typos</span></p>';
 
 const ACCEPTED_DEFINITION = '<p>You accept it as a bug.</p>';
-const NOT_IN_SCOPE_DEFINITION = '<p>It is a valid issue but not something the team should be penalized for '
-  + '<span style="color:grey;">e.g., it was not related to features delivered in this version</span>.</p>';
-const REJECTED_DEFINITION = '<p>What tester treated as a bug is in fact the expected behavior (from the user\'s point of view), or the tester '
-  + 'was mistaken in some other way.</p>';
+const NOT_IN_SCOPE_DEFINITION =
+  '<p>It is a valid issue but not something the team should be penalized for ' +
+  '<span style="color:grey;">e.g., it was not related to features delivered in this version</span>.</p>';
+const REJECTED_DEFINITION =
+  "<p>What tester treated as a bug is in fact the expected behavior (from the user's point of view), or the tester " +
+  'was mistaken in some other way.</p>';
 const CANNOT_REPRODUCE_DEFINITION = '<p>You are unable to reproduce the behavior reported in the bug after multiple tries.</p>';
 const ISSUE_UNCLEAR_DEFINITION = '<p>The issue description is not clear.</p>';
 const UNDEFINED_DEFINITION = null;
 
 export const LABEL_DEFINITIONS = {
-  severityVeryLow : VERY_LOW_DEFINITION,
+  severityVeryLow: VERY_LOW_DEFINITION,
   severityLow: LOW_DEFINITION,
   severityMedium: MEDIUM_DEFINITION,
   severityHigh: HIGH_DEFINITION,
@@ -105,7 +109,6 @@ const REQUIRED_LABELS = {
  * from the GitHub repository for the CATcher application.
  */
 export class LabelService {
-
   private static severityLabels: Label[] = Object.values(REQUIRED_LABELS.severity);
   private static typeLabels: Label[] = Object.values(REQUIRED_LABELS.type);
   private static responseLabels: Label[] = Object.values(REQUIRED_LABELS.response);
@@ -120,17 +123,16 @@ export class LabelService {
   };
   private static testerLabelArrays = {
     severity: LabelService.severityLabels,
-    type: LabelService.typeLabels,
+    type: LabelService.typeLabels
   };
 
-  constructor(private githubService: GithubService) {
-  }
+  constructor(private githubService: GithubService) {}
 
   public static getRequiredLabelsAsArray(needAllLabels: boolean): Label[] {
     let requiredLabels: Label[] = [];
 
     const labels = needAllLabels ? Object.values(this.allLabelArrays) : Object.values(this.testerLabelArrays);
-    labels.map(label => requiredLabels = requiredLabels.concat(label));
+    labels.map((label) => (requiredLabels = requiredLabels.concat(label)));
     return requiredLabels;
   }
 
@@ -140,21 +142,19 @@ export class LabelService {
    * with the remote repository.
    */
   syncLabels(needAllLabels: boolean): UnaryFunction<Observable<boolean>, Observable<any>> {
-    return pipe(
-      flatMap(() => this.synchronizeRemoteLabels(needAllLabels))
-    );
+    return pipe(flatMap(() => this.synchronizeRemoteLabels(needAllLabels)));
   }
 
   /**
    * Synchronizes the labels in github with those required by the application.
    */
   synchronizeRemoteLabels(needAllLabels: boolean): Observable<any> {
-      return this.githubService.fetchAllLabels().pipe(
-        map((response) => {
-          this.ensureRepoHasRequiredLabels(this.parseLabelData(response), LabelService.getRequiredLabelsAsArray(needAllLabels));
-          return response;
-        })
-      );
+    return this.githubService.fetchAllLabels().pipe(
+      map((response) => {
+        this.ensureRepoHasRequiredLabels(this.parseLabelData(response), LabelService.getRequiredLabelsAsArray(needAllLabels));
+        return response;
+      })
+    );
   }
 
   /**
@@ -201,7 +201,7 @@ export class LabelService {
       return WHITE_COLOR;
     }
 
-    const existingLabel = LabelService.getRequiredLabelsAsArray(true).find(label => label.labelValue === labelValue);
+    const existingLabel = LabelService.getRequiredLabelsAsArray(true).find((label) => label.labelValue === labelValue);
 
     if (existingLabel === undefined || existingLabel.labelColor === undefined) {
       return WHITE_COLOR;
@@ -222,7 +222,7 @@ export class LabelService {
     }
 
     const existingLabel = LabelService.getRequiredLabelsAsArray(true).find(
-      label => label.labelValue === labelValue && label.labelCategory === labelCategory
+      (label) => label.labelValue === labelValue && label.labelCategory === labelCategory
     );
 
     if (existingLabel === undefined || existingLabel.labelDefinition === undefined) {
@@ -242,33 +242,23 @@ export class LabelService {
    * @param requiredLabels: required labels.
    */
   private ensureRepoHasRequiredLabels(actualLabels: Label[], requiredLabels: Label[]): void {
-
-    requiredLabels.forEach(label => {
-
+    requiredLabels.forEach((label) => {
       // Finds for a label that has the same name as a required label.
-      const nameMatchedLabels: Label[] = actualLabels.filter(remoteLabel =>
-          remoteLabel.getFormattedName() === label.getFormattedName());
+      const nameMatchedLabels: Label[] = actualLabels.filter((remoteLabel) => remoteLabel.getFormattedName() === label.getFormattedName());
 
       if (nameMatchedLabels.length === 0) {
-
         // Create new Label (Could not find a label with the same name & category)
         this.githubService.createLabel(label.getFormattedName(), label.labelColor);
-
       } else if (nameMatchedLabels.length === 1) {
         if (nameMatchedLabels[0].equals(label)) {
-
           // the label exists exactly as expected -> do nothing
-
         } else {
-
           // the label exists but the color does not match
           this.githubService.updateLabel(label.getFormattedName(), label.labelColor);
-
         }
       } else {
         throw new Error('Unexpected error: the repo has multiple labels with the same name ' + label.getFormattedName());
       }
-
     });
   }
 
@@ -280,16 +270,13 @@ export class LabelService {
     const labelData: Label[] = [];
 
     for (const label of labels) {
-
       let labelCategory: string;
       let labelValue: string;
       const containsDotRegex = /\./g;
 
       const rawName: string = String(label['name']);
 
-      [labelCategory, labelValue] = containsDotRegex.test(rawName)
-        ? String(label['name']).split('.')
-        : [undefined, rawName];
+      [labelCategory, labelValue] = containsDotRegex.test(rawName) ? String(label['name']).split('.') : [undefined, rawName];
 
       const labelColor: string = String(label['color']);
 
@@ -300,13 +287,13 @@ export class LabelService {
     return labelData;
   }
 
-   /**
+  /**
    * Returns true if the given color is considered "dark"
    * The color is considered "dark" if its luminance is less than COLOR_DARKNESS_THRESHOLD
    * @param inputColor: the color
    */
   isDarkColor(inputColor: string): boolean {
-    const COLOR = (inputColor.charAt(0) === '#') ? inputColor.substring(1, 7) : inputColor;
+    const COLOR = inputColor.charAt(0) === '#' ? inputColor.substring(1, 7) : inputColor;
     const R = parseInt(COLOR.substring(0, 2), 16);
     const G = parseInt(COLOR.substring(2, 4), 16);
     const B = parseInt(COLOR.substring(4, 6), 16);
@@ -318,7 +305,7 @@ export class LabelService {
       return Math.pow((col + 0.055) / 1.055, 2.4);
     });
     // Calculate the luminance of the color
-    const LUMINANCE = (0.2126 * LINEAR_RGB[0]) + (0.7152 * LINEAR_RGB[1]) + (0.0722 * LINEAR_RGB[2]);
+    const LUMINANCE = 0.2126 * LINEAR_RGB[0] + 0.7152 * LINEAR_RGB[1] + 0.0722 * LINEAR_RGB[2];
     // The color is "dark" if the luminance is lower than the threshold
     return LUMINANCE < COLOR_DARKNESS_THRESHOLD;
   }
@@ -335,16 +322,15 @@ export class LabelService {
     textColor = this.isDarkColor(color) ? COLOR_LIGHT_TEXT : COLOR_DARK_TEXT;
 
     const styles = {
-      'background-color' : `#${color}`,
-      'border-radius' : '3px',
-      'cursor' : 'default',
-      'padding' : '3px',
-      'color' : `#${textColor}`,
-      'font-weight' : '410',
-      'display': display
+      'background-color': `#${color}`,
+      'border-radius': '3px',
+      cursor: 'default',
+      padding: '3px',
+      color: `#${textColor}`,
+      'font-weight': '410',
+      display: display
     };
 
     return styles;
   }
-
 }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -4,7 +4,6 @@ import { AppConfig } from '../../../environments/environment';
 import { downloadAsTextFile } from '../../shared/lib/file-download';
 import { ElectronService } from './electron.service';
 
-
 @Injectable({
   providedIn: 'root'
 })
@@ -66,9 +65,10 @@ export class LoggingService {
     const logHeaderWithDateTime = `${this.LOG_START_HEADER}\n${currentDateTime}`;
 
     // Check if Trimming is Necessary
-    const numberOfSessions: number = currentLog == null ? 0 : currentLog.split('\n')
-      .filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER))
-      .length;
+    const numberOfSessions: number =
+      currentLog == null
+        ? 0
+        : currentLog.split('\n').filter((currentLogLine: string) => currentLogLine.includes(this.LOG_START_HEADER)).length;
 
     if (numberOfSessions === 0) {
       return logHeaderWithDateTime;
@@ -78,7 +78,8 @@ export class LoggingService {
       return `${currentLog}${this.SESSION_LOG_SEPARATOR}${logHeaderWithDateTime}`;
     }
 
-    const separatedSessionLogs: string[] = currentLog.split(`${this.LOG_START_HEADER}`)
+    const separatedSessionLogs: string[] = currentLog
+      .split(`${this.LOG_START_HEADER}`)
       .filter((line: string) => !!line)
       .map((line: string) => `${this.LOG_START_HEADER}\n${line.trim()}`);
 
@@ -96,7 +97,7 @@ export class LoggingService {
     localStorage.setItem(this.LOG_KEY, updatedLog);
   }
 
-  private updateLog(... updatedLog: any[]): void {
+  private updateLog(...updatedLog: any[]): void {
     this.setCachedLog(`${this.getCachedLog()}\n${updatedLog.toString()}`);
   }
 

--- a/src/app/core/services/mocks/mock.auth.service.ts
+++ b/src/app/core/services/mocks/mock.auth.service.ts
@@ -12,7 +12,12 @@ import { LoggingService } from '../logging.service';
 import { PhaseService } from '../phase.service';
 import { UserService } from '../user.service';
 
-export enum AuthState { 'NotAuthenticated', 'AwaitingAuthentication', 'ConfirmOAuthUser', 'Authenticated'}
+export enum AuthState {
+  'NotAuthenticated',
+  'AwaitingAuthentication',
+  'ConfirmOAuthUser',
+  'Authenticated'
+}
 
 @Injectable({
   providedIn: 'root'
@@ -22,15 +27,18 @@ export class MockAuthService {
   currentAuthState = this.authStateSource.asObservable();
   accessToken = new BehaviorSubject(undefined);
 
-  constructor(private router: Router, private ngZone: NgZone,
-              private githubService: GithubService,
-              private userService: UserService,
-              private issueService: IssueService,
-              private phaseService: PhaseService,
-              private dataService: DataService,
-              private githubEventService: GithubEventService,
-              private titleService: Title,
-              private logger: LoggingService) {}
+  constructor(
+    private router: Router,
+    private ngZone: NgZone,
+    private githubService: GithubService,
+    private userService: UserService,
+    private issueService: IssueService,
+    private phaseService: PhaseService,
+    private dataService: DataService,
+    private githubEventService: GithubEventService,
+    private titleService: Title,
+    private logger: LoggingService
+  ) {}
 
   /**
    * Will store the OAuth token.

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -21,7 +21,7 @@ let octokit = new Octokit();
 
 @Injectable()
 export class MockGithubService {
-  numIssuesCreated: number;  // tracks the number of GithubIssues created by this mock service
+  numIssuesCreated: number; // tracks the number of GithubIssues created by this mock service
 
   constructor() {
     this.numIssuesCreated = 0;
@@ -58,17 +58,17 @@ export class MockGithubService {
    * Creates a GithubIssue with the specified title / description / labels.
    */
   createIssue(title: string, description: string, labels: string[]): Observable<GithubIssue> {
-      const githubLabels: GithubLabel[] = labels.map(labelString => new GithubLabel({name: labelString}));
+    const githubLabels: GithubLabel[] = labels.map((labelString) => new GithubLabel({ name: labelString }));
 
-      const githubIssueData = {
-        number: this.numIssuesCreated, // Issue's display ID
-        title: title,
-        body: description,
-        labels: githubLabels
-      };
+    const githubIssueData = {
+      number: this.numIssuesCreated, // Issue's display ID
+      title: title,
+      body: description,
+      labels: githubLabels
+    };
 
-      this.numIssuesCreated++;
-      return of(new GithubIssue(githubIssueData));
+    this.numIssuesCreated++;
+    return of(new GithubIssue(githubIssueData));
   }
 
   /**
@@ -77,12 +77,14 @@ export class MockGithubService {
    * being present.
    */
   fetchAllLabels(): Observable<Array<{}>> {
-    return of(LabelService.getRequiredLabelsAsArray(true).map((label: Label) => {
-      return {
-        name: label.labelCategory ? `${label.labelCategory}.${label.labelValue}` : `${label.labelValue}`,
-        color: `${label.labelColor}`
-      };
-    }));
+    return of(
+      LabelService.getRequiredLabelsAsArray(true).map((label: Label) => {
+        return {
+          name: label.labelCategory ? `${label.labelCategory}.${label.labelValue}` : `${label.labelValue}`,
+          color: `${label.labelColor}`
+        };
+      })
+    );
   }
 
   /**
@@ -97,8 +99,7 @@ export class MockGithubService {
    */
   fetchDataFile(): Observable<{}> {
     return of({
-      data: 'role,name,team\n' +
-        `${AppConfig.role},${AppConfig.username},${AppConfig.team}\n`
+      data: 'role,name,team\n' + `${AppConfig.role},${AppConfig.username},${AppConfig.team}\n`
     });
   }
 
@@ -121,7 +122,7 @@ export class MockGithubService {
    */
   fetchSettingsFile(): Observable<SessionData> {
     return of({
-      openPhases : [Phase.phaseBugReporting, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration],
+      openPhases: [Phase.phaseBugReporting, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration],
       [Phase.phaseBugReporting]: 'undefined',
       [Phase.phaseTeamResponse]: 'undefined',
       [Phase.phaseTesterResponse]: 'undefined',

--- a/src/app/core/services/permission.service.ts
+++ b/src/app/core/services/permission.service.ts
@@ -4,145 +4,148 @@ import { UserRole } from '../models/user.model';
 import { PhaseService } from './phase.service';
 import { UserService } from './user.service';
 
-const enum PermissionLevel { Phase = 'Phase', User = 'User' }
+const enum PermissionLevel {
+  Phase = 'Phase',
+  User = 'User'
+}
 
 const PERMISSIONS = {
   [Phase.phaseBugReporting]: {
     [UserRole.Student]: {
-      'isIssueCreatable': true,
-      'isIssueDeletable': true,
-      'isIssueTitleEditable': true,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: true,
+      isIssueDeletable: true,
+      isIssueTitleEditable: true,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Tutor]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': false,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Admin]: {
-      'isIssueCreatable': true,
-      'isIssueDeletable': true,
-      'isIssueTitleEditable': true,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: true,
+      isIssueDeletable: true,
+      isIssueTitleEditable: true,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     }
   },
 
   [Phase.phaseTeamResponse]: {
     [UserRole.Student]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': true,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: true,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Tutor]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': false,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Admin]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': true,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: true,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     }
   },
 
   [Phase.phaseTesterResponse]: {
     [UserRole.Student]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': false,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': true,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: true,
+      isTutorResponseEditable: false
     },
     [UserRole.Tutor]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': false,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Admin]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': true,
-      'isTesterResponseEditable': true,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: true,
+      isTesterResponseEditable: true,
+      isTutorResponseEditable: false
     }
   },
 
   /** Phase 3 Permissions **/
   [Phase.phaseModeration]: {
     [UserRole.Student]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': false,
-      'isIssueLabelsEditable': false,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': false,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
     },
     [UserRole.Tutor]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': true,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: true
     },
     [UserRole.Admin]: {
-      'isIssueCreatable': false,
-      'isIssueDeletable': false,
-      'isIssueTitleEditable': false,
-      'isIssueDescriptionEditable': true,
-      'isIssueLabelsEditable': true,
-      'isTeamResponseEditable': false,
-      'isTesterResponseEditable': false,
-      'isTutorResponseEditable': true,
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: true
     }
   }
 };
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class PermissionService {
   constructor(private userService: UserService, private phaseService: PhaseService) {}
@@ -180,9 +183,14 @@ export class PermissionService {
   }
 
   isIssueEditable(): boolean {
-    return this.isIssueTitleEditable() || this.isIssueDescriptionEditable()
-           || this.isIssueLabelsEditable() || this.isTeamResponseEditable()
-           || this.isTesterResponseEditable() || this.isTutorResponseEditable();
+    return (
+      this.isIssueTitleEditable() ||
+      this.isIssueDescriptionEditable() ||
+      this.isIssueLabelsEditable() ||
+      this.isTeamResponseEditable() ||
+      this.isTesterResponseEditable() ||
+      this.isTutorResponseEditable()
+    );
   }
 
   private askForPermission(permissionLevel: PermissionLevel, permissionType: string): boolean {

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -12,13 +12,13 @@ export const SESSION_AVALIABILITY_FIX_FAILED = 'Session Availability Fix failed.
 
 export const PhaseDescription = {
   [Phase.phaseBugReporting]: 'Bug Reporting Phase',
-  [Phase.phaseTeamResponse]: 'Team\'s Response Phase',
-  [Phase.phaseTesterResponse]: 'Tester\'s Response Phase',
+  [Phase.phaseTeamResponse]: "Team's Response Phase",
+  [Phase.phaseTesterResponse]: "Tester's Response Phase",
   [Phase.phaseModeration]: 'Moderation Phase'
 };
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 
 /**
@@ -26,7 +26,6 @@ export const PhaseDescription = {
  * current session data and repository details related to the session.
  */
 export class PhaseService {
-
   public currentPhase: Phase;
   private repoName: string;
   private orgName: string;
@@ -40,9 +39,7 @@ export class PhaseService {
     phaseModeration: ''
   };
 
-  constructor(private githubService: GithubService,
-              private labelService: LabelService,
-              private repoCreatorService: RepoCreatorService) {}
+  constructor(private githubService: GithubService, private labelService: LabelService, private repoCreatorService: RepoCreatorService) {}
   /**
    * Stores the location of the repositories belonging to
    * each phase of the application.
@@ -66,9 +63,7 @@ export class PhaseService {
   }
 
   fetchSessionData(): Observable<SessionData> {
-    return this.githubService.fetchSettingsFile().pipe(
-      map(data => data as SessionData)
-    );
+    return this.githubService.fetchSettingsFile().pipe(map((data) => data as SessionData));
   }
 
   /**
@@ -151,9 +146,10 @@ export class PhaseService {
       this.repoCreatorService.verifyRepoCreation(this.getPhaseOwner(this.currentPhase), this.sessionData[this.currentPhase]),
       throwIfFalse(
         (isSessionCreated: boolean) => isSessionCreated,
-        () => new Error(SESSION_AVALIABILITY_FIX_FAILED)),
+        () => new Error(SESSION_AVALIABILITY_FIX_FAILED)
+      ),
       this.labelService.syncLabels(this.isTeamOrModerationPhase()),
-      retry(1)  // Retry once, to handle edge case where GitHub API cannot immediately confirm existence of the newly created repo.
+      retry(1) // Retry once, to handle edge case where GitHub API cannot immediately confirm existence of the newly created repo.
     );
   }
 
@@ -168,5 +164,4 @@ export class PhaseService {
   reset() {
     this.currentPhase = null;
   }
-
 }

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -8,18 +8,17 @@ export const MALFORMED_PROFILES_ERROR: Error = new Error('profiles.json is malfo
   providedIn: 'root'
 })
 export class ProfileService {
-  constructor(
-    private githubService: GithubService
-  ) { }
+  constructor(private githubService: GithubService) {}
 
   /**
    * Gets the required profiles from the external repository file.
    */
   public fetchExternalProfiles(): Promise<Profile[]> {
-    return this.githubService.getProfilesData()
-      .then(res => res.json())
-      .then(json => json.profiles || [])
-      .then(profiles => {
+    return this.githubService
+      .getProfilesData()
+      .then((res) => res.json())
+      .then((json) => json.profiles || [])
+      .then((profiles) => {
         this.validateProfiles(profiles);
         return profiles;
       });

--- a/src/app/core/services/repo-creator.service.ts
+++ b/src/app/core/services/repo-creator.service.ts
@@ -9,20 +9,14 @@ import { SessionFixConfirmationComponent } from './session-fix-confirmation/sess
 import { UserService } from './user.service';
 
 export const MISSING_REQUIRED_REPO = 'You cannot proceed without the required repository.';
-export const CURRENT_PHASE_REPO_CLOSED = 'Current Phase\'s Repository has not been opened.';
-export const BUG_REPORTING_INVALID_ROLE =
-  "'Bug-Reporting Phase\'s repository initialisation is only available to Students.'";
-
+export const CURRENT_PHASE_REPO_CLOSED = "Current Phase's Repository has not been opened.";
+export const BUG_REPORTING_INVALID_ROLE = "'Bug-Reporting Phase's repository initialisation is only available to Students.'";
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class RepoCreatorService {
-  constructor(
-    private githubService: GithubService,
-    private userService: UserService,
-    private repoCreationConfirmationDialog: MatDialog
-  ) {}
+  constructor(private githubService: GithubService, private userService: UserService, private repoCreationConfirmationDialog: MatDialog) {}
 
   /**
    * Prompts user to allow CATcher to create a repo, if repo does not
@@ -30,8 +24,10 @@ export class RepoCreatorService {
    * @param currentPhase the current phase of the session.
    * @param phaseRepo the name of the specified repository.
    */
-  public requestRepoCreationPermissions(currentPhase: Phase, phaseRepo: string):
-    UnaryFunction<Observable<boolean>, Observable<boolean | null>> {
+  public requestRepoCreationPermissions(
+    currentPhase: Phase,
+    phaseRepo: string
+  ): UnaryFunction<Observable<boolean>, Observable<boolean | null>> {
     return pipe(
       flatMap((isRepoPresent: boolean) => {
         if (!isRepoPresent && currentPhase === Phase.phaseBugReporting) {
@@ -49,20 +45,21 @@ export class RepoCreatorService {
    * @return Observable<boolean> - Representing user's permission grant.
    */
   private openRepoCreationConfirmation(phaseRepo: string): Observable<boolean> {
-    const dialogRef: MatDialogRef<SessionFixConfirmationComponent> =
-    this.repoCreationConfirmationDialog.open(SessionFixConfirmationComponent, {
-      data: {user: this.userService.currentUser.loginId, repoName: phaseRepo}
-    });
+    const dialogRef: MatDialogRef<SessionFixConfirmationComponent> = this.repoCreationConfirmationDialog.open(
+      SessionFixConfirmationComponent,
+      {
+        data: { user: this.userService.currentUser.loginId, repoName: phaseRepo }
+      }
+    );
     return dialogRef.afterClosed();
   }
 
- /**
-  * Checks if the current phase and current user role match the given permissions
-  * for the user to create the phase repository if deemed necessary
-  * @param currentPhase the current phase of the session.
-  */
-  public verifyRepoCreationPermissions(currentPhase: Phase):
-    UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
+  /**
+   * Checks if the current phase and current user role match the given permissions
+   * for the user to create the phase repository if deemed necessary
+   * @param currentPhase the current phase of the session.
+   */
+  public verifyRepoCreationPermissions(currentPhase: Phase): UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
       tap((repoCreationPermission: boolean | null) => {
         if (repoCreationPermission === null) {
@@ -86,8 +83,7 @@ export class RepoCreatorService {
    * @return - Dummy Observable to give the API sometime to propagate if the creation of the new
    *           repository is needed since the API Call used here does not return any response.
    */
-  public attemptRepoCreation(phaseRepo: string):
-    UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
+  public attemptRepoCreation(phaseRepo: string): UnaryFunction<Observable<boolean | null>, Observable<boolean | null>> {
     return pipe(
       flatMap((repoCreationPermission: boolean | null) => {
         if (repoCreationPermission === null) {
@@ -95,7 +91,7 @@ export class RepoCreatorService {
           return of(null);
         } else {
           this.githubService.createRepository(phaseRepo);
-          return new Observable(subscriber => {
+          return new Observable((subscriber) => {
             setTimeout(() => subscriber.next(true), 1000);
           });
         }
@@ -108,8 +104,7 @@ export class RepoCreatorService {
    * @param phaseOwner the user or organization holding the specified repository.
    * @param phaseRepo the name of the specified repository.
    */
-  public verifyRepoCreation(phaseOwner: string, phaseRepo: string):
-    UnaryFunction<Observable<boolean | null>, Observable<boolean>> {
+  public verifyRepoCreation(phaseOwner: string, phaseRepo: string): UnaryFunction<Observable<boolean | null>, Observable<boolean>> {
     return pipe(
       flatMap((isFixAttempted: boolean | null) => {
         if (!isFixAttempted) {

--- a/src/app/core/services/session-fix-confirmation/session-fix-confirmation.component.ts
+++ b/src/app/core/services/session-fix-confirmation/session-fix-confirmation.component.ts
@@ -12,12 +12,7 @@ export interface RepositoryData {
   styleUrls: ['./session-fix-confirmation.component.css']
 })
 export class SessionFixConfirmationComponent implements OnInit {
+  constructor(public dialogRef: MatDialogRef<SessionFixConfirmationComponent>, @Inject(MAT_DIALOG_DATA) public data: RepositoryData) {}
 
-  constructor(
-    public dialogRef: MatDialogRef<SessionFixConfirmationComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: RepositoryData) {}
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -4,27 +4,37 @@ import { uuid } from '../../shared/lib/uuid';
 import { GithubService } from './github.service';
 
 const SUPPORTED_VIDEO_FILE_TYPES = ['mp4', 'mov'];
-export const SUPPORTED_FILE_TYPES = ['gif', 'jpeg', 'jpg', 'png', 'docx', 'gz', 'log', 'pdf', 'pptx', 'txt', 'xlsx', 'zip',
-                                     ...SUPPORTED_VIDEO_FILE_TYPES];
-export const FILE_TYPE_SUPPORT_ERROR = 'We don\'t support that file type.' +
-  ' Try again with ' + SUPPORTED_FILE_TYPES.join(', ') + '.';
+export const SUPPORTED_FILE_TYPES = [
+  'gif',
+  'jpeg',
+  'jpg',
+  'png',
+  'docx',
+  'gz',
+  'log',
+  'pdf',
+  'pptx',
+  'txt',
+  'xlsx',
+  'zip',
+  ...SUPPORTED_VIDEO_FILE_TYPES
+];
+export const FILE_TYPE_SUPPORT_ERROR = "We don't support that file type." + ' Try again with ' + SUPPORTED_FILE_TYPES.join(', ') + '.';
 /**
  * Returns an error message string for when file exceeds the defined size limit
  * @param fileType Canonical name for file, not to be confused with file extension
  * @param size Number of MBs
  */
-export const getSizeExceedErrorMsg = (fileType: string, size: number): string =>
-  `Oops, ${fileType} is too big. Keep it under ${size}MiB.`;
+export const getSizeExceedErrorMsg = (fileType: string, size: number): string => `Oops, ${fileType} is too big. Keep it under ${size}MiB.`;
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 
 /**
  * Responsible for upload of media files to the current phase's repository.
  */
 export class UploadService {
-
   constructor(private githubService: GithubService) {}
 
   uploadFile(base64File: string | ArrayBuffer, userFilename: string) {

--- a/src/app/phase-bug-reporting/issue/issue.component.ts
+++ b/src/app/phase-bug-reporting/issue/issue.component.ts
@@ -18,18 +18,15 @@ export class IssueComponent implements OnInit {
 
   @ViewChild(ViewIssueComponent, { static: true }) viewIssue: ViewIssueComponent;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    this.route.params.subscribe(
-      params => {
-        this.issueId = + params['issue_id'];
-      }
-    );
+    this.route.params.subscribe((params) => {
+      this.issueId = +params['issue_id'];
+    });
   }
 
   canDeactivate(): boolean {
     return !this.viewIssue.isEditing();
   }
-
 }

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.css
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.css
@@ -1,6 +1,6 @@
 .form {
   width: 80%;
-  margin:0 auto;
+  margin: 0 auto;
 }
 
 mat-form-field {

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -2,45 +2,46 @@
 
 <form [formGroup]="newIssueForm" #myForm="ngForm" (ngSubmit)="submitNewIssue(myForm)">
   <div class="form">
-
     <div class="row">
-
       <div class="column left">
         <mat-form-field>
-          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256">
-          <mat-error *ngIf="title.errors && title.errors['required'] && (title.touched || title.dirty)">
-            Title required.
-          </mat-error>
-          <mat-error *ngIf="title.errors && title.errors['maxlength']">
-            Title cannot exceed 256 characters.
-          </mat-error>
-          <mat-hint *ngIf="title.value?.length >= 206">
-            {{256 - title.value?.length}} characters remaining.
-          </mat-hint>
+          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" />
+          <mat-error *ngIf="title.errors && title.errors['required'] && (title.touched || title.dirty)"> Title required. </mat-error>
+          <mat-error *ngIf="title.errors && title.errors['maxlength']"> Title cannot exceed 256 characters. </mat-error>
+          <mat-hint *ngIf="title.value?.length >= 206"> {{ 256 - title.value?.length }} characters remaining. </mat-hint>
         </mat-form-field>
 
-        <div style="margin: 10px 0 10px 0;">
+        <div style="margin: 10px 0 10px 0">
           <app-comment-editor
             [id]="'description'"
             [commentField]="description"
             [commentForm]="this.newIssueForm"
             [(isFormPending)]="this.isFormPending"
-            [(submitButtonText)]="this.submitButtonText">
+            [(submitButtonText)]="this.submitButtonText"
+          >
           </app-comment-editor>
         </div>
 
-        <button style="float: right" class="submit-new-bug-report" type="submit" mat-stroked-button color="primary"
-          [disabled]="!newIssueForm.valid || isFormPending">
+        <button
+          style="float: right"
+          class="submit-new-bug-report"
+          type="submit"
+          mat-stroked-button
+          color="primary"
+          [disabled]="!newIssueForm.valid || isFormPending"
+        >
           {{ this.submitButtonText }}
         </button>
       </div>
 
       <div class="column right">
-        <div class="severity-dropdown"><app-label-dropdown initialValue="" attributeName="severity" [dropdownForm]="newIssueForm"></app-label-dropdown></div>
-        <div class="bug-dropdown"><app-label-dropdown initialValue="" attributeName="type" [dropdownForm]="newIssueForm"></app-label-dropdown></div>
+        <div class="severity-dropdown">
+          <app-label-dropdown initialValue="" attributeName="severity" [dropdownForm]="newIssueForm"></app-label-dropdown>
+        </div>
+        <div class="bug-dropdown">
+          <app-label-dropdown initialValue="" attributeName="type" [dropdownForm]="newIssueForm"></app-label-dropdown>
+        </div>
       </div>
-
     </div>
-
   </div>
 </form>

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.ts
@@ -18,16 +18,20 @@ export class NewIssueComponent implements OnInit {
   isFormPending = false;
   submitButtonText: string;
 
-  constructor(private issueService: IssueService, private formBuilder: FormBuilder,
-              private errorHandlingService: ErrorHandlingService, public labelService: LabelService,
-              private router: Router) { }
+  constructor(
+    private issueService: IssueService,
+    private formBuilder: FormBuilder,
+    private errorHandlingService: ErrorHandlingService,
+    public labelService: LabelService,
+    private router: Router
+  ) {}
 
   ngOnInit() {
     this.newIssueForm = this.formBuilder.group({
       title: ['', [Validators.required, Validators.maxLength(256)]],
       description: [''],
       severity: ['', Validators.required],
-      type: ['', Validators.required],
+      type: ['', Validators.required]
     });
 
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
@@ -38,23 +42,28 @@ export class NewIssueComponent implements OnInit {
       return;
     }
     this.isFormPending = true;
-    this.issueService.createIssue(this.title.value,
-      Issue.updateDescription(this.description.value),
-      this.severity.value, this.type.value).pipe(finalize(() => this.isFormPending = false))
+    this.issueService
+      .createIssue(this.title.value, Issue.updateDescription(this.description.value), this.severity.value, this.type.value)
+      .pipe(finalize(() => (this.isFormPending = false)))
       .subscribe(
-        newIssue => {
+        (newIssue) => {
           this.issueService.updateLocalStore(newIssue);
           this.router.navigateByUrl(`phaseBugReporting/issues/${newIssue.id}`);
           form.resetForm();
-          },
-          error => {
+        },
+        (error) => {
           this.errorHandlingService.handleError(error);
-        });
+        }
+      );
   }
 
   canDeactivate() {
-    return !this.isAttributeEditing(this.title) && !this.isAttributeEditing(this.description)
-      && !this.isAttributeEditing(this.severity) && !this.isAttributeEditing(this.type);
+    return (
+      !this.isAttributeEditing(this.title) &&
+      !this.isAttributeEditing(this.description) &&
+      !this.isAttributeEditing(this.severity) &&
+      !this.isAttributeEditing(this.type)
+    );
   }
 
   isAttributeEditing(attribute: AbstractControl) {

--- a/src/app/phase-bug-reporting/phase-bug-reporting-routing.module.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting-routing.module.ts
@@ -8,10 +8,18 @@ import { PhaseBugReportingComponent } from './phase-bug-reporting.component';
 
 const routes: Routes = [
   { path: 'phaseBugReporting', component: PhaseBugReportingComponent, canActivate: [AuthGuard] },
-  { path: 'phaseBugReporting/issues/new', component: NewIssueComponent, canActivate: [AuthGuard],
-    canDeactivate: [CanDeactivateIssueGuard] },
-  { path: 'phaseBugReporting/issues/:issue_id', component: IssueComponent, canActivate: [AuthGuard],
-    canDeactivate: [CanDeactivateIssueGuard] },
+  {
+    path: 'phaseBugReporting/issues/new',
+    component: NewIssueComponent,
+    canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateIssueGuard]
+  },
+  {
+    path: 'phaseBugReporting/issues/:issue_id',
+    component: IssueComponent,
+    canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateIssueGuard]
+  }
 ];
 
 @NgModule({

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.css
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.css
@@ -7,8 +7,8 @@
 
 .title {
   color: black;
-  margin:0;
-  padding:30px 20px;
+  margin: 0;
+  padding: 30px 20px;
 }
 
 .mat-column-actions {
@@ -21,11 +21,11 @@
 }
 
 .mat-column-title {
-  width: 35%
+  width: 35%;
 }
 
 .mat-column-type {
-  width: 25%
+  width: 25%;
 }
 
 .mat-column-severity {

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -1,18 +1,28 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0px"> {{userService.currentUser.role === 'Student' ? 'Issues you posted' : 'All Issues' }}</h1> </div>
+      <div class="grid-flush-left">
+        <h1 class="mat-headline" style="margin: 0px">
+          {{ userService.currentUser.role === 'Student' ? 'Issues you posted' : 'All Issues' }}
+        </h1>
+      </div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <div class="grid-flush-right">
-        <button *ngIf="permissions.isIssueCreatable()" mat-stroked-button class="create-new-bug-report-button" color="primary" routerLink="issues/new">
+        <button
+          *ngIf="permissions.isIssueCreatable()"
+          mat-stroked-button
+          class="create-new-bug-report-button"
+          color="primary"
+          routerLink="issues/new"
+        >
           New Issue
         </button>
       </div>

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.ts
@@ -10,28 +10,14 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../shared/issue-tables/iss
   styleUrls: ['./phase-bug-reporting.component.css']
 })
 export class PhaseBugReportingComponent implements OnInit {
-
-  readonly displayedColumns = [
-    TABLE_COLUMNS.ID,
-    TABLE_COLUMNS.TITLE,
-    TABLE_COLUMNS.TYPE,
-    TABLE_COLUMNS.SEVERITY,
-    TABLE_COLUMNS.ACTIONS
-  ];
-  readonly actionButtons: ACTION_BUTTONS[] = [
-    ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.DELETE_ISSUE,
-    ACTION_BUTTONS.FIX_ISSUE
-  ];
+  readonly displayedColumns = [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
+  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.DELETE_ISSUE, ACTION_BUTTONS.FIX_ISSUE];
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  constructor(public permissions: PermissionService,
-              public userService: UserService) {
-  }
+  constructor(public permissions: PermissionService, public userService: UserService) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;

--- a/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
@@ -22,10 +22,6 @@ import { PhaseBugReportingComponent } from './phase-bug-reporting.component';
     IssueTablesModule,
     LabelDropdownModule
   ],
-  declarations: [
-    PhaseBugReportingComponent,
-    NewIssueComponent,
-    IssueComponent,
-  ],
+  declarations: [PhaseBugReportingComponent, NewIssueComponent, IssueComponent]
 })
 export class PhaseBugReportingModule {}

--- a/src/app/phase-moderation/issue/issue.component.ts
+++ b/src/app/phase-moderation/issue/issue.component.ts
@@ -26,21 +26,20 @@ export class IssueComponent implements OnInit {
 
   @ViewChild(ViewIssueComponent, { static: true }) viewIssue: ViewIssueComponent;
 
-  constructor(private route: ActivatedRoute,
-              public userService: UserService,
-              public permissions: PermissionService,
-              public issueService: IssueService) { }
+  constructor(
+    private route: ActivatedRoute,
+    public userService: UserService,
+    public permissions: PermissionService,
+    public issueService: IssueService
+  ) {}
 
   ngOnInit() {
-    this.route.params.subscribe(
-      params => {
-        this.issueId = + params['issue_id'];
-      }
-    );
+    this.route.params.subscribe((params) => {
+      this.issueId = +params['issue_id'];
+    });
   }
 
   canDeactivate(): boolean {
     return !this.viewIssue.isEditing();
   }
-
 }

--- a/src/app/phase-moderation/phase-moderation-routing.module.ts
+++ b/src/app/phase-moderation/phase-moderation-routing.module.ts
@@ -9,7 +9,7 @@ const routes: Routes = [
   {
     path: 'phaseModeration',
     component: PhaseModerationComponent,
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard]
   },
   {
     path: 'phaseModeration/issues/:issue_id',

--- a/src/app/phase-moderation/phase-moderation.component.css
+++ b/src/app/phase-moderation/phase-moderation.component.css
@@ -1,24 +1,24 @@
 .mat-column-id {
-    width: 10%;
-  }
-  
-  .mat-column-title {
-    width: 20%;
-  }
-  
-  .mat-column-type {
-    width: 15%
-  }
-  
-  .mat-column-severity {
-    width: 10%;
-  }
+  width: 10%;
+}
 
-  .mat-column-Todo-Remaining {
-    width: 20%;
-  }
+.mat-column-title {
+  width: 20%;
+}
 
-  .mat-column-actions {
-    width: 10%;
-    text-align: center;
-  }
+.mat-column-type {
+  width: 15%;
+}
+
+.mat-column-severity {
+  width: 10%;
+}
+
+.mat-column-Todo-Remaining {
+  width: 20%;
+}
+
+.mat-column-actions {
+  width: 10%;
+  text-align: center;
+}

--- a/src/app/phase-moderation/phase-moderation.component.html
+++ b/src/app/phase-moderation/phase-moderation.component.html
@@ -1,29 +1,27 @@
 <div>
   <div style="text-align: center; margin-bottom: 20px">
-    <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id}} </span>
+    <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id }} </span>
     <button *ngIf="teamList" [matMenuTriggerFor]="teamMenu" mat-icon-button>
       <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> settings </mat-icon>
     </button>
 
     <mat-menu #teamMenu>
-      <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList"
-              (click)="updateDisplayedTeam(team)">
-        <span> {{team}} </span>
+      <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList" (click)="updateDisplayedTeam(team)">
+        <span> {{ team }} </span>
       </button>
     </mat-menu>
   </div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0px"> Issues Submitted by Students </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0px">Issues Submitted by Students</h1></div>
     </mat-grid-tile>
-    <br/>
+    <br />
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>
 
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
-
 </div>

--- a/src/app/phase-moderation/phase-moderation.component.ts
+++ b/src/app/phase-moderation/phase-moderation.component.ts
@@ -12,9 +12,7 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../shared/issue-tables/iss
   templateUrl: './phase-moderation.component.html',
   styleUrls: ['./phase-moderation.component.css']
 })
-
 export class PhaseModerationComponent implements OnInit {
-
   displayedColumns = [
     TABLE_COLUMNS.ID,
     TABLE_COLUMNS.TITLE,
@@ -30,9 +28,7 @@ export class PhaseModerationComponent implements OnInit {
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  constructor(private issueService: IssueService,
-              public userService: UserService,
-              private dataService: DataService) { }
+  constructor(private issueService: IssueService, public userService: UserService, private dataService: DataService) {}
 
   ngOnInit() {
     this.issueService.setIssueTeamFilter(this.teamFilter);
@@ -46,7 +42,7 @@ export class PhaseModerationComponent implements OnInit {
     const teams = this.dataService.getTeams();
     switch (IssuesFilter[Phase.phaseModeration][this.userService.currentUser.role]) {
       case 'FILTER_BY_TEAM_ASSIGNED':
-        return ['All Teams', ...this.userService.currentUser.allocatedTeams.map(team => team.id)];
+        return ['All Teams', ...this.userService.currentUser.allocatedTeams.map((team) => team.id)];
       case 'NO_FILTER':
         return ['All Teams', ...teams];
       default:
@@ -58,5 +54,4 @@ export class PhaseModerationComponent implements OnInit {
     this.teamFilter = newTeam;
     this.table.issues.teamFilter = this.teamFilter;
   }
-
 }

--- a/src/app/phase-moderation/phase-moderation.module.ts
+++ b/src/app/phase-moderation/phase-moderation.module.ts
@@ -17,11 +17,8 @@ import { PhaseModerationComponent } from './phase-moderation.component';
     CommentEditorModule,
     ViewIssueModule,
     MarkdownModule.forChild(),
-    IssueTablesModule,
+    IssueTablesModule
   ],
-  declarations: [
-    PhaseModerationComponent,
-    IssueComponent,
-  ],
+  declarations: [PhaseModerationComponent, IssueComponent]
 })
 export class PhaseModerationModule {}

--- a/src/app/phase-team-response/issue/issue.component.ts
+++ b/src/app/phase-team-response/issue/issue.component.ts
@@ -25,20 +25,15 @@ export class IssueComponent implements OnInit {
 
   @ViewChild(ViewIssueComponent, { static: true }) viewIssue: ViewIssueComponent;
 
-  constructor(public issueService: IssueService,
-              private route: ActivatedRoute,
-              public permissions: PermissionService) { }
+  constructor(public issueService: IssueService, private route: ActivatedRoute, public permissions: PermissionService) {}
 
   ngOnInit() {
-    this.route.params.subscribe(
-      params => {
-        this.issueId = + params['issue_id'];
-      }
-    );
+    this.route.params.subscribe((params) => {
+      this.issueId = +params['issue_id'];
+    });
   }
 
   canDeactivate(): boolean {
     return !this.viewIssue.isEditing();
   }
-
 }

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
@@ -7,8 +7,8 @@
 
 .title {
   color: black;
-  margin:0;
-  padding:30px 20px;
+  margin: 0;
+  padding: 30px 20px;
 }
 
 .mat-column-id {
@@ -20,23 +20,23 @@
 }
 
 .mat-column-type {
-  width: 15%
+  width: 15%;
 }
 
 .mat-column-severity {
   width: 10%;
 }
 .mat-column-responseTag {
-  width: 10%
+  width: 10%;
 }
 .mat-column-assignees {
-  width: 10%
+  width: 10%;
 }
 .mat-column-teamAssigned {
-  width: 7%
+  width: 7%;
 }
 .mat-column-duplicatedIssues {
-  width: 10%
+  width: 10%;
 }
 .mat-column-actions {
   width: 15%;

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -1,12 +1,12 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0px"> Faulty Issues </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0px">Faulty Issues</h1></div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -10,23 +10,19 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 @Component({
   selector: 'app-issues-faulty',
   templateUrl: './issues-faulty.component.html',
-  styleUrls: ['./issues-faulty.component.css'],
+  styleUrls: ['./issues-faulty.component.css']
 })
 export class IssuesFaultyComponent implements OnInit, OnChanges {
   displayedColumns: string[];
   filter: (issue: Issue) => boolean;
 
-  readonly actionButtons: ACTION_BUTTONS[] = [
-    ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.FIX_ISSUE
-  ];
+  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.FIX_ISSUE];
 
   @Input() teamFilter: string;
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  constructor(public issueService: IssueService, public userService: UserService,
-      public permissions: PermissionService) {
+  constructor(public issueService: IssueService, public userService: UserService, public permissions: PermissionService) {
     if (userService.currentUser.role === UserRole.Student) {
       this.displayedColumns = [
         TABLE_COLUMNS.ID,
@@ -64,7 +60,7 @@ export class IssuesFaultyComponent implements OnInit, OnChanges {
       const hasTeamResponse = (issue: Issue) => this.issueService.hasTeamResponse(issue.id);
       const isDuplicateIssue = (issue: Issue) => !!issue.duplicateOf;
       const isDuplicatedBy = (issue: Issue) =>
-            !!this.issueService.issues$.getValue().filter(childIssue => childIssue.duplicateOf === issue.id).length;
+        !!this.issueService.issues$.getValue().filter((childIssue) => childIssue.duplicateOf === issue.id).length;
       return hasTeamResponse(issue) && isDuplicateIssue(issue) && isDuplicatedBy(issue);
     };
   }

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.css
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.css
@@ -7,8 +7,8 @@
 
 .title {
   color: black;
-  margin:0;
-  padding:30px 20px;
+  margin: 0;
+  padding: 30px 20px;
 }
 
 .mat-column-actions {
@@ -21,15 +21,15 @@
 }
 
 .mat-column-title {
-  width: 26%
+  width: 26%;
 }
 
 .mat-column-teamAssigned {
-  width: 10%
+  width: 10%;
 }
 
 .mat-column-type {
-  width: 12%
+  width: 12%;
 }
 
 .mat-column-severity {

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -1,12 +1,12 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0"> Issues Pending Response </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0">Issues Pending Response</h1></div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.ts
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.ts
@@ -27,8 +27,7 @@ export class IssuesPendingComponent implements OnInit, OnChanges {
 
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  constructor(public issueService: IssueService,
-              public permissions: PermissionService, public userService: UserService) {
+  constructor(public issueService: IssueService, public permissions: PermissionService, public userService: UserService) {
     if (userService.currentUser.role !== UserRole.Student) {
       this.displayedColumns = [
         TABLE_COLUMNS.ID,
@@ -60,7 +59,7 @@ export class IssuesPendingComponent implements OnInit, OnChanges {
   ngOnInit() {
     const isNotDuplicate = (issue: Issue) => !issue.duplicateOf;
     const doesNotHaveFinalisedResponse = (issue: Issue) =>
-        (!this.issueService.hasTeamResponse(issue.id) || (!issue.status || issue.status === STATUS.Incomplete));
+      !this.issueService.hasTeamResponse(issue.id) || !issue.status || issue.status === STATUS.Incomplete;
     this.filter = (issue: Issue) => doesNotHaveFinalisedResponse(issue) && isNotDuplicate(issue);
   }
 

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.css
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.css
@@ -7,8 +7,8 @@
 
 .title {
   color: black;
-  margin:0;
-  padding:30px 20px;
+  margin: 0;
+  padding: 30px 20px;
 }
 
 .mat-column-id {
@@ -20,23 +20,23 @@
 }
 
 .mat-column-type {
-  width: 11%
+  width: 11%;
 }
 
 .mat-column-severity {
   width: 6%;
 }
 .mat-column-responseTag {
-  width: 10%
+  width: 10%;
 }
 .mat-column-assignees {
-  width: 10%
+  width: 10%;
 }
 .mat-column-teamAssigned {
-  width: 6%
+  width: 6%;
 }
 .mat-column-duplicatedIssues {
-  width: 10%
+  width: 10%;
 }
 .mat-column-actions {
   width: 13%;

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -1,12 +1,12 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0px"> Issues Responded </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0px">Issues Responded</h1></div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.ts
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.ts
@@ -9,17 +9,13 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 @Component({
   selector: 'app-issues-responded',
   templateUrl: './issues-responded.component.html',
-  styleUrls: ['./issues-responded.component.css'],
+  styleUrls: ['./issues-responded.component.css']
 })
 export class IssuesRespondedComponent implements OnInit, OnChanges {
   displayedColumns: string[];
   filter: (issue: Issue) => boolean;
 
-  readonly actionButtons: ACTION_BUTTONS[] = [
-    ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.MARK_AS_PENDING,
-    ACTION_BUTTONS.FIX_ISSUE
-  ];
+  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.MARK_AS_PENDING, ACTION_BUTTONS.FIX_ISSUE];
 
   @Input() teamFilter: string;
 

--- a/src/app/phase-team-response/phase-team-response-routing.module.ts
+++ b/src/app/phase-team-response/phase-team-response-routing.module.ts
@@ -7,8 +7,12 @@ import { PhaseTeamResponseComponent } from './phase-team-response.component';
 
 const routes: Routes = [
   { path: 'phaseTeamResponse', component: PhaseTeamResponseComponent, canActivate: [AuthGuard] },
-  { path: 'phaseTeamResponse/issues/:issue_id', component: IssueComponent, canActivate: [AuthGuard],
-    canDeactivate: [CanDeactivateIssueGuard] }
+  {
+    path: 'phaseTeamResponse/issues/:issue_id',
+    component: IssueComponent,
+    canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateIssueGuard]
+  }
 ];
 
 @NgModule({

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -7,8 +7,8 @@
 
 .title {
   color: black;
-  margin:0;
-  padding:30px 20px;
+  margin: 0;
+  padding: 30px 20px;
 }
 
 .mat-column-actions {
@@ -21,11 +21,11 @@
 }
 
 .mat-column-title {
-  width: 40%
+  width: 40%;
 }
 
 .mat-column-type {
-  width: 30%
+  width: 30%;
 }
 
 .mat-column-severity {

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -1,14 +1,13 @@
 <div>
   <div style="text-align: center; margin-bottom: 20px">
-    <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id}} </span>
+    <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id }} </span>
     <button *ngIf="teamList" [matMenuTriggerFor]="teamMenu" mat-icon-button>
       <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> settings </mat-icon>
     </button>
 
     <mat-menu #teamMenu>
-      <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList"
-              (click)="updateDisplayedTeam(team)">
-        <span> {{team}} </span>
+      <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList" (click)="updateDisplayedTeam(team)">
+        <span> {{ team }} </span>
       </button>
     </mat-menu>
   </div>

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -23,7 +23,7 @@ export class PhaseTeamResponseComponent implements OnInit {
     const teams = this.dataService.getTeams();
     switch (IssuesFilter[Phase.phaseTeamResponse][this.userService.currentUser.role]) {
       case 'FILTER_BY_TEAM_ASSIGNED':
-        return ['All Teams', ...this.userService.currentUser.allocatedTeams.map(team => team.id)];
+        return ['All Teams', ...this.userService.currentUser.allocatedTeams.map((team) => team.id)];
       case 'NO_FILTER':
         return ['All Teams', ...teams];
       default:

--- a/src/app/phase-team-response/phase-team-response.module.ts
+++ b/src/app/phase-team-response/phase-team-response.module.ts
@@ -20,14 +20,8 @@ import { PhaseTeamResponseComponent } from './phase-team-response.component';
     CommentEditorModule,
     ViewIssueModule,
     MarkdownModule.forChild(),
-    IssueTablesModule,
+    IssueTablesModule
   ],
-  declarations: [
-    PhaseTeamResponseComponent,
-    IssueComponent,
-    IssuesPendingComponent,
-    IssuesRespondedComponent,
-    IssuesFaultyComponent,
-  ],
+  declarations: [PhaseTeamResponseComponent, IssueComponent, IssuesPendingComponent, IssuesRespondedComponent, IssuesFaultyComponent]
 })
 export class PhaseTeamResponseModule {}

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.html
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.html
@@ -1,16 +1,15 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0"> Issues Pending Response </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0">Issues Pending Response</h1></div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"
-                    [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.ts
@@ -9,16 +9,9 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
   styleUrls: ['./issue-pending.component.css']
 })
 export class IssuePendingComponent implements OnInit {
-
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
 
-  readonly displayedColumns = [
-    TABLE_COLUMNS.ID,
-    TABLE_COLUMNS.TITLE,
-    TABLE_COLUMNS.TYPE,
-    TABLE_COLUMNS.SEVERITY,
-    TABLE_COLUMNS.ACTIONS
-  ];
+  readonly displayedColumns = [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
   readonly actionButtons: ACTION_BUTTONS[] = [
     ACTION_BUTTONS.VIEW_IN_WEB,
     ACTION_BUTTONS.RESPOND_TO_ISSUE,
@@ -27,16 +20,15 @@ export class IssuePendingComponent implements OnInit {
   ];
   filter: (issue: Issue) => boolean;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
     const hasComment = (issue: Issue) => !!issue.issueComment;
-    const isNotDone = (issue: Issue) => (!issue.status || issue.status === STATUS.Incomplete);
+    const isNotDone = (issue: Issue) => !issue.status || issue.status === STATUS.Incomplete;
     this.filter = (issue: Issue) => isNotDone(issue) && hasComment(issue);
   }
 
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;
   }
-
 }

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.html
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.html
@@ -1,16 +1,15 @@
 <div>
   <mat-grid-list cols="3" rowHeight="80px">
     <mat-grid-tile>
-      <div class="grid-flush-left"> <h1 class="mat-headline" style="margin: 0"> Issues Responded </h1> </div>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0">Issues Responded</h1></div>
     </mat-grid-tile>
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
       </mat-form-field>
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"
-                    [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.ts
@@ -9,23 +9,12 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
   styleUrls: ['./issue-responded.component.css']
 })
 export class IssueRespondedComponent implements OnInit {
-
   @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
-  readonly displayedColumns  = [
-    TABLE_COLUMNS.ID,
-    TABLE_COLUMNS.TITLE,
-    TABLE_COLUMNS.TYPE,
-    TABLE_COLUMNS.SEVERITY,
-    TABLE_COLUMNS.ACTIONS
-  ];
-  readonly actionButtons: ACTION_BUTTONS[] = [
-    ACTION_BUTTONS.VIEW_IN_WEB,
-    ACTION_BUTTONS.MARK_AS_PENDING,
-    ACTION_BUTTONS.FIX_ISSUE
-  ];
+  readonly displayedColumns = [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE, TABLE_COLUMNS.TYPE, TABLE_COLUMNS.SEVERITY, TABLE_COLUMNS.ACTIONS];
+  readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.MARK_AS_PENDING, ACTION_BUTTONS.FIX_ISSUE];
   filter: (issue: Issue) => boolean;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
     const issueIsDone = (issue: Issue) => issue.status === STATUS.Done;
@@ -36,5 +25,4 @@ export class IssueRespondedComponent implements OnInit {
   applyFilter(filterValue: string) {
     this.table.issues.filter = filterValue;
   }
-
 }

--- a/src/app/phase-tester-response/issue/issue.component.ts
+++ b/src/app/phase-tester-response/issue/issue.component.ts
@@ -15,23 +15,20 @@ export class IssueComponent implements OnInit {
     ISSUE_COMPONENTS.SEVERITY_LABEL,
     ISSUE_COMPONENTS.TYPE_LABEL,
     ISSUE_COMPONENTS.TEAM_RESPONSE,
-    ISSUE_COMPONENTS.TESTER_RESPONSE,
+    ISSUE_COMPONENTS.TESTER_RESPONSE
   ];
 
   @ViewChild(ViewIssueComponent, { static: true }) viewIssue: ViewIssueComponent;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute) {}
 
   ngOnInit() {
-    this.route.params.subscribe(
-      params => {
-        this.issueId = + params['issue_id'];
-      }
-    );
+    this.route.params.subscribe((params) => {
+      this.issueId = +params['issue_id'];
+    });
   }
 
   canDeactivate(): boolean {
     return !this.viewIssue.isEditing();
   }
-
 }

--- a/src/app/phase-tester-response/phase-tester-response-routing.module.ts
+++ b/src/app/phase-tester-response/phase-tester-response-routing.module.ts
@@ -6,13 +6,17 @@ import { IssueComponent } from './issue/issue.component';
 import { PhaseTesterResponseComponent } from './phase-tester-response.component';
 
 const routes: Routes = [
-  { path: 'phaseTesterResponse', component: PhaseTesterResponseComponent, canActivate: [AuthGuard]},
-  { path: 'phaseTesterResponse/issues/:issue_id', component: IssueComponent, canActivate: [AuthGuard],
-    canDeactivate: [CanDeactivateIssueGuard] }
+  { path: 'phaseTesterResponse', component: PhaseTesterResponseComponent, canActivate: [AuthGuard] },
+  {
+    path: 'phaseTesterResponse/issues/:issue_id',
+    component: IssueComponent,
+    canActivate: [AuthGuard],
+    canDeactivate: [CanDeactivateIssueGuard]
+  }
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class PhaseTesterResponseRoutingModule { }
+export class PhaseTesterResponseRoutingModule {}

--- a/src/app/phase-tester-response/phase-tester-response.component.ts
+++ b/src/app/phase-tester-response/phase-tester-response.component.ts
@@ -6,10 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./phase-tester-response.component.css']
 })
 export class PhaseTesterResponseComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/phase-tester-response/phase-tester-response.module.ts
+++ b/src/app/phase-tester-response/phase-tester-response.module.ts
@@ -12,19 +12,7 @@ import { PhaseTesterResponseComponent } from './phase-tester-response.component'
 
 @NgModule({
   exports: [PhaseTesterResponseComponent],
-  declarations: [
-    PhaseTesterResponseComponent,
-    IssueComponent,
-    IssuePendingComponent,
-    IssueRespondedComponent
-  ],
-  imports: [
-    CommonModule,
-    PhaseTesterResponseRoutingModule,
-    SharedModule,
-    ViewIssueModule,
-    IssueTablesModule,
-    MarkdownModule.forChild()
-  ]
+  declarations: [PhaseTesterResponseComponent, IssueComponent, IssuePendingComponent, IssueRespondedComponent],
+  imports: [CommonModule, PhaseTesterResponseRoutingModule, SharedModule, ViewIssueModule, IssueTablesModule, MarkdownModule.forChild()]
 })
-export class PhaseTesterResponseModule { }
+export class PhaseTesterResponseModule {}

--- a/src/app/shared/comment-editor/comment-editor.component.css
+++ b/src/app/shared/comment-editor/comment-editor.component.css
@@ -1,10 +1,10 @@
 .tab-content {
-  padding: 10px
+  padding: 10px;
 }
 
 .highlight-drag-box {
   border-style: dashed;
-  border-color: #98FB98;
+  border-color: #98fb98;
   border-width: 2px;
 }
 
@@ -28,7 +28,7 @@
 }
 
 .error {
-  color: #B22222;
+  color: #b22222;
 }
 
 .file {
@@ -36,7 +36,7 @@
   top: 0;
   left: 0;
   opacity: 0;
-  width:100%;
-  height:100%;
-  cursor: pointer
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
 }

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -1,26 +1,45 @@
 <form [formGroup]="commentForm" style="min-height: 350px">
   <mat-tab-group class="mat-elevation-z1" animationDuration="0ms">
     <mat-tab label="Write">
-      <div #dropArea class="tab-content"
-           (dragleave)="onDragExit($event)" (dragenter)="onDragEnter($event)" (drop)="onDrop($event)"
-           (dragover)="enableFileDrop($event)">
-
+      <div
+        #dropArea
+        class="tab-content"
+        (dragleave)="onDragExit($event)"
+        (dragenter)="onDragEnter($event)"
+        (drop)="onDrop($event)"
+        (dragover)="enableFileDrop($event)"
+      >
         <mat-form-field appearance="outline" style="width: 100%">
           <mat-label></mat-label>
-          <textarea (paste)="onPaste($event)" #commentTextArea (dragover)="disableCaretMovement($event)"
-                    id="{{ this.id }}" formControlName="{{ this.id }}" matInput
-                    cdkTextareaAutosize #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="10"
-                    cdkAutosizeMaxRows="20" class="text-input-area" placeholder="{{ this.placeholderText }}"></textarea>
+          <textarea
+            (paste)="onPaste($event)"
+            #commentTextArea
+            (dragover)="disableCaretMovement($event)"
+            id="{{ this.id }}"
+            formControlName="{{ this.id }}"
+            matInput
+            cdkTextareaAutosize
+            #autosize="cdkTextareaAutosize"
+            cdkAutosizeMinRows="10"
+            cdkAutosizeMaxRows="20"
+            class="text-input-area"
+            placeholder="{{ this.placeholderText }}"
+          ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>
 
           <div class="drag-and-drop">
             <span *ngIf="!isInErrorState"> Attach files by dragging & dropping or select them by clicking here. </span>
-            <span *ngIf="isInErrorState" class="error"> {{uploadErrorMessage}} </span>
-            <input #fileInput [disabled]="this.commentField.disabled"
-                   [accept]="SUPPORTED_FILE_TYPES"
-                   type="file" class="file" (change)="onFileInputUpload($event, fileInput)">
+            <span *ngIf="isInErrorState" class="error"> {{ uploadErrorMessage }} </span>
+            <input
+              #fileInput
+              [disabled]="this.commentField.disabled"
+              [accept]="SUPPORTED_FILE_TYPES"
+              type="file"
+              class="file"
+              (change)="onFileInputUpload($event, fileInput)"
+            />
           </div>
         </mat-form-field>
       </div>
@@ -28,7 +47,7 @@
     <mat-tab label="Preview">
       <div class="tab-content" style="min-height: 228px">
         <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)"></markdown>
-        <div *ngIf="commentField.value ===''"> Nothing to preview. </div>
+        <div *ngIf="commentField.value === ''">Nothing to preview.</div>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -48,9 +48,9 @@ export class CommentEditorComponent implements OnInit {
   dragActiveCounter = 0;
   uploadErrorMessage: string;
 
-  formatFileUploadingButtonText: (string) => string = (currentButtonText: string) => {
+  formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';
-  };
+  }
 
   ngOnInit() {
     if (this.initialDescription !== undefined) {

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -37,9 +37,7 @@ export class CommentEditorComponent implements OnInit {
   // Allow the comment editor to control the text of the submit button to prompt the user.
   @Input() submitButtonText?: string;
   @Output() submitButtonTextChange: EventEmitter<string> = new EventEmitter<string>();
-  formatFileUploadingButtonText: (string) => string = (currentButtonText: string) => {
-    return currentButtonText + ' (Waiting for File Upload to finish...)';
-  };
+
   initialSubmitButtonText: string;
   lastUploadingTime: string;
 
@@ -49,6 +47,10 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
+
+  formatFileUploadingButtonText: (string) => string = (currentButtonText: string) => {
+    return currentButtonText + ' (Waiting for File Upload to finish...)';
+  };
 
   ngOnInit() {
     if (this.initialDescription !== undefined) {

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -3,11 +3,7 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angu
 import { AbstractControl, FormGroup } from '@angular/forms';
 import * as DOMPurify from 'dompurify';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
-import {
-  FILE_TYPE_SUPPORT_ERROR,
-  getSizeExceedErrorMsg,
-  SUPPORTED_FILE_TYPES,
-  UploadService } from '../../core/services/upload.service';
+import { FILE_TYPE_SUPPORT_ERROR, getSizeExceedErrorMsg, SUPPORTED_FILE_TYPES, UploadService } from '../../core/services/upload.service';
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 const BYTES_PER_MB = 1024 * 1024;
@@ -20,13 +16,12 @@ const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_M
 @Component({
   selector: 'app-comment-editor',
   templateUrl: './comment-editor.component.html',
-  styleUrls: ['./comment-editor.component.css'],
+  styleUrls: ['./comment-editor.component.css']
 })
 export class CommentEditorComponent implements OnInit {
   readonly SUPPORTED_FILE_TYPES = SUPPORTED_FILE_TYPES;
 
-  constructor(private uploadService: UploadService,
-              private errorHandlingService: ErrorHandlingService) {}
+  constructor(private uploadService: UploadService, private errorHandlingService: ErrorHandlingService) {}
 
   @Input() commentField: AbstractControl; // Compulsory Input
   @Input() commentForm: FormGroup; // Compulsory Input
@@ -42,9 +37,9 @@ export class CommentEditorComponent implements OnInit {
   // Allow the comment editor to control the text of the submit button to prompt the user.
   @Input() submitButtonText?: string;
   @Output() submitButtonTextChange: EventEmitter<string> = new EventEmitter<string>();
-  formatFileUploadingButtonText: (string) => string = ((currentButtonText: string) => {
+  formatFileUploadingButtonText: (string) => string = (currentButtonText: string) => {
     return currentButtonText + ' (Waiting for File Upload to finish...)';
-  });
+  };
   initialSubmitButtonText: string;
   lastUploadingTime: string;
 
@@ -61,7 +56,7 @@ export class CommentEditorComponent implements OnInit {
     }
 
     if (this.commentField === undefined || this.commentForm === undefined || this.id === undefined) {
-      throw new Error('Comment Editor\'s compulsory properties are not defined.');
+      throw new Error("Comment Editor's compulsory properties are not defined.");
     }
 
     this.initialSubmitButtonText = this.submitButtonText;
@@ -129,8 +124,8 @@ export class CommentEditorComponent implements OnInit {
   }
 
   updateParentFormsSubmittability(isFormPending: boolean, submitButtonText: string) {
-      this.isFormPendingChange.emit(isFormPending);
-      this.submitButtonTextChange.emit(submitButtonText);
+    this.isFormPendingChange.emit(isFormPending);
+    this.submitButtonTextChange.emit(submitButtonText);
   }
 
   readAndUploadFile(file: File): void {
@@ -162,20 +157,24 @@ export class CommentEditorComponent implements OnInit {
     this.updateParentFormsSubmittability(true, this.formatFileUploadingButtonText(this.initialSubmitButtonText));
 
     reader.onload = () => {
-      this.uploadService.uploadFile(reader.result, filename).subscribe((response) => {
-        this.insertUploadUrl(filename, response.data.content.download_url);
-      }, (error) => {
-        this.handleUploadError(error, insertedText);
-        // Allow button enabling if this is the last file that was uploaded.
-        if (currentFileUploadTime === this.lastUploadingTime) {
-          this.updateParentFormsSubmittability(false, this.initialSubmitButtonText);
+      this.uploadService.uploadFile(reader.result, filename).subscribe(
+        (response) => {
+          this.insertUploadUrl(filename, response.data.content.download_url);
+        },
+        (error) => {
+          this.handleUploadError(error, insertedText);
+          // Allow button enabling if this is the last file that was uploaded.
+          if (currentFileUploadTime === this.lastUploadingTime) {
+            this.updateParentFormsSubmittability(false, this.initialSubmitButtonText);
+          }
+        },
+        () => {
+          // Allow button enabling if this is the last file that was uploaded.
+          if (currentFileUploadTime === this.lastUploadingTime) {
+            this.updateParentFormsSubmittability(false, this.initialSubmitButtonText);
+          }
         }
-      }, () => {
-        // Allow button enabling if this is the last file that was uploaded.
-        if (currentFileUploadTime === this.lastUploadingTime) {
-          this.updateParentFormsSubmittability(false, this.initialSubmitButtonText);
-        }
-      });
+      );
     };
     reader.readAsDataURL(file);
   }
@@ -252,15 +251,15 @@ export class CommentEditorComponent implements OnInit {
         ? cursorPosition
         : cursorPosition + differenceInLength; // after the uploading text
 
-    this.commentField.setValue(
-      this.commentField.value.replace(`[Uploading ${filename}...]`, `[${filename}](${uploadUrl})`));
+    this.commentField.setValue(this.commentField.value.replace(`[Uploading ${filename}...]`, `[${filename}](${uploadUrl})`));
 
     this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
   }
 
   private removeHighlightBorderStyle() {
     this.dragActiveCounter--;
-    if (this.dragActiveCounter === 0) { // To make sure when dragging over a child element, drop area is still highlight.
+    if (this.dragActiveCounter === 0) {
+      // To make sure when dragging over a child element, drop area is still highlight.
       this.dropArea.nativeElement.classList.remove('highlight-drag-box');
       this.dropArea.nativeElement.classList.remove('highlight-drag-box-disabled');
     }

--- a/src/app/shared/comment-editor/comment-editor.module.ts
+++ b/src/app/shared/comment-editor/comment-editor.module.ts
@@ -4,15 +4,8 @@ import { SharedModule } from '../shared.module';
 import { CommentEditorComponent } from './comment-editor.component';
 
 @NgModule({
-  imports: [
-    SharedModule,
-    MarkdownModule.forChild(),
-  ],
-  declarations: [
-    CommentEditorComponent,
-  ],
-  exports: [
-    CommentEditorComponent
-  ]
+  imports: [SharedModule, MarkdownModule.forChild()],
+  declarations: [CommentEditorComponent],
+  exports: [CommentEditorComponent]
 })
-export class CommentEditorModule { }
+export class CommentEditorModule {}

--- a/src/app/shared/error-toasters/error-toaster.module.ts
+++ b/src/app/shared/error-toasters/error-toaster.module.ts
@@ -6,24 +6,9 @@ import { GeneralMessageErrorComponent } from './general-message-error/general-me
 import { InvalidCredentialsErrorComponent } from './invalid-credentials-error/invalid-credentials-error.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    MaterialModule,
-  ],
-  declarations: [
-    GeneralMessageErrorComponent,
-    FormErrorComponent,
-    InvalidCredentialsErrorComponent,
-  ],
-  exports: [
-    GeneralMessageErrorComponent,
-    FormErrorComponent,
-    InvalidCredentialsErrorComponent,
-  ],
-  entryComponents: [
-    GeneralMessageErrorComponent,
-    FormErrorComponent,
-    InvalidCredentialsErrorComponent,
-  ]
+  imports: [CommonModule, MaterialModule],
+  declarations: [GeneralMessageErrorComponent, FormErrorComponent, InvalidCredentialsErrorComponent],
+  exports: [GeneralMessageErrorComponent, FormErrorComponent, InvalidCredentialsErrorComponent],
+  entryComponents: [GeneralMessageErrorComponent, FormErrorComponent, InvalidCredentialsErrorComponent]
 })
 export class ErrorToasterModule {}

--- a/src/app/shared/error-toasters/form-error/form-error.component.html
+++ b/src/app/shared/error-toasters/form-error/form-error.component.html
@@ -1,18 +1,21 @@
-<div *ngIf="data.errors; else generalMessage" style="display: inline-block;">
+<div *ngIf="data.errors; else generalMessage" style="display: inline-block">
   <div *ngFor="let error of data.errors">
     Validation Error:
     <ul>
-      <li> {{ error.code + ' in ' + error.field }} </li>
+      <li>{{ error.code + ' in ' + error.field }}</li>
     </ul>
   </div>
-  <button style="position: absolute; top: 30%; bottom: 30%; left: 75%; height: 40%" mat-button
-          color="accent"
-          (click)="snackBarRef.dismiss()"> Close </button>
+  <button
+    style="position: absolute; top: 30%; bottom: 30%; left: 75%; height: 40%"
+    mat-button
+    color="accent"
+    (click)="snackBarRef.dismiss()"
+  >
+    Close
+  </button>
 </div>
 
 <ng-template #generalMessage>
-  <div style="max-width: 300px; display: inline-block;"> {{"Error code " + data.status + ": " + data.message}} </div>
-  <button style="float: right; margin-top: 8px;" mat-button
-          color="accent"
-          (click)="snackBarRef.dismiss()"> Close </button>
+  <div style="max-width: 300px; display: inline-block">{{ 'Error code ' + data.status + ': ' + data.message }}</div>
+  <button style="float: right; margin-top: 8px" mat-button color="accent" (click)="snackBarRef.dismiss()">Close</button>
 </ng-template>

--- a/src/app/shared/error-toasters/form-error/form-error.component.ts
+++ b/src/app/shared/error-toasters/form-error/form-error.component.ts
@@ -3,10 +3,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
 
 @Component({
   selector: 'app-form-error',
-  templateUrl: './form-error.component.html',
+  templateUrl: './form-error.component.html'
 })
 export class FormErrorComponent {
-  constructor(
-    public snackBarRef: MatSnackBarRef<FormErrorComponent>,
-    @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+  constructor(public snackBarRef: MatSnackBarRef<FormErrorComponent>, @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 }

--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.html
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.html
@@ -1,4 +1,2 @@
-<p style="display: inline-block; max-width:300px"> {{data.message}} </p>
-<button style="float: right; margin-top: 8px;" mat-button
-        color="accent"
-        (click)="snackBarRef.dismiss()"> Close </button>
+<p style="display: inline-block; max-width: 300px">{{ data.message }}</p>
+<button style="float: right; margin-top: 8px" mat-button color="accent" (click)="snackBarRef.dismiss()">Close</button>

--- a/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
+++ b/src/app/shared/error-toasters/general-message-error/general-message-error.component.ts
@@ -3,10 +3,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
 
 @Component({
   selector: 'app-general-message-error',
-  templateUrl: './general-message-error.component.html',
+  templateUrl: './general-message-error.component.html'
 })
 export class GeneralMessageErrorComponent {
-  constructor(
-    public snackBarRef: MatSnackBarRef<GeneralMessageErrorComponent>,
-    @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+  constructor(public snackBarRef: MatSnackBarRef<GeneralMessageErrorComponent>, @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 }

--- a/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.html
+++ b/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.html
@@ -1,4 +1,2 @@
-<p style="display: inline-block;"> Invalid Credentials, please try again! </p>
-<button style="float: right; margin-top: 8px;" mat-button
-        color="accent"
-        (click)="snackBarRef.dismiss()"> Close </button>
+<p style="display: inline-block">Invalid Credentials, please try again!</p>
+<button style="float: right; margin-top: 8px" mat-button color="accent" (click)="snackBarRef.dismiss()">Close</button>

--- a/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
+++ b/src/app/shared/error-toasters/invalid-credentials-error/invalid-credentials-error.component.ts
@@ -3,10 +3,8 @@ import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material';
 
 @Component({
   selector: 'app-form-error',
-  templateUrl: './invalid-credentials-error.component.html',
+  templateUrl: './invalid-credentials-error.component.html'
 })
 export class InvalidCredentialsErrorComponent {
-  constructor(
-    public snackBarRef: MatSnackBarRef<InvalidCredentialsErrorComponent>,
-    @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
+  constructor(public snackBarRef: MatSnackBarRef<InvalidCredentialsErrorComponent>, @Inject(MAT_SNACK_BAR_DATA) public data: any) {}
 }

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -16,9 +16,13 @@ export class IssuesDataTable extends DataSource<Issue> {
 
   public isLoading$ = this.issueService.isLoading.asObservable();
 
-  constructor(private issueService: IssueService, private sort: MatSort,
-              private paginator: MatPaginator, private displayedColumn: string[],
-              private defaultFilter?: (issue: Issue) => boolean) {
+  constructor(
+    private issueService: IssueService,
+    private sort: MatSort,
+    private paginator: MatPaginator,
+    private displayedColumn: string[],
+    private defaultFilter?: (issue: Issue) => boolean
+  ) {
     super();
   }
 
@@ -40,31 +44,32 @@ export class IssuesDataTable extends DataSource<Issue> {
       this.paginator.page,
       this.sort.sortChange,
       this.filterChange,
-      this.teamFilterChange,
+      this.teamFilterChange
     ];
 
     this.issueService.startPollIssues();
-    this.issueSubscription = this.issueService.issues$.pipe(
-      flatMap(() => {
-        return merge(...displayDataChanges).pipe(
-          map(() => {
-            let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
-            if (this.defaultFilter) {
-              data = data.filter(this.defaultFilter);
-            }
-            data = getSortedData(this.sort, data);
-            data = this.getFilteredTeamData(data);
-            data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
-            data = paginateData(this.paginator, data);
+    this.issueSubscription = this.issueService.issues$
+      .pipe(
+        flatMap(() => {
+          return merge(...displayDataChanges).pipe(
+            map(() => {
+              let data = <Issue[]>Object.values(this.issueService.issues$.getValue()).reverse();
+              if (this.defaultFilter) {
+                data = data.filter(this.defaultFilter);
+              }
+              data = getSortedData(this.sort, data);
+              data = this.getFilteredTeamData(data);
+              data = applySearchFilter(this.filter, this.displayedColumn, this.issueService, data);
+              data = paginateData(this.paginator, data);
 
-            return data;
-          })
-        );
-      })
-    ).subscribe((issues) => {
-      this.issuesSubject.next(issues);
-    }
-    );
+              return data;
+            })
+          );
+        })
+      )
+      .subscribe((issues) => {
+        this.issuesSubject.next(issues);
+      });
   }
 
   get filter(): string {

--- a/src/app/shared/issue-tables/issue-paginator.ts
+++ b/src/app/shared/issue-tables/issue-paginator.ts
@@ -2,16 +2,16 @@ import { MatPaginator } from '@angular/material';
 import { Issue } from '../../core/models/issue.model';
 
 export function paginateData(paginator: MatPaginator, data: Issue[]): Issue[] {
-    paginator.length = data.length;
-    let result = getDataForPage(paginator.pageIndex, paginator.pageSize, data);
-    if (result.length === 0) {
-        paginator.pageIndex -= 1;
-        result = getDataForPage(paginator.pageIndex, paginator.pageSize, data);
-    }
-    return result;
+  paginator.length = data.length;
+  let result = getDataForPage(paginator.pageIndex, paginator.pageSize, data);
+  if (result.length === 0) {
+    paginator.pageIndex -= 1;
+    result = getDataForPage(paginator.pageIndex, paginator.pageSize, data);
+  }
+  return result;
 }
 
 function getDataForPage(pageIndex: number, pageSize: number, data: Issue[]): Issue[] {
-    const startIndex = pageIndex * pageSize;
-    return data.splice(startIndex, pageSize);
+  const startIndex = pageIndex * pageSize;
+  return data.splice(startIndex, pageSize);
 }

--- a/src/app/shared/issue-tables/issue-sorter.ts
+++ b/src/app/shared/issue-tables/issue-sorter.ts
@@ -3,10 +3,10 @@ import { Issue, ISSUE_TYPE_ORDER, SEVERITY_ORDER } from '../../core/models/issue
 
 export function getSortedData(sort: MatSort, data: Issue[]): Issue[] {
   if (!sort.active) {
-      return data;
+    return data;
   }
 
-  const direction: number = (sort.direction === 'asc' ? 1 : -1);
+  const direction: number = sort.direction === 'asc' ? 1 : -1;
 
   return data.sort((a, b) => {
     switch (sort.active) {
@@ -22,7 +22,8 @@ export function getSortedData(sort: MatSort, data: Issue[]): Issue[] {
         return -direction * compareByIntegerValue(a.numOfUnresolvedDisputes(), b.numOfUnresolvedDisputes());
       case 'id':
         return direction * compareByIntegerValue(a.id, b.id);
-      default: // title, responseTag are string values
+      default:
+        // title, responseTag are string values
         return direction * compareByStringValue(a[sort.active], b[sort.active]);
     }
   });
@@ -45,9 +46,9 @@ function compareByIssueType(issueTypeA: string, issueTypeB: string): number {
 function compareByStringValue(valueA: string, valueB: string): number {
   const orderA = String(valueA || '').toUpperCase();
   const orderB = String(valueB || '').toUpperCase();
-  return (orderA < orderB ? -1 : 1);
+  return orderA < orderB ? -1 : 1;
 }
 
 function compareByIntegerValue(valueA: number, valueB: number): number {
-  return (valueA < valueB ? -1 : 1);
+  return valueA < valueB ? -1 : 1;
 }

--- a/src/app/shared/issue-tables/issue-tables-columns.ts
+++ b/src/app/shared/issue-tables/issue-tables-columns.ts
@@ -1,12 +1,12 @@
 export enum TABLE_COLUMNS {
-    ID = 'id',
-    TITLE = 'title',
-    TEAM_ASSIGNED = 'teamAssigned',
-    TYPE = 'type',
-    SEVERITY = 'severity',
-    RESPONSE = 'responseTag',
-    ASSIGNEE = 'assignees',
-    DUPLICATED_ISSUES = 'duplicatedIssues',
-    TODO = 'Todo Remaining',
-    ACTIONS = 'actions'
-  }
+  ID = 'id',
+  TITLE = 'title',
+  TEAM_ASSIGNED = 'teamAssigned',
+  TYPE = 'type',
+  SEVERITY = 'severity',
+  RESPONSE = 'responseTag',
+  ASSIGNEE = 'assignees',
+  DUPLICATED_ISSUES = 'duplicatedIssues',
+  TODO = 'Todo Remaining',
+  ACTIONS = 'actions'
+}

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -1,97 +1,127 @@
 <table mat-table [dataSource]="this.issues" matSort class="mat-elevation-z8">
-
   <!-- ID Column -->
   <ng-container matColumnDef="id">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> ID </th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
     <td mat-cell *matCellDef="let issue">
-      <span (click)="$event.stopPropagation()" style="cursor: default;">{{issue.id}}</span>
+      <span (click)="$event.stopPropagation()" style="cursor: default">{{ issue.id }}</span>
     </td>
   </ng-container>
 
   <!-- Title Column -->
   <ng-container matColumnDef="title">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Title </th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Title</th>
     <td mat-cell *matCellDef="let issue">
-      <a class="no-underline link-grey-dark" [routerLink]="'issues/' + issue.id"> {{this.fitTitleText(issue.title)}} </a>
+      <a class="no-underline link-grey-dark" [routerLink]="'issues/' + issue.id"> {{ this.fitTitleText(issue.title) }} </a>
     </td>
   </ng-container>
 
   <!-- Team Assigned Column -->
   <ng-container *ngIf="userService.currentUser.role !== 'Student'" matColumnDef="teamAssigned">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Team </th>
-    <td mat-cell *matCellDef="let issue"> {{ issue.teamAssigned && issue.teamAssigned.id || '-'}} </td>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Team</th>
+    <td mat-cell *matCellDef="let issue">{{ (issue.teamAssigned && issue.teamAssigned.id) || '-' }}</td>
   </ng-container>
 
   <!-- Type Column -->
   <ng-container matColumnDef="type">
-    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '10%' : '15%'" *matHeaderCellDef mat-sort-header> Type </th>
+    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '10%' : '15%'" *matHeaderCellDef mat-sort-header>Type</th>
     <td mat-cell *matCellDef="let issue">
-          <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
-              {{issue.type || '-'}}
-          </span>
-          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" style="display: inline; padding: 1px 2px">
-            <mat-icon style="vertical-align: middle;">arrow_right_alt</mat-icon>
-          </span>
-          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))">
-            {{issue.teamChosenType}}
-          </span>
+      <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
+        {{ issue.type || '-' }}
+      </span>
+      <span
+        *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type"
+        (click)="$event.stopPropagation()"
+        style="display: inline; padding: 1px 2px"
+      >
+        <mat-icon style="vertical-align: middle">arrow_right_alt</mat-icon>
+      </span>
+      <span
+        *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type"
+        (click)="$event.stopPropagation()"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))"
+      >
+        {{ issue.teamChosenType }}
+      </span>
     </td>
   </ng-container>
 
   <!-- Severity Column -->
   <ng-container matColumnDef="severity">
-    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '9%' : '12%'" *matHeaderCellDef mat-sort-header> Severity </th>
+    <th mat-header-cell [style.width]="permissions.isTeamResponseEditable() ? '9%' : '12%'" *matHeaderCellDef mat-sort-header>Severity</th>
     <td mat-cell *matCellDef="let issue">
-      <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))">
-        {{issue.severity || '-'}}
+      <span
+        (click)="$event.stopPropagation()"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))"
+      >
+        {{ issue.severity || '-' }}
       </span>
-      <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" style="display: inline; margin: 3px;">
-        <mat-icon style="vertical-align: middle;">arrow_right_alt</mat-icon>
+      <span
+        *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity"
+        (click)="$event.stopPropagation()"
+        style="display: inline; margin: 3px"
+      >
+        <mat-icon style="vertical-align: middle">arrow_right_alt</mat-icon>
       </span>
-      <span *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenSeverity))">
-        {{issue.teamChosenSeverity}}
+      <span
+        *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity"
+        (click)="$event.stopPropagation()"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenSeverity))"
+      >
+        {{ issue.teamChosenSeverity }}
       </span>
     </td>
   </ng-container>
 
   <!--Response Tag Column-->
   <ng-container matColumnDef="responseTag">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Response </th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Response</th>
     <td mat-cell *matCellDef="let issue">
-        <span (click)="$event.stopPropagation()" *ngIf="issue.responseTag"
-              [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))">
-          {{issue.responseTag}}
-        </span>
+      <span
+        (click)="$event.stopPropagation()"
+        *ngIf="issue.responseTag"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))"
+      >
+        {{ issue.responseTag }}
+      </span>
       <span *ngIf="!issue.responseTag" style="margin-left: 10%">
-          <mat-icon matTooltip="Should not be empty" matTooltipPosition="above" color="warn">warning</mat-icon>
-        </span>
-  </ng-container>
+        <mat-icon matTooltip="Should not be empty" matTooltipPosition="above" color="warn">warning</mat-icon>
+      </span>
+    </td></ng-container
+  >
 
   <!--Assignee Column-->
   <ng-container matColumnDef="assignees">
-    <th [style.width]="userService.currentUser.role === 'Student' ? '15%' : '10%'" mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </th>
+    <th [style.width]="userService.currentUser.role === 'Student' ? '15%' : '10%'" mat-header-cell *matHeaderCellDef mat-sort-header>
+      Assignees
+    </th>
     <td mat-cell *matCellDef="let issue">
-        <span (click)="$event.stopPropagation()" style="cursor: default;" *ngIf="issue.assignees.length !== 0">
-          {{issue.assignees.join(', ')}}
-        </span>
+      <span (click)="$event.stopPropagation()" style="cursor: default" *ngIf="issue.assignees.length !== 0">
+        {{ issue.assignees.join(', ') }}
+      </span>
       <span *ngIf="issue.assignees.length === 0" style="margin-left: 5%">
-          <mat-icon matTooltip="We strongly recommend assigning all issues to someone"
-                    matTooltipPosition="above" style="color: #FFAB40;">warning</mat-icon>
-        </span>
-  </ng-container>
+        <mat-icon matTooltip="We strongly recommend assigning all issues to someone" matTooltipPosition="above" style="color: #ffab40"
+          >warning</mat-icon
+        >
+      </span>
+    </td></ng-container
+  >
 
   <!-- Duplicated Issues Column -->
   <ng-container matColumnDef="duplicatedIssues">
-    <th mat-header-cell *matHeaderCellDef> Duplicates </th>
+    <th mat-header-cell *matHeaderCellDef>Duplicates</th>
     <td mat-cell *matCellDef="let issue">
-      <div *ngIf="(issueService.getDuplicateIssuesFor(issue) | async).length === 0">
-        -
-      </div>
-      <mat-chip-list *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(issue) | async)" style="display: inline-block; margin-left: 5px;">
-        <mat-chip [routerLink]="['issues/' + duplicateIssue.id]"
-                  [matTooltip]="duplicateIssue.title" matTooltipPosition="above"
-                  style="font-size: 12px; cursor: pointer">
-          #{{duplicateIssue.id}}
+      <div *ngIf="(issueService.getDuplicateIssuesFor(issue) | async).length === 0">-</div>
+      <mat-chip-list
+        *ngFor="let duplicateIssue of issueService.getDuplicateIssuesFor(issue) | async"
+        style="display: inline-block; margin-left: 5px"
+      >
+        <mat-chip
+          [routerLink]="['issues/' + duplicateIssue.id]"
+          [matTooltip]="duplicateIssue.title"
+          matTooltipPosition="above"
+          style="font-size: 12px; cursor: pointer"
+        >
+          #{{ duplicateIssue.id }}
         </mat-chip>
       </mat-chip-list>
     </td>
@@ -99,64 +129,115 @@
 
   <!-- To do Column -->
   <ng-container matColumnDef="Todo Remaining">
-    <th mat-header-cell *matHeaderCellDef mat-sort-header> Todo Remaining </th>
+    <th mat-header-cell *matHeaderCellDef mat-sort-header>Todo Remaining</th>
     <td mat-cell *matCellDef="let issue">
       <span *ngIf="isTodoListChecked(issue) && issue.issueDisputes.length > 0"> <font color="green">All tasks are completed</font> </span>
-      <span *ngIf="!isTodoListChecked(issue)"> <font color="red">{{ issue.issueDisputes.length - todoFinished(issue) }}/{{ issue.issueDisputes.length }} tasks pending.</font></span>
-      <progress *ngIf="issue.issueDisputes.length > 0" value={{todoFinished(issue)}} max={{issue.issueDisputes.length}} role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></progress>
+      <span *ngIf="!isTodoListChecked(issue)">
+        <font color="red"
+          >{{ issue.issueDisputes.length - todoFinished(issue) }}/{{ issue.issueDisputes.length }} tasks pending.</font
+        ></span
+      >
+      <progress
+        *ngIf="issue.issueDisputes.length > 0"
+        value="{{ todoFinished(issue) }}"
+        max="{{ issue.issueDisputes.length }}"
+        role="progressbar"
+        style="width: 100%"
+        aria-valuenow="100"
+        aria-valuemin="0"
+        aria-valuemax="100"
+      ></progress>
       <span *ngIf="issue.issueDisputes.length === 0"> No Todo List for this issue </span>
     </td>
   </ng-container>
 
   <!-- Action Buttons Column -->
   <ng-container matColumnDef="actions">
-    <th mat-header-cell *matHeaderCellDef> Actions </th>
+    <th mat-header-cell *matHeaderCellDef>Actions</th>
     <td mat-cell *matCellDef="let issue">
-      <button mat-button matTooltip="View this issue on GitHub" *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
-              (click)="this.viewIssueInBrowser(issue.id)" style="
-              transform: scale(0.8)">
+      <button
+        mat-button
+        matTooltip="View this issue on GitHub"
+        *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
+        (click)="this.viewIssueInBrowser(issue.id)"
+        style="transform: scale(0.8)"
+      >
         <mat-icon>open_in_new</mat-icon>
       </button>
-      <button *ngIf="this.isResponseEditable() && !issue.status
-       && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryEditIssue"
-              [routerLink]="'issues/' + issue.id" mat-button color="accent"
-              style="transform: scale(0.8)" matTooltip="Respond to this issue" (click)="this.logIssueRespondRouting(issue.id)">
+      <button
+        *ngIf="this.isResponseEditable() && !issue.status && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryEditIssue"
+        [routerLink]="'issues/' + issue.id"
+        mat-button
+        color="accent"
+        style="transform: scale(0.8)"
+        matTooltip="Respond to this issue"
+        (click)="this.logIssueRespondRouting(issue.id)"
+      >
         <mat-icon>feedback</mat-icon>
       </button>
       <ng-template #tryEditIssue>
-        <button *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
-                mat-button color="accent"
-                style="transform: scale(0.8)" matTooltip="Edit this issue" >
+        <button
+          *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
+          mat-button
+          color="accent"
+          style="transform: scale(0.8)"
+          matTooltip="Edit this issue"
+        >
           <mat-icon>edit</mat-icon>
         </button>
       </ng-template>
-      <button *ngIf="this.isResponseEditable() && issue.status
-      && this.isActionVisible(action_buttons.MARK_AS_RESPONDED)"
-              mat-button color="primary" (click)="markAsResponded(issue)"
-              style="transform: scale(0.8)" matTooltip="Mark this issue as Responded">
+      <button
+        *ngIf="this.isResponseEditable() && issue.status && this.isActionVisible(action_buttons.MARK_AS_RESPONDED)"
+        mat-button
+        color="primary"
+        (click)="markAsResponded(issue)"
+        style="transform: scale(0.8)"
+        matTooltip="Mark this issue as Responded"
+      >
         <mat-icon>check_circle</mat-icon>
       </button>
-      <button color="primary" matTooltip="Mark this issue as Pending" mat-button (click)="markAsPending(issue)"
-              style="transform: scale(0.8)" *ngIf="(userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin')
-              && this.isActionVisible(action_buttons.MARK_AS_PENDING)">
+      <button
+        color="primary"
+        matTooltip="Mark this issue as Pending"
+        mat-button
+        (click)="markAsPending(issue)"
+        style="transform: scale(0.8)"
+        *ngIf="
+          (userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin') &&
+          this.isActionVisible(action_buttons.MARK_AS_PENDING)
+        "
+      >
         <mat-icon>cancel</mat-icon>
       </button>
-      <button mat-button color="warn" *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id]
-          && this.isActionVisible(action_buttons.DELETE_ISSUE)"
-              (click)="openDeleteDialog(issue.id); $event.stopPropagation()" 
-              matTooltip="Delete this issue" style="transform: scale(0.8)">
+      <button
+        mat-button
+        color="warn"
+        *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)"
+        (click)="openDeleteDialog(issue.id); $event.stopPropagation()"
+        matTooltip="Delete this issue"
+        style="transform: scale(0.8)"
+      >
         <mat-icon>delete_outline</mat-icon>
       </button>
-      <mat-spinner color="warn" [diameter]="25" style="display: inline; padding-right: 30px; margin-left: 5px"
-                   *ngIf="issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)" ></mat-spinner>
+      <mat-spinner
+        color="warn"
+        [diameter]="25"
+        style="display: inline; padding-right: 30px; margin-left: 5px"
+        *ngIf="issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)"
+      ></mat-spinner>
     </td>
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="this.headers"></tr>
-  <tr mat-row *matRowDef="let issue; columns: this.headers;" (click)="this.logIssueEditRouting(issue.id)" [routerLink]="'issues/' + issue.id" style="cursor: pointer"></tr>
+  <tr
+    mat-row
+    *matRowDef="let issue; columns: this.headers"
+    (click)="this.logIssueEditRouting(issue.id)"
+    [routerLink]="'issues/' + issue.id"
+    style="cursor: pointer"
+  ></tr>
 </table>
-<mat-card *ngIf="this.issues.isLoading$ | async"
-          style="display: flex; justify-content: center; align-items: center">
+<mat-card *ngIf="this.issues.isLoading$ | async" style="display: flex; justify-content: center; align-items: center">
   <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
 </mat-card>
 <mat-paginator [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -28,7 +28,6 @@ export enum ACTION_BUTTONS {
   styleUrls: ['./issue-tables.component.css']
 })
 export class IssueTablesComponent implements OnInit, AfterViewInit {
-
   @Input() headers: string[];
   @Input() actions: ACTION_BUTTONS[];
   @Input() filters?: any = undefined;
@@ -37,28 +36,29 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   issues: IssuesDataTable;
-  issuesPendingDeletion: {[id: number]: boolean};
+  issuesPendingDeletion: { [id: number]: boolean };
 
   public readonly action_buttons = ACTION_BUTTONS;
 
   // Messages for the modal popup window upon deleting an issue
   private readonly deleteIssueModalMessages = ['Do you wish to delete this issue?', 'This action is irreversible!'];
   private readonly yesButtonModalMessage = 'Yes, I wish to delete this issue';
-  private readonly noButtonModalMessage = 'No, I don\'t wish to delete this issue';
+  private readonly noButtonModalMessage = "No, I don't wish to delete this issue";
 
-  constructor(public userService: UserService,
-              public permissions: PermissionService,
-              public labelService: LabelService,
-              private githubService: GithubService,
-              public issueService: IssueService,
-              private phaseService: PhaseService,
-              private errorHandlingService: ErrorHandlingService,
-              private loggingService: LoggingService,
-              private dialogService: DialogService) { }
+  constructor(
+    public userService: UserService,
+    public permissions: PermissionService,
+    public labelService: LabelService,
+    private githubService: GithubService,
+    public issueService: IssueService,
+    private phaseService: PhaseService,
+    private errorHandlingService: ErrorHandlingService,
+    private loggingService: LoggingService,
+    private dialogService: DialogService
+  ) {}
 
   ngOnInit() {
-    this.issues = new IssuesDataTable(this.issueService, this.sort,
-      this.paginator, this.headers, this.filters);
+    this.issues = new IssuesDataTable(this.issueService, this.sort, this.paginator, this.headers, this.filters);
     this.issuesPendingDeletion = {};
   }
 
@@ -73,18 +73,20 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
    * @param title - Title of Issue that is to be displayed in the Table Row.
    */
   fitTitleText(title: string): string {
-
     // Arbitrary Length of Characters beyond which an overflow occurs.
     const MAX_WORD_LENGTH = 43;
     const SPLITTER_TEXT = ' ';
     const ELLIPSES = '...';
 
-    return title.split(SPLITTER_TEXT).map(word => {
-      if (word.length > MAX_WORD_LENGTH) {
-        return word.substring(0, MAX_WORD_LENGTH - 5).concat(ELLIPSES);
-      }
-      return word;
-    }).join(SPLITTER_TEXT);
+    return title
+      .split(SPLITTER_TEXT)
+      .map((word) => {
+        if (word.length > MAX_WORD_LENGTH) {
+          return word.substring(0, MAX_WORD_LENGTH - 5).concat(ELLIPSES);
+        }
+        return word;
+      })
+      .join(SPLITTER_TEXT);
   }
 
   isActionVisible(action: ACTION_BUTTONS): boolean {
@@ -95,11 +97,14 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     this.loggingService.info(`IssueTablesComponent: Marking Issue ${issue.id} as Responded`);
     const newIssue = issue.clone(this.phaseService.currentPhase);
     newIssue.status = STATUS.Done;
-    this.issueService.updateIssue(newIssue).subscribe((updatedIssue) => {
-      this.issueService.updateLocalStore(updatedIssue);
-    }, error => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService.updateIssue(newIssue).subscribe(
+      (updatedIssue) => {
+        this.issueService.updateLocalStore(updatedIssue);
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error);
+      }
+    );
     event.stopPropagation();
   }
 
@@ -111,11 +116,14 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     this.loggingService.info(`IssueTablesComponent: Marking Issue ${issue.id} as Pending`);
     const newIssue = issue.clone(this.phaseService.currentPhase);
     newIssue.status = STATUS.Incomplete;
-    this.issueService.updateIssue(newIssue).subscribe((updatedIssue) => {
-      this.issueService.updateLocalStore(updatedIssue);
-    }, error => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService.updateIssue(newIssue).subscribe(
+      (updatedIssue) => {
+        this.issueService.updateLocalStore(updatedIssue);
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error);
+      }
+    );
     event.stopPropagation();
   }
 
@@ -150,24 +158,33 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     this.loggingService.info(`IssueTablesComponent: Deleting Issue ${id}`);
     this.issuesPendingDeletion = {
       ...this.issuesPendingDeletion,
-      [id]: true,
+      [id]: true
     };
-    this.issueService.deleteIssue(id).pipe(finalize(() => {
-      const { [id]: issueRemoved, ...theRest } = this.issuesPendingDeletion;
-      this.issuesPendingDeletion = theRest;
-    })).subscribe((removedIssue) => {
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService
+      .deleteIssue(id)
+      .pipe(
+        finalize(() => {
+          const { [id]: issueRemoved, ...theRest } = this.issuesPendingDeletion;
+          this.issuesPendingDeletion = theRest;
+        })
+      )
+      .subscribe(
+        (removedIssue) => {},
+        (error) => {
+          this.errorHandlingService.handleError(error);
+        }
+      );
     event.stopPropagation();
   }
 
   openDeleteDialog(id: number) {
     const dialogRef = this.dialogService.openUserConfirmationModal(
-      this.deleteIssueModalMessages, this.yesButtonModalMessage, this.noButtonModalMessage
+      this.deleteIssueModalMessages,
+      this.yesButtonModalMessage,
+      this.noButtonModalMessage
     );
 
-    dialogRef.afterClosed().subscribe(res => {
+    dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.loggingService.info(`Deleting issue ${id}`);
         this.deleteIssue(id);

--- a/src/app/shared/issue-tables/issue-tables.module.ts
+++ b/src/app/shared/issue-tables/issue-tables.module.ts
@@ -5,16 +5,8 @@ import { MaterialModule } from '../material.module';
 import { IssueTablesComponent } from './issue-tables.component';
 
 @NgModule({
-  exports: [
-    IssueTablesComponent
-  ],
-  declarations: [
-    IssueTablesComponent
-  ],
-  imports: [
-    CommonModule,
-    MaterialModule,
-    RouterModule
-  ]
+  exports: [IssueTablesComponent],
+  declarations: [IssueTablesComponent],
+  imports: [CommonModule, MaterialModule, RouterModule]
 })
-export class IssueTablesModule { }
+export class IssueTablesModule {}

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -8,30 +8,30 @@ import { TABLE_COLUMNS } from './issue-tables-columns';
  * This module exports a single function applySearchFilter which is called by IssuesDataTable.
  */
 export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, data: Issue[]): Issue[] {
-    const searchKey = filter.toLowerCase();
-    const result = data.slice().filter((issue: Issue) => {
-      for (const column of displayedColumn) {
-        switch (column) {
-          case TABLE_COLUMNS.ASSIGNEE:
-            if (matchesAssignee(issue.assignees, searchKey)) {
-              return true;
-            }
-            break;
-          case TABLE_COLUMNS.DUPLICATED_ISSUES:
-            if (matchesDuplicatedIssue(issueService, issue.id, searchKey)) {
-              return true;
-            }
-            break;
-          default:
-            if (matchesOtherColumns(issue, column, searchKey)) {
-              return true;
-            }
-            break;
-        }
+  const searchKey = filter.toLowerCase();
+  const result = data.slice().filter((issue: Issue) => {
+    for (const column of displayedColumn) {
+      switch (column) {
+        case TABLE_COLUMNS.ASSIGNEE:
+          if (matchesAssignee(issue.assignees, searchKey)) {
+            return true;
+          }
+          break;
+        case TABLE_COLUMNS.DUPLICATED_ISSUES:
+          if (matchesDuplicatedIssue(issueService, issue.id, searchKey)) {
+            return true;
+          }
+          break;
+        default:
+          if (matchesOtherColumns(issue, column, searchKey)) {
+            return true;
+          }
+          break;
       }
-      return false;
-    });
-    return result;
+    }
+    return false;
+  });
+  return result;
 }
 
 function containsSearchKey(item: string, searchKey: string): boolean {
@@ -39,7 +39,7 @@ function containsSearchKey(item: string, searchKey: string): boolean {
 }
 
 function duplicatedIssuesContainsSearchKey(duplicatedIssues: Issue[], searchKey: string): boolean {
-  return duplicatedIssues.filter(el => `#${String(el.id)}`.includes(searchKey)).length !== 0;
+  return duplicatedIssues.filter((el) => `#${String(el.id)}`.includes(searchKey)).length !== 0;
 }
 
 function matchesAssignee(assignees: string[], searchKey: string): boolean {
@@ -50,7 +50,7 @@ function matchesAssignee(assignees: string[], searchKey: string): boolean {
 }
 
 function matchesDuplicatedIssue(issueService: IssueService, id: number, searchKey: string): boolean {
-  const duplicatedIssues = issueService.issues$.getValue().filter(el => el.duplicateOf === id);
+  const duplicatedIssues = issueService.issues$.getValue().filter((el) => el.duplicateOf === id);
   return duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKey);
 }
 

--- a/src/app/shared/issue/assignee/assignee.component.html
+++ b/src/app/shared/issue/assignee/assignee.component.html
@@ -1,20 +1,29 @@
 <div>
   <span class="mat-title"> Assignees </span>
-  <button *ngIf="permissions.isIssueLabelsEditable() && isEditable && !issue.duplicateOf" style="float: right" (click)="openSelector()" mat-icon-button>
+  <button
+    *ngIf="permissions.isIssueLabelsEditable() && isEditable && !issue.duplicateOf"
+    style="float: right"
+    (click)="openSelector()"
+    mat-icon-button
+  >
     <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> edit </mat-icon>
   </button>
 
-  <mat-select class="no-arrow" [style.display]="isInEditMode ? 'block' : 'none'" placeholder="-" multiple
-              (openedChange)="handleEditMode($event)"
-              (closed)="updateAssignee()"
-              [(ngModel)]="this.assignees">
-    <mat-select-trigger>
-    </mat-select-trigger>
-    <mat-option *ngFor="let assignee of teamMembers" [value]="assignee.toLowerCase()">{{assignee}}</mat-option>
+  <mat-select
+    class="no-arrow"
+    [style.display]="isInEditMode ? 'block' : 'none'"
+    placeholder="-"
+    multiple
+    (openedChange)="handleEditMode($event)"
+    (closed)="updateAssignee()"
+    [(ngModel)]="this.assignees"
+  >
+    <mat-select-trigger> </mat-select-trigger>
+    <mat-option *ngFor="let assignee of teamMembers" [value]="assignee.toLowerCase()">{{ assignee }}</mat-option>
   </mat-select>
 
-  <p *ngIf="issue.assignees.length === 0" style="margin-top: 5px"> - </p>
+  <p *ngIf="issue.assignees.length === 0" style="margin-top: 5px">-</p>
   <mat-list style="padding-top: 0" dense *ngIf="issue.assignees.length > 0">
-    <mat-list-item style="font-size: 1em;" *ngFor="let assignee of issue.assignees">{{assignee}}</mat-list-item>
+    <mat-list-item style="font-size: 1em" *ngFor="let assignee of issue.assignees">{{ assignee }}</mat-list-item>
   </mat-list>
 </div>

--- a/src/app/shared/issue/assignee/assignee.component.ts
+++ b/src/app/shared/issue/assignee/assignee.component.ts
@@ -27,15 +27,16 @@ export class AssigneeComponent implements OnInit {
 
   @Output() issueUpdated = new EventEmitter<Issue>();
 
-  constructor(private issueService: IssueService,
-              private errorHandlingService: ErrorHandlingService,
-              private phaseService: PhaseService,
-              public permissions: PermissionService) {
-  }
+  constructor(
+    private issueService: IssueService,
+    private errorHandlingService: ErrorHandlingService,
+    private phaseService: PhaseService,
+    public permissions: PermissionService
+  ) {}
 
   ngOnInit(): void {
     this.teamMembers = this.team.teamMembers.map((user) => user.loginId);
-    this.assignees = this.issue.assignees.map(a => a.toLowerCase());
+    this.assignees = this.issue.assignees.map((a) => a.toLowerCase());
   }
 
   openSelector() {
@@ -52,18 +53,24 @@ export class AssigneeComponent implements OnInit {
   updateAssignee(): void {
     const newIssue = this.issue.clone(this.phaseService.currentPhase);
     newIssue.assignees = this.assignees;
-    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
-      this.issueUpdated.emit(updatedIssue);
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService.updateIssue(newIssue).subscribe(
+      (updatedIssue: Issue) => {
+        this.issueUpdated.emit(updatedIssue);
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error);
+      }
+    );
     // Update assignees of duplicate issues
-    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues: Issue[]) => {
-      issues.forEach((issue: Issue) => {
-        const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
-        newDuplicateIssue.assignees = this.assignees;
-        this.issueService.updateIssue(newDuplicateIssue);
+    this.issueService
+      .getDuplicateIssuesFor(this.issue)
+      .pipe(first())
+      .subscribe((issues: Issue[]) => {
+        issues.forEach((issue: Issue) => {
+          const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
+          newDuplicateIssue.assignees = this.assignees;
+          this.issueService.updateIssue(newDuplicateIssue);
+        });
       });
-    });
   }
 }

--- a/src/app/shared/issue/conflict-dialog/conflict-dialog.component.html
+++ b/src/app/shared/issue/conflict-dialog/conflict-dialog.component.html
@@ -1,7 +1,12 @@
 <div style="display: flex; margin-bottom: 20px; align-items: center">
-  <h1 mat-dialog-title style="margin: 0">{{ 'The content you are editing has changed'}}</h1>
-  <mat-slide-toggle *ngIf="!isOnPreview" style="display: inline-block; margin-left: 50px"
-                    color="primary" [checked]="showDiff" (change)="handleChangeShowDiff()">
+  <h1 mat-dialog-title style="margin: 0">{{ 'The content you are editing has changed' }}</h1>
+  <mat-slide-toggle
+    *ngIf="!isOnPreview"
+    style="display: inline-block; margin-left: 50px"
+    color="primary"
+    [checked]="showDiff"
+    (change)="handleChangeShowDiff()"
+  >
     Show Difference
   </mat-slide-toggle>
   <button mat-icon-button color="default" style="margin: 0 0 0 auto" (click)="close()">
@@ -9,7 +14,7 @@
   </button>
 </div>
 
-<div mat-dialog-content style="display: flex;">
+<div mat-dialog-content style="display: flex">
   <div class="full-width">
     <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="handleTabChange($event)">
       <mat-tab label="Markdown Text">
@@ -20,7 +25,7 @@
       </mat-tab>
       <mat-tab label="Preview Updated Content">
         <div class="tab-content">
-          <markdown>{{data.updatedContent}}</markdown>
+          <markdown>{{ data.updatedContent }}</markdown>
         </div>
       </mat-tab>
     </mat-tab-group>

--- a/src/app/shared/issue/conflict-dialog/conflict-dialog.component.ts
+++ b/src/app/shared/issue/conflict-dialog/conflict-dialog.component.ts
@@ -27,8 +27,8 @@ export class ConflictDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: Conflict,
     private sanitizer: DomSanitizer,
     public labelService: LabelService,
-    public issueService: IssueService) {
-
+    public issueService: IssueService
+  ) {
     this.diffHtml = this.sanitizer.bypassSecurityTrustHtml(data.getHtmlDiffString());
     this.updatedHtml = this.sanitizer.bypassSecurityTrustHtml(data.getHtmlUpdatedString());
     this.isReady = true;
@@ -43,6 +43,6 @@ export class ConflictDialogComponent {
   }
 
   handleTabChange(event: MatTabChangeEvent): void {
-    this.isOnPreview = (event.index === 1);
+    this.isOnPreview = event.index === 1;
   }
 }

--- a/src/app/shared/issue/description/description.component.css
+++ b/src/app/shared/issue/description/description.component.css
@@ -1,4 +1,4 @@
 span {
-    vertical-align: middle; 
-    margin-left: 5px;
+  vertical-align: middle;
+  margin-left: 5px;
 }

--- a/src/app/shared/issue/description/description.component.html
+++ b/src/app/shared/issue/description/description.component.html
@@ -1,9 +1,9 @@
-<h3 class="mat-title">{{title}}</h3>
+<h3 class="mat-title">{{ title }}</h3>
 <form [formGroup]="issueDescriptionForm" #myForm="ngForm" (ngSubmit)="updateDescription(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span> <strong> Tester </strong> posted on {{issue.created_at}}. </span>
-      <button style="float: right;" mat-button *ngIf="permissions.isIssueDescriptionEditable() && !isEditing" (click)="changeToEditMode()">
+      <span> <strong> Tester </strong> posted on {{ issue.created_at }}. </span>
+      <button style="float: right" mat-button *ngIf="permissions.isIssueDescriptionEditable() && !isEditing" (click)="changeToEditMode()">
         Edit
       </button>
     </div>
@@ -16,20 +16,42 @@
         [commentField]="this.issueDescriptionForm.get('description')"
         [commentForm]="this.issueDescriptionForm"
         [(isFormPending)]="this.isSavePending"
-        [(submitButtonText)]="this.submitButtonText">
+        [(submitButtonText)]="this.submitButtonText"
+      >
       </app-comment-editor>
       <div class="editor-actions">
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isSavePending"
-                mat-raised-button color="primary" (click)="viewChanges()">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isSavePending"
+          mat-raised-button
+          color="primary"
+          (click)="viewChanges()"
+        >
           View Updated Description
         </button>
-        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="openCancelDialog()">Cancel</button>
-        <button class="editor-action" *ngIf="conflict" type="submit" [disabled]="issueDescriptionForm.invalid || isSavePending"
-                mat-raised-button color="warn">
+        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="openCancelDialog()">
+          Cancel
+        </button>
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="submit"
+          [disabled]="issueDescriptionForm.invalid || isSavePending"
+          mat-raised-button
+          color="warn"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" *ngIf="!conflict" type="submit" [disabled]="issueDescriptionForm.invalid || isSavePending"
-                mat-stroked-button color="primary">
+        <button
+          class="editor-action"
+          *ngIf="!conflict"
+          type="submit"
+          [disabled]="issueDescriptionForm.invalid || isSavePending"
+          mat-stroked-button
+          color="primary"
+        >
           {{ submitButtonText }}
         </button>
       </div>

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.html
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.html
@@ -1,27 +1,51 @@
 <div>
-  <mat-checkbox [disabled]="!permissions.isTeamResponseEditable() && !permissions.isTutorResponseEditable()" labelPosition="after" [checked]="issue.duplicated" (change)="handleCheckboxChange($event)">
+  <mat-checkbox
+    [disabled]="!permissions.isTeamResponseEditable() && !permissions.isTutorResponseEditable()"
+    labelPosition="after"
+    [checked]="issue.duplicated"
+    (change)="handleCheckboxChange($event)"
+  >
     <span class="mat-title">A Duplicate Of:</span>
   </mat-checkbox>
-  <button *ngIf="permissions.isIssueLabelsEditable()" [style.visibility]="issue.duplicated ? 'inherit' : 'hidden'" style="float: right" (click)="openSelection()" mat-icon-button>
+  <button
+    *ngIf="permissions.isIssueLabelsEditable()"
+    [style.visibility]="issue.duplicated ? 'inherit' : 'hidden'"
+    style="float: right"
+    (click)="openSelection()"
+    mat-icon-button
+  >
     <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> edit </mat-icon>
   </button>
 
-  <mat-select [style.display]="isEditing ? 'block' : 'none'" class="no-arrow" placeholder="-" [value]="issue.duplicateOf"
-              (selectionChange)="updateDuplicateStatus($event)" (openedChange)="handleSelectionOpenChange($event)">
+  <mat-select
+    [style.display]="isEditing ? 'block' : 'none'"
+    class="no-arrow"
+    placeholder="-"
+    [value]="issue.duplicateOf"
+    (selectionChange)="updateDuplicateStatus($event)"
+    (openedChange)="handleSelectionOpenChange($event)"
+  >
     <mat-select-trigger></mat-select-trigger>
-    <mat-option [matTooltip]="issue.title" [matTooltipDisabled]="!isTooltipNecessary(issue)" [matTooltipPosition]="'left'"
-                *ngFor="let issue of duplicatedIssueList | async" [disabled]="dupIssueOptionIsDisabled(issue)"
-                [value]="issue.id">
-      <div class="duplicate-dropdown-issuedetails" [ngStyle]="{'width': dupIssueOptionIsDisabled(issue) ? '150px' : 'auto'}">
-        <span class="mat-body-strong"> #{{issue.id}}: </span>  <span class="mat-body">{{issue.title}}</span>
+    <mat-option
+      [matTooltip]="issue.title"
+      [matTooltipDisabled]="!isTooltipNecessary(issue)"
+      [matTooltipPosition]="'left'"
+      *ngFor="let issue of duplicatedIssueList | async"
+      [disabled]="dupIssueOptionIsDisabled(issue)"
+      [value]="issue.id"
+    >
+      <div class="duplicate-dropdown-issuedetails" [ngStyle]="{ width: dupIssueOptionIsDisabled(issue) ? '150px' : 'auto' }">
+        <span class="mat-body-strong"> #{{ issue.id }}: </span> <span class="mat-body">{{ issue.title }}</span>
       </div>
-      <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="display: inline-block; color: #f44336"> ({{getDisabledDupOptionErrorText(issue)}}) </span>
+      <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="display: inline-block; color: #f44336">
+        ({{ getDisabledDupOptionErrorText(issue) }})
+      </span>
     </mat-option>
   </mat-select>
 
   <div>
     <span *ngIf="issue.duplicated" style="margin-top: 5px">
-      {{ issue.duplicateOf ? ('#' + issue.duplicateOf + ': ' + (issueService.getIssue(issue.duplicateOf) | async).title) : 'Not specified'}}
+      {{ issue.duplicateOf ? '#' + issue.duplicateOf + ': ' + (issueService.getIssue(issue.duplicateOf) | async).title : 'Not specified' }}
     </span>
     <span *ngIf="!issue.duplicated" style="margin-top: 5px"> - </span>
   </div>

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -1,19 +1,9 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-  ViewEncapsulation
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MatCheckbox, MatSelect, MatSelectChange } from '@angular/material';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Issue, SEVERITY_ORDER } from '../../../core/models/issue.model';
-import {
-  ErrorHandlingService
-} from '../../../core/services/error-handling.service';
+import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { IssueService } from '../../../core/services/issue.service';
 import { PermissionService } from '../../../core/services/permission.service';
 import { PhaseService } from '../../../core/services/phase.service';
@@ -22,7 +12,7 @@ import { PhaseService } from '../../../core/services/phase.service';
   selector: 'app-duplicate-of-component',
   templateUrl: './duplicate-of.component.html',
   styleUrls: ['./duplicate-of.component.css'],
-  encapsulation: ViewEncapsulation.None,
+  encapsulation: ViewEncapsulation.None
 })
 export class DuplicateOfComponent implements OnInit {
   isEditing = false;
@@ -40,11 +30,12 @@ export class DuplicateOfComponent implements OnInit {
   // Max chars visible for a non-duplicate entry in duplicates dropdown list.
   readonly MAX_TITLE_LENGTH_FOR_NON_DUPLICATE_ISSUE = 37;
 
-  constructor(public issueService: IssueService,
-              public permissions: PermissionService,
-              private errorHandlingService: ErrorHandlingService,
-              private phaseService: PhaseService) {
-  }
+  constructor(
+    public issueService: IssueService,
+    public permissions: PermissionService,
+    private errorHandlingService: ErrorHandlingService,
+    private phaseService: PhaseService
+  ) {}
 
   /**
    * Checks if the supplied issue requires a tooltip
@@ -56,9 +47,7 @@ export class DuplicateOfComponent implements OnInit {
     // Maximum Possible Title length varies based on whether the issue
     // is a duplicate. (Whether the Duplicate Issue Tag is visible)
     let maxTitleLength: number;
-    maxTitleLength = issue.duplicated
-      ? this.MAX_TITLE_LENGTH_FOR_DUPLICATE_ISSUE
-      : this.MAX_TITLE_LENGTH_FOR_NON_DUPLICATE_ISSUE;
+    maxTitleLength = issue.duplicated ? this.MAX_TITLE_LENGTH_FOR_DUPLICATE_ISSUE : this.MAX_TITLE_LENGTH_FOR_NON_DUPLICATE_ISSUE;
 
     return issue.title.length > maxTitleLength;
   }
@@ -76,22 +65,16 @@ export class DuplicateOfComponent implements OnInit {
   }
 
   dupIssueOptionIsDisabled(issue: Issue): boolean {
-    return SEVERITY_ORDER[this.issue.severity] > SEVERITY_ORDER[issue.severity]
-      || (issue.duplicated || !!issue.duplicateOf);
+    return SEVERITY_ORDER[this.issue.severity] > SEVERITY_ORDER[issue.severity] || issue.duplicated || !!issue.duplicateOf;
   }
 
   getDisabledDupOptionErrorText(issue: Issue): string {
     const reason = new Array<string>();
     if (this.dupIssueOptionIsDisabled(issue)) {
-      if (SEVERITY_ORDER[this.issue.severity]
-        > SEVERITY_ORDER[issue.severity]) {
-
+      if (SEVERITY_ORDER[this.issue.severity] > SEVERITY_ORDER[issue.severity]) {
         reason.push('Issue of lower priority');
-
       } else if (issue.duplicated || !!issue.duplicateOf) {
-
         reason.push('A duplicated issue');
-
       }
     }
     return reason.join(', ');
@@ -136,11 +119,12 @@ export class DuplicateOfComponent implements OnInit {
   }
 
   private getDupIssueList(): Observable<Issue[]> {
-    return this.issueService.issues$.pipe(map((issues) => {
-      return issues.filter((issue) => {
-        return this.issue.id !== issue.id
-          && this.issue.teamAssigned.id === issue.teamAssigned.id;
-      });
-    }));
+    return this.issueService.issues$.pipe(
+      map((issues) => {
+        return issues.filter((issue) => {
+          return this.issue.id !== issue.id && this.issue.teamAssigned.id === issue.teamAssigned.id;
+        });
+      })
+    );
   }
 }

--- a/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
+++ b/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
@@ -1,11 +1,15 @@
 <div>
   <span class="mat-title"> Duplicated Issues </span>
-    <mat-chip-list>
-      <mat-chip *ngFor="let duplicatedIssue of (duplicatedIssues | async)"
-                style="cursor: pointer" [matTooltip]="duplicatedIssue.title"
-                matTooltipPosition="above" (removed)="removeDuplicateStatus(duplicatedIssue)">
-        <a class="no-underline link-grey-dark" [routerLink]="['../' + duplicatedIssue.id]"> #{{duplicatedIssue.id}} </a>
-        <mat-icon *ngIf="permissions.isTeamResponseEditable() || permissions.isTutorResponseEditable()" matChipRemove>cancel</mat-icon>
-      </mat-chip>
-    </mat-chip-list>
+  <mat-chip-list>
+    <mat-chip
+      *ngFor="let duplicatedIssue of duplicatedIssues | async"
+      style="cursor: pointer"
+      [matTooltip]="duplicatedIssue.title"
+      matTooltipPosition="above"
+      (removed)="removeDuplicateStatus(duplicatedIssue)"
+    >
+      <a class="no-underline link-grey-dark" [routerLink]="['../' + duplicatedIssue.id]"> #{{ duplicatedIssue.id }} </a>
+      <mat-icon *ngIf="permissions.isTeamResponseEditable() || permissions.isTutorResponseEditable()" matChipRemove>cancel</mat-icon>
+    </mat-chip>
+  </mat-chip-list>
 </div>

--- a/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.ts
+++ b/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.ts
@@ -10,18 +10,19 @@ import { PhaseService } from '../../../core/services/phase.service';
   selector: 'app-duplicated-issues-component',
   templateUrl: './duplicated-issues.component.html',
   styleUrls: ['./duplicated-issues.component.css'],
-  encapsulation: ViewEncapsulation.None,
+  encapsulation: ViewEncapsulation.None
 })
 export class DuplicatedIssuesComponent implements OnInit {
   duplicatedIssues: Observable<Issue[]>;
 
   @Input() issue: Issue;
 
-  constructor(public issueService: IssueService,
-              public errorHandlingService: ErrorHandlingService,
-              public phaseService: PhaseService,
-              public permissions: PermissionService) {
-  }
+  constructor(
+    public issueService: IssueService,
+    public errorHandlingService: ErrorHandlingService,
+    public phaseService: PhaseService,
+    public permissions: PermissionService
+  ) {}
 
   ngOnInit() {
     this.duplicatedIssues = this.issueService.getDuplicateIssuesFor(this.issue);

--- a/src/app/shared/issue/issue-components.module.ts
+++ b/src/app/shared/issue/issue-components.module.ts
@@ -13,12 +13,7 @@ import { TitleComponent } from './title/title.component';
 import { UnsureCheckboxComponent } from './unsure-checkbox/unsure-checkbox.component';
 
 @NgModule({
-  imports: [
-    SharedModule,
-    CommentEditorModule,
-    MatProgressBarModule,
-    MarkdownModule.forChild(),
-  ],
+  imports: [SharedModule, CommentEditorModule, MatProgressBarModule, MarkdownModule.forChild()],
   declarations: [
     TitleComponent,
     DescriptionComponent,
@@ -27,7 +22,7 @@ import { UnsureCheckboxComponent } from './unsure-checkbox/unsure-checkbox.compo
     DuplicateOfComponent,
     DuplicatedIssuesComponent,
     UnsureCheckboxComponent,
-    ConflictDialogComponent,
+    ConflictDialogComponent
   ],
   exports: [
     TitleComponent,
@@ -37,10 +32,8 @@ import { UnsureCheckboxComponent } from './unsure-checkbox/unsure-checkbox.compo
     DuplicateOfComponent,
     DuplicatedIssuesComponent,
     UnsureCheckboxComponent,
-    ConflictDialogComponent,
+    ConflictDialogComponent
   ],
-  entryComponents: [
-    ConflictDialogComponent,
-  ]
+  entryComponents: [ConflictDialogComponent]
 })
-export class IssueComponentsModule { }
+export class IssueComponentsModule {}

--- a/src/app/shared/issue/label/label.component.css
+++ b/src/app/shared/issue/label/label.component.css
@@ -5,8 +5,8 @@
 .option {
   background-color: Transparent;
   border: none;
-  outline:none;
-  margin-right: 30px
+  outline: none;
+  margin-right: 30px;
 }
 
 .infoPopup {

--- a/src/app/shared/issue/label/label.component.html
+++ b/src/app/shared/issue/label/label.component.html
@@ -1,24 +1,24 @@
-<span class="mat-title"> {{this.labelService.getLabelTitle(attributeName)}} </span>
-<button *ngIf="permissions.isIssueLabelsEditable() && !issue.duplicateOf" style="float: right" [matMenuTriggerFor]="labelList" mat-icon-button>
+<span class="mat-title"> {{ this.labelService.getLabelTitle(attributeName) }} </span>
+<button
+  *ngIf="permissions.isIssueLabelsEditable() && !issue.duplicateOf"
+  style="float: right"
+  [matMenuTriggerFor]="labelList"
+  mat-icon-button
+>
   <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> edit </mat-icon>
 </button>
 
 <mat-menu #labelList>
-  <div mat-menu-item class="labelLine" *ngFor="let value of labelValues;" [ngStyle]="{'padding-left': '15px', 'padding-right': '15px'}">
-      <button class="labelInfo option"
-          (click)="updateLabel(value.labelValue)"
-          [disabled]="value.labelValue === this.issue[attributeName]">
-        <mat-icon [ngStyle]="{'color': '#' + value.labelColor, 'font-size' : '1.8em'}">stop</mat-icon>
-        <span> {{value.labelValue}}</span>
-      </button>
+  <div mat-menu-item class="labelLine" *ngFor="let value of labelValues" [ngStyle]="{ 'padding-left': '15px', 'padding-right': '15px' }">
+    <button class="labelInfo option" (click)="updateLabel(value.labelValue)" [disabled]="value.labelValue === this.issue[attributeName]">
+      <mat-icon [ngStyle]="{ color: '#' + value.labelColor, 'font-size': '1.8em' }">stop</mat-icon>
+      <span> {{ value.labelValue }}</span>
+    </button>
 
-      <button *ngIf="hasLabelDefinition(value)"
-              class="infoPopup"
-              (click)="openDefinitionPage(value); $event.stopPropagation();">
-        <mat-icon style="font-size: 20px">info</mat-icon>
-      </button>
-
+    <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openDefinitionPage(value); $event.stopPropagation()">
+      <mat-icon style="font-size: 20px">info</mat-icon>
+    </button>
   </div>
 </mat-menu>
 
-<p [ngStyle]="this.labelService.setLabelStyle(this.labelColor)">{{issue[attributeName] || '-'}}</p>
+<p [ngStyle]="this.labelService.setLabelStyle(this.labelColor)">{{ issue[attributeName] || '-' }}</p>

--- a/src/app/shared/issue/label/label.component.ts
+++ b/src/app/shared/issue/label/label.component.ts
@@ -12,7 +12,7 @@ import { PhaseService } from '../../../core/services/phase.service';
 @Component({
   selector: 'app-issue-label',
   templateUrl: './label.component.html',
-  styleUrls: ['./label.component.css'],
+  styleUrls: ['./label.component.css']
 })
 export class LabelComponent implements OnInit, OnChanges {
   labelValues: Label[];
@@ -24,13 +24,14 @@ export class LabelComponent implements OnInit, OnChanges {
 
   @Output() issueUpdated = new EventEmitter<Issue>();
 
-  constructor(private issueService: IssueService,
-              private errorHandlingService: ErrorHandlingService,
-              private phaseService: PhaseService,
-              public labelService: LabelService,
-              public permissions: PermissionService,
-              public dialogService: DialogService) {
-  }
+  constructor(
+    private issueService: IssueService,
+    private errorHandlingService: ErrorHandlingService,
+    private phaseService: PhaseService,
+    public labelService: LabelService,
+    public permissions: PermissionService,
+    public dialogService: DialogService
+  ) {}
 
   ngOnInit() {
     // Get the list of labels based on their type (severity, type, response)
@@ -45,20 +46,26 @@ export class LabelComponent implements OnInit, OnChanges {
   updateLabel(value: string) {
     const newIssue = this.issue.clone(this.phaseService.currentPhase);
     newIssue[this.attributeName] = value;
-    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
-      this.issueUpdated.emit(updatedIssue);
-      this.labelColor = this.labelService.getColorOfLabel(updatedIssue[this.attributeName]);
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService.updateIssue(newIssue).subscribe(
+      (updatedIssue: Issue) => {
+        this.issueUpdated.emit(updatedIssue);
+        this.labelColor = this.labelService.getColorOfLabel(updatedIssue[this.attributeName]);
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error);
+      }
+    );
     // Update labels of duplicate issues
-    this.issueService.getDuplicateIssuesFor(this.issue).pipe(first()).subscribe((issues: Issue[]) => {
-      issues.forEach((issue: Issue) => {
-        const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
-        newDuplicateIssue[this.attributeName] = value;
-        this.issueService.updateIssue(newDuplicateIssue);
+    this.issueService
+      .getDuplicateIssuesFor(this.issue)
+      .pipe(first())
+      .subscribe((issues: Issue[]) => {
+        issues.forEach((issue: Issue) => {
+          const newDuplicateIssue = issue.clone(this.phaseService.currentPhase);
+          newDuplicateIssue[this.attributeName] = value;
+          this.issueService.updateIssue(newDuplicateIssue);
+        });
       });
-    });
   }
 
   openDefinitionPage(value: Label): void {

--- a/src/app/shared/issue/title/title.component.css
+++ b/src/app/shared/issue/title/title.component.css
@@ -6,5 +6,5 @@
 .title-button {
   display: inline-block;
   float: right;
-  margin: 5px
+  margin: 5px;
 }

--- a/src/app/shared/issue/title/title.component.html
+++ b/src/app/shared/issue/title/title.component.html
@@ -1,28 +1,37 @@
 <div *ngIf="!isEditing">
-  <h1 class="mat-display-1 title">{{issue.title}} <span style="color:#a3aab1">#{{issue.id}}</span></h1>
-  <button *ngIf="permissions.isIssueCreatable()" mat-stroked-button color="primary" class="title-button"
-          [routerLink]="'/' + phaseService.currentPhase + '/issues/new'">New Issue</button>
-  <button *ngIf="permissions.isIssueTitleEditable()" mat-stroked-button color="primary" class="title-button" (click)="changeToEditMode()">Edit</button>
+  <h1 class="mat-display-1 title">
+    {{ issue.title }} <span style="color: #a3aab1">#{{ issue.id }}</span>
+  </h1>
+  <button
+    *ngIf="permissions.isIssueCreatable()"
+    mat-stroked-button
+    color="primary"
+    class="title-button"
+    [routerLink]="'/' + phaseService.currentPhase + '/issues/new'"
+  >
+    New Issue
+  </button>
+  <button *ngIf="permissions.isIssueTitleEditable()" mat-stroked-button color="primary" class="title-button" (click)="changeToEditMode()">
+    Edit
+  </button>
 </div>
-
 
 <div *ngIf="isEditing">
   <form [formGroup]="issueTitleForm" #myForm="ngForm" (ngSubmit)="updateTitle(myForm)">
     <mat-form-field style="width: 80%">
-      <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256">
-      <mat-error *ngIf="issueTitleForm.get('title').hasError('required')">
-        Title is required.
-      </mat-error>
-      <mat-error *ngIf="issueTitleForm.get('title').hasError('maxlength')">
-        Title cannot exceed 256 characters.
-      </mat-error>
+      <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" />
+      <mat-error *ngIf="issueTitleForm.get('title').hasError('required')"> Title is required. </mat-error>
+      <mat-error *ngIf="issueTitleForm.get('title').hasError('maxlength')"> Title cannot exceed 256 characters. </mat-error>
       <mat-hint *ngIf="issueTitleForm.get('title').value?.length >= 206">
-        {{256 - issueTitleForm.get('title').value?.length}} characters remaining.
+        {{ 256 - issueTitleForm.get('title').value?.length }} characters remaining.
       </mat-hint>
     </mat-form-field>
 
-    <button type="submit" [disabled]="issueTitleForm.invalid || isSavePending" mat-stroked-button color="primary"
-            class="title-button">Save</button>
-    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="openCancelDialog()">Cancel</button>
+    <button type="submit" [disabled]="issueTitleForm.invalid || isSavePending" mat-stroked-button color="primary" class="title-button">
+      Save
+    </button>
+    <button type="button" [disabled]="isSavePending" mat-stroked-button color="warn" class="title-button" (click)="openCancelDialog()">
+      Cancel
+    </button>
   </form>
 </div>

--- a/src/app/shared/issue/title/title.component.ts
+++ b/src/app/shared/issue/title/title.component.ts
@@ -11,7 +11,7 @@ import { PhaseService } from '../../../core/services/phase.service';
 @Component({
   selector: 'app-issue-title',
   templateUrl: './title.component.html',
-  styleUrls: ['./title.component.css'],
+  styleUrls: ['./title.component.css']
 })
 export class TitleComponent implements OnInit {
   isEditing = false;
@@ -26,17 +26,18 @@ export class TitleComponent implements OnInit {
   private readonly yesButtonModalMessage = 'Cancel';
   private readonly noButtonModalMessage = 'Continue editing';
 
-  constructor(private issueService: IssueService,
-              private formBuilder: FormBuilder,
-              private errorHandlingService: ErrorHandlingService,
-              public permissions: PermissionService,
-              public phaseService: PhaseService,
-              private dialogService: DialogService) {
-  }
+  constructor(
+    private issueService: IssueService,
+    private formBuilder: FormBuilder,
+    private errorHandlingService: ErrorHandlingService,
+    public permissions: PermissionService,
+    public phaseService: PhaseService,
+    private dialogService: DialogService
+  ) {}
 
   ngOnInit() {
     this.issueTitleForm = this.formBuilder.group({
-      title: new FormControl('', [Validators.required, Validators.maxLength(256)]),
+      title: new FormControl('', [Validators.required, Validators.maxLength(256)])
     });
   }
 
@@ -59,23 +60,33 @@ export class TitleComponent implements OnInit {
     this.isSavePending = true;
     const newIssue = this.issue.clone(this.phaseService.currentPhase);
     newIssue.title = this.issueTitleForm.get('title').value;
-    this.issueService.updateIssue(newIssue).pipe(finalize(() => {
-      this.isEditing = false;
-      this.isSavePending = false;
-    })).subscribe((editedIssue: Issue) => {
-      this.issueUpdated.emit(editedIssue);
-      form.resetForm();
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService
+      .updateIssue(newIssue)
+      .pipe(
+        finalize(() => {
+          this.isEditing = false;
+          this.isSavePending = false;
+        })
+      )
+      .subscribe(
+        (editedIssue: Issue) => {
+          this.issueUpdated.emit(editedIssue);
+          form.resetForm();
+        },
+        (error) => {
+          this.errorHandlingService.handleError(error);
+        }
+      );
   }
 
   openCancelDialog(): void {
     const dialogRef = this.dialogService.openUserConfirmationModal(
-      this.cancelEditModalMessages, this.yesButtonModalMessage, this.noButtonModalMessage
+      this.cancelEditModalMessages,
+      this.yesButtonModalMessage,
+      this.noButtonModalMessage
     );
 
-    dialogRef.afterClosed().subscribe(res => {
+    dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.cancelEditMode();
       }

--- a/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.css
+++ b/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.css
@@ -1,4 +1,3 @@
 .mat-checkbox-disabled .mat-checkbox-label {
-    color: black;
-  }
-  
+  color: black;
+}

--- a/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.html
+++ b/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.html
@@ -1,3 +1,3 @@
 <mat-checkbox labelPosition="before" [checked]="issue.unsure" (change)="handleChangeOfUnsureCheckbox($event)">
-    <span class="mat-title"> Unsure </span>
+  <span class="mat-title"> Unsure </span>
 </mat-checkbox>

--- a/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.ts
+++ b/src/app/shared/issue/unsure-checkbox/unsure-checkbox.component.ts
@@ -10,17 +10,13 @@ import { PhaseService } from '../../../core/services/phase.service';
   styleUrls: ['./unsure-checkbox.component.css']
 })
 export class UnsureCheckboxComponent implements OnInit {
-
   @Input() issue: Issue;
 
   @Output() issueUpdated = new EventEmitter<Issue>();
 
-  constructor(private issueService: IssueService,
-              private errorHandlingService: ErrorHandlingService,
-              private phaseService: PhaseService) { }
+  constructor(private issueService: IssueService, private errorHandlingService: ErrorHandlingService, private phaseService: PhaseService) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   handleChangeOfUnsureCheckbox(event) {
     let UNSURE = false;
@@ -31,11 +27,13 @@ export class UnsureCheckboxComponent implements OnInit {
 
     const newIssue = this.issue.clone(this.phaseService.currentPhase);
     newIssue.unsure = UNSURE;
-    this.issueService.updateIssue(newIssue).subscribe((updatedIssue: Issue) => {
-      this.issueUpdated.emit(updatedIssue);
-    }, (error) => {
-      this.errorHandlingService.handleError(error);
-    });
+    this.issueService.updateIssue(newIssue).subscribe(
+      (updatedIssue: Issue) => {
+        this.issueUpdated.emit(updatedIssue);
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error);
+      }
+    );
   }
-
 }

--- a/src/app/shared/label-definition-popup/label-definition-popup.component.css
+++ b/src/app/shared/label-definition-popup/label-definition-popup.component.css
@@ -1,3 +1,3 @@
 .modalPopup {
-    min-width: 800px;
+  min-width: 800px;
 }

--- a/src/app/shared/label-definition-popup/label-definition-popup.component.html
+++ b/src/app/shared/label-definition-popup/label-definition-popup.component.html
@@ -1,5 +1,5 @@
 <div class="modalPopup">
-  <h1 mat-dialog-title> {{labelName}} </h1>
+  <h1 mat-dialog-title>{{ labelName }}</h1>
   <div mat-dialog-content>
     <div [innerHTML]="labelDefinitionHtmlTemplate"></div>
   </div>

--- a/src/app/shared/label-definition-popup/label-definition-popup.component.ts
+++ b/src/app/shared/label-definition-popup/label-definition-popup.component.ts
@@ -10,7 +10,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 @Component({
   selector: 'app-label-definition-popup',
   templateUrl: './label-definition-popup.component.html',
-  styleUrls: ['./label-definition-popup.component.css'],
+  styleUrls: ['./label-definition-popup.component.css']
 })
 export class LabelDefinitionPopupComponent {
   labelName: string;
@@ -33,5 +33,4 @@ export class LabelDefinitionPopupComponent {
   onNoClick(): void {
     this.dialogRef.close(false);
   }
-
 }

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -1,24 +1,29 @@
 <form [formGroup]="dropdownForm">
-  <mat-form-field style="width: 100%;">
-    <mat-select [ngClass]="dropdownTextColor" formControlName="{{attributeName}}" placeholder="{{this.labelService.getLabelTitle(attributeName)}}"
-      (selectionChange)="setSelectedLabelColor($event.value)" [ngStyle]="this.labelService.setLabelStyle(this.selectedColor, 'inline-block')" required>
+  <mat-form-field style="width: 100%">
+    <mat-select
+      [ngClass]="dropdownTextColor"
+      formControlName="{{ attributeName }}"
+      placeholder="{{ this.labelService.getLabelTitle(attributeName) }}"
+      (selectionChange)="setSelectedLabelColor($event.value)"
+      [ngStyle]="this.labelService.setLabelStyle(this.selectedColor, 'inline-block')"
+      required
+    >
       <mat-select-trigger>
-        {{dropdownControl.value}}
+        {{ dropdownControl.value }}
       </mat-select-trigger>
       <div mat-menu-item class="labelLine" *ngFor="let value of labelList">
-        <mat-option [value]="value.labelValue" [ngStyle]="{'background': 'transparent'}">
-          <mat-icon [ngStyle]="{'color': '#' + value.labelColor}">stop</mat-icon>
-          <span> {{value.labelValue}}</span>
+        <mat-option [value]="value.labelValue" [ngStyle]="{ background: 'transparent' }">
+          <mat-icon [ngStyle]="{ color: '#' + value.labelColor }">stop</mat-icon>
+          <span> {{ value.labelValue }}</span>
         </mat-option>
 
         <button *ngIf="hasLabelDefinition(value)" class="infoPopup" (click)="openModalPopup(value)">
           <mat-icon style="font-size: 20px">info</mat-icon>
         </button>
-        
       </div>
     </mat-select>
     <mat-error *ngIf="dropdownControl.errors && dropdownControl.errors['required'] && dropdownControl.touched">
-      {{this.labelService.getLabelTitle(attributeName)}} required.
+      {{ this.labelService.getLabelTitle(attributeName) }} required.
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/shared/label-dropdown/label-dropdown.component.ts
+++ b/src/app/shared/label-dropdown/label-dropdown.component.ts
@@ -21,8 +21,7 @@ export class LabelDropdownComponent implements OnInit {
   selectedColor: string;
   labelList: Label[];
 
-  constructor(public labelService: LabelService,
-              public dialogService: DialogService) { }
+  constructor(public labelService: LabelService, public dialogService: DialogService) {}
 
   ngOnInit() {
     this.selectedColor = this.labelService.getColorOfLabel(this.initialValue);
@@ -35,8 +34,10 @@ export class LabelDropdownComponent implements OnInit {
   }
 
   openModalPopup(label: Label): void {
-    this.dialogService.openLabelDefinitionDialog(label.getFormattedName(),
-    this.labelService.getLabelDefinition(label.labelValue, label.labelCategory));
+    this.dialogService.openLabelDefinitionDialog(
+      label.getFormattedName(),
+      this.labelService.getLabelDefinition(label.labelValue, label.labelCategory)
+    );
   }
 
   hasLabelDefinition(label: Label): boolean {

--- a/src/app/shared/label-dropdown/label-dropdown.module.ts
+++ b/src/app/shared/label-dropdown/label-dropdown.module.ts
@@ -4,15 +4,8 @@ import { SharedModule } from '../shared.module';
 import { LabelDropdownComponent } from './label-dropdown.component';
 
 @NgModule({
-  declarations: [
-    LabelDropdownComponent
-  ],
-  imports: [
-    CommonModule,
-    SharedModule
-  ],
-  exports: [
-    LabelDropdownComponent
-  ]
+  declarations: [LabelDropdownComponent],
+  imports: [CommonModule, SharedModule],
+  exports: [LabelDropdownComponent]
 })
-export class LabelDropdownModule { }
+export class LabelDropdownModule {}

--- a/src/app/shared/layout/header.component.html
+++ b/src/app/shared/layout/header.component.html
@@ -1,22 +1,33 @@
-<mat-toolbar color="primary" style="position: sticky; position: -webkit-sticky; top: 0; z-index: 1000;">
-  <button *ngIf="isBackButtonShown()" mat-icon-button class="mat-toolbar mat-primary back-button" style="transform: scale(0.9)" (click)="goBack()">
+<mat-toolbar color="primary" style="position: sticky; position: -webkit-sticky; top: 0; z-index: 1000">
+  <button
+    *ngIf="isBackButtonShown()"
+    mat-icon-button
+    class="mat-toolbar mat-primary back-button"
+    style="transform: scale(0.9)"
+    (click)="goBack()"
+  >
     <mat-icon>arrow_back_ios</mat-icon>
   </button>
-  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase">CATcher 
-    v{{this.getVersion()}}</a>
+  <a class="mat-toolbar mat-primary" style="text-decoration: none" [routerLink]="phaseService.currentPhase"
+    >CATcher v{{ this.getVersion() }}</a
+  >
   <span id="phase-descriptor" *ngIf="auth.isAuthenticated()" style="margin-left: 10px">
-    ({{this.getPhaseDescription(phaseService.currentPhase)}})
+    ({{ this.getPhaseDescription(phaseService.currentPhase) }})
   </span>
 
   <div *ngIf="auth.isAuthenticated() && this.phaseService.sessionData.openPhases.length > 1">
-    <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white;">expand_more</mat-icon></button>
+    <button mat-button [matMenuTriggerFor]="menu"><mat-icon style="color: white">expand_more</mat-icon></button>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item *ngFor="let openPhase of this.phaseService.sessionData.openPhases"
-       (click)="this.routeToSelectedPhase(openPhase)">
+      <button
+        mat-menu-item
+        *ngFor="let openPhase of this.phaseService.sessionData.openPhases"
+        (click)="this.routeToSelectedPhase(openPhase)"
+      >
         <span>
-          <mat-icon [ngStyle]="{color: 'green',
-            visibility: this.phaseService.currentPhase === openPhase ? 'visible' : 'hidden'}">done</mat-icon>
-          {{this.getPhaseDescription(openPhase)}}
+          <mat-icon [ngStyle]="{ color: 'green', visibility: this.phaseService.currentPhase === openPhase ? 'visible' : 'hidden' }"
+            >done</mat-icon
+          >
+          {{ this.getPhaseDescription(openPhase) }}
         </span>
       </button>
     </mat-menu>
@@ -26,23 +37,31 @@
   <button mat-button matTooltip="Download CATcher Log" (click)="this.exportLogFile()">
     <mat-icon>receipt</mat-icon>
   </button>
-  <button *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()" mat-button matTooltip="View current page on GitHub" (click)="viewBrowser()">
+  <button
+    *ngIf="auth.isAuthenticated() && isOpenUrlButtonShown()"
+    mat-button
+    matTooltip="View current page on GitHub"
+    (click)="viewBrowser()"
+  >
     View on GitHub
     <mat-icon>open_in_new</mat-icon>
   </button>
-  <button *ngIf="auth.isAuthenticated() && isReloadButtonShown() && !this.isReloadButtonDisabled"
-    mat-button matTooltip="Synchronize with Github data" (click)="reload()">
+  <button
+    *ngIf="auth.isAuthenticated() && isReloadButtonShown() && !this.isReloadButtonDisabled"
+    mat-button
+    matTooltip="Synchronize with Github data"
+    (click)="reload()"
+  >
     Sync
     <mat-icon>refresh</mat-icon>
   </button>
   <div class="sync-spinner" *ngIf="auth.isAuthenticated() && isReloadButtonShown() && this.isReloadButtonDisabled">
-    <span style="font-size: 14px; margin-right: 7px;">Sync</span>
+    <span style="font-size: 14px; margin-right: 7px">Sync</span>
     <mat-spinner class="white-spinner" [diameter]="20"></mat-spinner>
   </div>
 
-  <button *ngIf="auth.isAuthenticated()" mat-button matTooltip="Log out" 
-    (click)="openLogOutDialog(); $event.stopPropagation()">
-      ({{userService.currentUser.loginId}})
+  <button *ngIf="auth.isAuthenticated()" mat-button matTooltip="Log out" (click)="openLogOutDialog(); $event.stopPropagation()">
+    ({{ userService.currentUser.loginId }})
     <mat-icon style="margin-left: 2px">exit_to_app</mat-icon>
   </button>
 </mat-toolbar>

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -29,28 +29,32 @@ export class HeaderComponent implements OnInit {
   EXCLUDE_DUPLICATE = '+-label:duplicate'; // exclude duplicate issues
 
   // Messages for the modal popup window upon logging out
-  private readonly logOutDialogMessages = ["Do you wish to log out?"];
-  private readonly yesButtonDialogMessage = "Yes, I wish to log out";
-  private readonly noButtonDialogMessage = "No, I don\'t wish to log out";
+  private readonly logOutDialogMessages = ['Do you wish to log out?'];
+  private readonly yesButtonDialogMessage = 'Yes, I wish to log out';
+  private readonly noButtonDialogMessage = "No, I don't wish to log out";
 
-  constructor(private router: Router,
-              public auth: AuthService,
-              public phaseService: PhaseService,
-              public userService: UserService,
-              public loggingService: LoggingService,
-              private location: Location,
-              private githubEventService: GithubEventService,
-              private issueService: IssueService,
-              private errorHandlingService: ErrorHandlingService,
-              private githubService: GithubService,
-              private electronService: ElectronService,
-              private dialogService: DialogService) {
-    router.events.pipe(
-      filter((e: any) => e instanceof RoutesRecognized),
-      pairwise()
-    ).subscribe(e => {
-      this.prevUrl = e[0].urlAfterRedirects;
-    });
+  constructor(
+    private router: Router,
+    public auth: AuthService,
+    public phaseService: PhaseService,
+    public userService: UserService,
+    public loggingService: LoggingService,
+    private location: Location,
+    private githubEventService: GithubEventService,
+    private issueService: IssueService,
+    private errorHandlingService: ErrorHandlingService,
+    private githubService: GithubService,
+    private electronService: ElectronService,
+    private dialogService: DialogService
+  ) {
+    router.events
+      .pipe(
+        filter((e: any) => e instanceof RoutesRecognized),
+        pairwise()
+      )
+      .subscribe((e) => {
+        this.prevUrl = e[0].urlAfterRedirects;
+      });
   }
 
   ngOnInit() {}
@@ -67,8 +71,10 @@ export class HeaderComponent implements OnInit {
     }
     // Replace Current Phase Data.
     this.phaseService.currentPhase = Phase[openPhase];
-    this.githubService.storePhaseDetails(this.phaseService.getPhaseOwner(this.phaseService.currentPhase),
-        this.phaseService.sessionData[openPhase]);
+    this.githubService.storePhaseDetails(
+      this.phaseService.getPhaseOwner(this.phaseService.currentPhase),
+      this.phaseService.sessionData[openPhase]
+    );
 
     // Remove current phase issues and load selected phase issues.
     this.githubService.reset();
@@ -88,9 +94,12 @@ export class HeaderComponent implements OnInit {
   }
 
   isOpenUrlButtonShown(): boolean {
-    return this.phaseService.currentPhase === Phase.phaseBugReporting ||
-    this.userService.currentUser.role === UserRole.Student ||
-    (this.issueService.getIssueTeamFilter() !== 'All Teams' || this.router.url.includes('/issues'));
+    return (
+      this.phaseService.currentPhase === Phase.phaseBugReporting ||
+      this.userService.currentUser.role === UserRole.Student ||
+      this.issueService.getIssueTeamFilter() !== 'All Teams' ||
+      this.router.url.includes('/issues')
+    );
   }
 
   getVersion(): string {
@@ -141,7 +150,7 @@ export class HeaderComponent implements OnInit {
     // The team filter string E.g "+label:tutorial.W12+label:team.3"
     const teamFilterString = this.TUTORIAL_LABEL.concat(`${teamFilter[0]}-${teamFilter[1]}`).concat(this.TEAM_LABEL).concat(teamFilter[2]);
     // Only include duplicate Issues in last Phase
-    return (this.phaseService.currentPhase === Phase.phaseModeration) ? teamFilterString : this.EXCLUDE_DUPLICATE.concat(teamFilterString);
+    return this.phaseService.currentPhase === Phase.phaseModeration ? teamFilterString : this.EXCLUDE_DUPLICATE.concat(teamFilterString);
   }
 
   reload() {
@@ -151,13 +160,13 @@ export class HeaderComponent implements OnInit {
       (success) => success,
       (error) => {
         this.errorHandlingService.handleError(error, () => this.githubEventService.reloadPage());
-      });
+      }
+    );
 
     // Prevent user from spamming the reload button
     setTimeout(() => {
       this.isReloadButtonDisabled = false;
-    },
-    3000);
+    }, 3000);
   }
 
   logOut() {
@@ -166,10 +175,12 @@ export class HeaderComponent implements OnInit {
 
   openLogOutDialog() {
     const dialogRef = this.dialogService.openUserConfirmationModal(
-      this.logOutDialogMessages, this.yesButtonDialogMessage, this.noButtonDialogMessage
+      this.logOutDialogMessages,
+      this.yesButtonDialogMessage,
+      this.noButtonDialogMessage
     );
 
-    dialogRef.afterClosed().subscribe(res => {
+    dialogRef.afterClosed().subscribe((res) => {
       if (res) {
         this.loggingService.info(`Logging out from ${this.userService.currentUser.loginId}`);
         this.logOut();

--- a/src/app/shared/lib/custom-ops.ts
+++ b/src/app/shared/lib/custom-ops.ts
@@ -2,8 +2,8 @@ import { pipe } from 'rxjs';
 import { filter, throwIfEmpty } from 'rxjs/operators';
 
 export function throwIfFalse(predicate, error_func) {
-    return pipe(
-        filter(v => predicate(v)),
-        throwIfEmpty(error_func)
-    );
+  return pipe(
+    filter((v) => predicate(v)),
+    throwIfEmpty(error_func)
+  );
 }

--- a/src/app/shared/lib/file-download.ts
+++ b/src/app/shared/lib/file-download.ts
@@ -1,19 +1,19 @@
 export function downloadAsTextFile(fileName: string, content: string) {
-    const blob: Blob = new Blob([content], {type: 'file/txt'});
-    const blobUrl: string = window.URL.createObjectURL(blob);
-    const hiddenElement: HTMLAnchorElement = createElement(blobUrl, fileName);
-    triggerDownload(hiddenElement);
-    // Remove its URL
-    window.URL.revokeObjectURL(blobUrl);
-    removeElement(hiddenElement);
+  const blob: Blob = new Blob([content], { type: 'file/txt' });
+  const blobUrl: string = window.URL.createObjectURL(blob);
+  const hiddenElement: HTMLAnchorElement = createElement(blobUrl, fileName);
+  triggerDownload(hiddenElement);
+  // Remove its URL
+  window.URL.revokeObjectURL(blobUrl);
+  removeElement(hiddenElement);
 }
 
 function createElement(blobUrl: string, fileName: string): HTMLAnchorElement {
-    const hiddenElement: HTMLAnchorElement = document.createElement('a');
-    hiddenElement.setAttribute('style', 'display: none;');
-    hiddenElement.href = blobUrl;
-    hiddenElement.download = fileName;
-    return hiddenElement;
+  const hiddenElement: HTMLAnchorElement = document.createElement('a');
+  hiddenElement.setAttribute('style', 'display: none;');
+  hiddenElement.href = blobUrl;
+  hiddenElement.download = fileName;
+  return hiddenElement;
 }
 
 /**
@@ -21,8 +21,8 @@ function createElement(blobUrl: string, fileName: string): HTMLAnchorElement {
  * @param element: anchor element that points to the file to be downloaded
  */
 function triggerDownload(element: HTMLAnchorElement) {
-    document.body.appendChild(element);
-    element.click();
+  document.body.appendChild(element);
+  element.click();
 }
 
 /**
@@ -30,6 +30,6 @@ function triggerDownload(element: HTMLAnchorElement) {
  * @param element : the attached element to be removed
  */
 function removeElement(element: HTMLAnchorElement) {
-    document.body.removeChild(element);
-    element.remove();
+  document.body.removeChild(element);
+  element.remove();
 }

--- a/src/app/shared/lib/github-paginator-parser.ts
+++ b/src/app/shared/lib/github-paginator-parser.ts
@@ -23,17 +23,20 @@ export function getNumberOfPages<T>(response: GithubResponse<T>): number {
  *
  */
 function githubPaginatorParser(linkStr: string) {
-  return linkStr.split(',').map((paginateItem) => {
-    return paginateItem.split(';').map((curr, idx) => {
-      if (idx === 0) {
-        return /[^_]page=(\d+)/.exec(curr)[1];
-      }
-      if (idx === 1) {
-        return /rel="(.+)"/.exec(curr)[1];
-      }
-    });
-  }).reduce((obj, curr) => {
-    obj[curr[1]] = curr[0];
-    return obj;
-  }, {});
+  return linkStr
+    .split(',')
+    .map((paginateItem) => {
+      return paginateItem.split(';').map((curr, idx) => {
+        if (idx === 0) {
+          return /[^_]page=(\d+)/.exec(curr)[1];
+        }
+        if (idx === 1) {
+          return /rel="(.+)"/.exec(curr)[1];
+        }
+      });
+    })
+    .reduce((obj, curr) => {
+      obj[curr[1]] = curr[0];
+      return obj;
+    }, {});
 }

--- a/src/app/shared/lib/graphgql-common.ts
+++ b/src/app/shared/lib/graphgql-common.ts
@@ -1,5 +1,5 @@
 export function flattenEdges(edges: Array<any>, transformFunc?: (node) => {}): Array<any> {
-  return edges.map(edge => {
+  return edges.map((edge) => {
     if (transformFunc) {
       return transformFunc(edge.node);
     } else {

--- a/src/app/shared/lib/html.ts
+++ b/src/app/shared/lib/html.ts
@@ -1,10 +1,5 @@
 export function escapeHTML(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
+  return unsafe.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
 }
 
 export function replaceNewlinesWithBreakLines(text: string): string {

--- a/src/app/shared/lib/marked.ts
+++ b/src/app/shared/lib/marked.ts
@@ -1,4 +1,4 @@
-import { MarkedOptions, MarkedRenderer } from "ngx-markdown";
+import { MarkedOptions, MarkedRenderer } from 'ngx-markdown';
 
 export function markedOptionsFactory(): MarkedOptions {
   const renderer = new MarkedRenderer();
@@ -17,6 +17,6 @@ export function markedOptionsFactory(): MarkedOptions {
     pedantic: false,
     sanitize: false,
     smartLists: true,
-    smartypants: false,
+    smartypants: false
   };
 }

--- a/src/app/shared/lib/string-utils.ts
+++ b/src/app/shared/lib/string-utils.ts
@@ -10,15 +10,15 @@ export function extractStringBetween(text: string, prefix: string, suffix: strin
   let result = text.trim();
   const startIdx = result.indexOf(prefix) + prefix.length;
 
-  if (startIdx === -1)  {
-    return "";
+  if (startIdx === -1) {
+    return '';
   }
 
   result = result.substring(startIdx);
   const endIdx = result.indexOf(suffix);
 
-  if (endIdx === -1)  {
-    return "";
+  if (endIdx === -1) {
+    return '';
   }
 
   result = result.substring(0, endIdx);

--- a/src/app/shared/lib/validate.ts
+++ b/src/app/shared/lib/validate.ts
@@ -8,8 +8,9 @@ export interface Schema {
 }
 
 export const isValidObject = (object: object, schema: Schema): boolean =>
-  Object.entries(schema)
-    .every(([key, rule]) =>
-      !rule.required || (key in object && // if key is present
-      rule.validate(object[key])) // if value abides by schema
-    );
+  Object.entries(schema).every(
+    ([key, rule]) =>
+      !rule.required ||
+      (key in object && // if key is present
+        rule.validate(object[key])) // if value abides by schema
+  );

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -39,7 +39,7 @@ import {
   MatTabsModule,
   MatToolbarModule,
   MatTooltipModule,
-  MatTreeModule,
+  MatTreeModule
 } from '@angular/material';
 
 @NgModule({
@@ -82,11 +82,10 @@ import {
     MatToolbarModule,
     MatTooltipModule,
     MatTreeModule,
-    ScrollingModule,
+    ScrollingModule
   ]
 })
 export class MaterialModule {}
-
 
 /**  Copyright 2018 Google Inc. All Rights Reserved.
  Use of this source code is governed by an MIT-style license that

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,15 +8,7 @@ import { ErrorToasterModule } from './error-toasters/error-toaster.module';
 import { MaterialModule } from './material.module';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    FormsModule,
-    ReactiveFormsModule,
-    HttpClientModule,
-    RouterModule,
-    MaterialModule,
-    ErrorToasterModule,
-  ],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, HttpClientModule, RouterModule, MaterialModule, ErrorToasterModule],
   declarations: [FormDisableControlDirective],
   exports: [
     FormDisableControlDirective,
@@ -26,7 +18,7 @@ import { MaterialModule } from './material.module';
     HttpClientModule,
     RouterModule,
     MaterialModule,
-    ErrorToasterModule,
+    ErrorToasterModule
   ]
 })
 export class SharedModule {}

--- a/src/app/shared/view-issue/issue-dispute/issue-dispute.component.css
+++ b/src/app/shared/view-issue/issue-dispute/issue-dispute.component.css
@@ -1,4 +1,4 @@
 .container {
-    padding: 10px 20px 0 20px;
-    display: grid;
+  padding: 10px 20px 0 20px;
+  display: grid;
 }

--- a/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
+++ b/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
@@ -3,26 +3,28 @@
   <div class="timeline-comment">
     <div class="timeline-header">
       <span style="vertical-align: middle; margin-left: 5px"> Post your response here. </span>
-      <button mat-button style="float: right;" *ngIf="!isEditing" (click)="changeToEditMode()">
-          Edit
-      </button>
+      <button mat-button style="float: right" *ngIf="!isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div>
       <div class="container" *ngFor="let dispute of issue.issueDisputes; index as i; trackBy: trackDisputeList">
         <div style="display: flex; align-items: center">
-          <div class="question-mark"> ? </div>
+          <div class="question-mark">?</div>
           <markdown [data]="this.getItemTitleText(dispute.title)"></markdown>
         </div>
-        <br>
+        <br />
         <markdown [data]="dispute.description"></markdown>
-        <br>
+        <br />
         <div>
-          <mat-checkbox style="display: inline-block; width: 20%" [id]="getTodoFormId(i)" [formControlName]="getTodoFormId(i)"
-          [disableControl]="!isEditing">
+          <mat-checkbox
+            style="display: inline-block; width: 20%"
+            [id]="getTodoFormId(i)"
+            [formControlName]="getTodoFormId(i)"
+            [disableControl]="!isEditing"
+          >
             Done
           </mat-checkbox>
         </div>
-        <br>
+        <br />
         <div>
           <markdown data="### Tutor's Response: "></markdown>
           <markdown [data]="dispute.tutorResponse" *ngIf="!isEditing"></markdown>
@@ -33,27 +35,56 @@
             [commentForm]="tutorResponseForm"
             [id]="getTutorResponseFormId(i)"
             [(isFormPending)]="isFormPending"
-            [(submitButtonText)]="submitButtonText">
+            [(submitButtonText)]="submitButtonText"
+          >
           </app-comment-editor>
         </div>
-        <br> <markdown data="-------------------"></markdown> <br>
+        <br />
+        <markdown data="-------------------"></markdown> <br />
       </div>
       <mat-divider></mat-divider>
       <div class="editor-actions" *ngIf="isEditing">
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isFormPending"
-                mat-raised-button color="primary" (click)="viewInGithub()">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isFormPending"
+          mat-raised-button
+          color="primary"
+          (click)="viewInGithub()"
+        >
           View Updated Response On Github
         </button>
-        <button class="editor-action" type="submit" *ngIf="!conflict" [disabled]="tutorResponseForm.invalid || isFormPending"
-          mat-stroked-button color="primary">
+        <button
+          class="editor-action"
+          type="submit"
+          *ngIf="!conflict"
+          [disabled]="tutorResponseForm.invalid || isFormPending"
+          mat-stroked-button
+          color="primary"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="submit" [disabled]="tutorResponseForm.invalid || isFormPending"
-                mat-raised-button color="warn" *ngIf="conflict">
+        <button
+          class="editor-action"
+          type="submit"
+          [disabled]="tutorResponseForm.invalid || isFormPending"
+          mat-raised-button
+          color="warn"
+          *ngIf="conflict"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="button" [disabled]="isFormPending" style="margin-left: 10px;" *ngIf="!this.isNewResponse()"
-          mat-stroked-button color="warn" (click)="cancelEditMode()">
+        <button
+          class="editor-action"
+          type="button"
+          [disabled]="isFormPending"
+          style="margin-left: 10px"
+          *ngIf="!this.isNewResponse()"
+          mat-stroked-button
+          color="warn"
+          (click)="cancelEditMode()"
+        >
           Cancel
         </button>
       </div>

--- a/src/app/shared/view-issue/issue-dispute/issue-dispute.module.ts
+++ b/src/app/shared/view-issue/issue-dispute/issue-dispute.module.ts
@@ -8,19 +8,8 @@ import { SharedModule } from '../../shared.module';
 import { IssueDisputeComponent } from './issue-dispute.component';
 
 @NgModule({
-  exports: [
-    IssueDisputeComponent
-  ],
-  declarations: [
-    IssueDisputeComponent,
-  ],
-  imports: [
-    CommonModule,
-    CommentEditorModule,
-    SharedModule,
-    IssueComponentsModule,
-    LabelDropdownModule,
-    MarkdownModule.forChild(),
-  ]
+  exports: [IssueDisputeComponent],
+  declarations: [IssueDisputeComponent],
+  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()]
 })
-export class IssueDisputeModule { }
+export class IssueDisputeModule {}

--- a/src/app/shared/view-issue/new-team-response/conflict-dialog/conflict-dialog.component.html
+++ b/src/app/shared/view-issue/new-team-response/conflict-dialog/conflict-dialog.component.html
@@ -1,11 +1,11 @@
 <div style="display: flex; margin-bottom: 20px; align-items: center">
-  <h1 mat-dialog-title style="margin: 0">{{ 'A new response was submitted by another user'}}</h1>
+  <h1 mat-dialog-title style="margin: 0">{{ 'A new response was submitted by another user' }}</h1>
   <button mat-icon-button color="default" style="margin: 0 0 0 auto" (click)="close()">
     <mat-icon>close</mat-icon>
   </button>
 </div>
 
-<div mat-dialog-content style="display: flex;">
+<div mat-dialog-content style="display: flex">
   <div class="column left">
     <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="handleTabChange($event)">
       <mat-tab label="Updated Markdown Text">
@@ -15,19 +15,18 @@
       </mat-tab>
       <mat-tab label="Preview">
         <div class="tab-content">
-          <markdown>{{data.teamResponse}}</markdown>
+          <markdown>{{ data.teamResponse }}</markdown>
         </div>
       </mat-tab>
     </mat-tab-group>
   </div>
 
   <div class="column right">
-
     <div *ngIf="data.type">
       <mat-divider></mat-divider>
       <span class="mat-title"> Type </span>
       <p [ngStyle]="labelService.setLabelStyle(labelService.getColorOfLabel(data.type))">
-        {{data.type || '-'}}
+        {{ data.type || '-' }}
       </p>
     </div>
 
@@ -35,7 +34,7 @@
       <mat-divider></mat-divider>
       <span class="mat-title"> Severity </span>
       <p [ngStyle]="labelService.setLabelStyle(labelService.getColorOfLabel(data.severity))">
-        {{data.severity || '-'}}
+        {{ data.severity || '-' }}
       </p>
     </div>
 
@@ -43,15 +42,13 @@
       <mat-divider></mat-divider>
       <span class="mat-title"> Response </span>
       <p [ngStyle]="labelService.setLabelStyle(labelService.getColorOfLabel(data.responseTag))">
-        {{data.responseTag || '-'}}
+        {{ data.responseTag || '-' }}
       </p>
     </div>
 
     <div *ngIf="data.assignees">
       <mat-divider></mat-divider>
-      <app-assignee-component  [issue]="data" [team]="data.teamAssigned"
-                               [isEditable]="false">
-      </app-assignee-component>
+      <app-assignee-component [issue]="data" [team]="data.teamAssigned" [isEditable]="false"> </app-assignee-component>
     </div>
 
     <div *ngIf="data.duplicateOf">
@@ -59,10 +56,9 @@
       <div>
         <span class="mat-title">A Duplicate Of:</span>
         <p style="margin-top: 5px">
-          {{ ('#' + data.duplicateOf + ': ' + (issueService.getIssue(data.duplicateOf) | async).title) }}
+          {{ '#' + data.duplicateOf + ': ' + (issueService.getIssue(data.duplicateOf) | async).title }}
         </p>
       </div>
     </div>
-
   </div>
 </div>

--- a/src/app/shared/view-issue/new-team-response/conflict-dialog/conflict-dialog.component.ts
+++ b/src/app/shared/view-issue/new-team-response/conflict-dialog/conflict-dialog.component.ts
@@ -21,8 +21,8 @@ export class ConflictDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: Issue,
     private sanitizer: DomSanitizer,
     public labelService: LabelService,
-    public issueService: IssueService) {
-
+    public issueService: IssueService
+  ) {
     this.updatedHtml = this.sanitizer.bypassSecurityTrustHtml(replaceNewlinesWithBreakLines(escapeHTML(data.teamResponse)));
     this.isReady = true;
   }
@@ -32,6 +32,6 @@ export class ConflictDialogComponent {
   }
 
   handleTabChange(event: MatTabChangeEvent): void {
-    this.isOnPreview = (event.index === 1);
+    this.isOnPreview = event.index === 1;
   }
 }

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -7,15 +7,21 @@
     <div>
       <div *ngIf="(issueService.getDuplicateIssuesFor(this.issue) | async).length === 0; else displayDuplicates" class="container">
         <div>
-          <mat-checkbox style="display: inline-block; width: 20%" formControlName="duplicated" (change)="handleChangeOfDuplicateCheckbox($event)">
+          <mat-checkbox
+            style="display: inline-block; width: 20%"
+            formControlName="duplicated"
+            (change)="handleChangeOfDuplicateCheckbox($event)"
+          >
             A Duplicate Of:
           </mat-checkbox>
 
           <mat-form-field [style.visibility]="!duplicated.value ? 'hidden' : 'visible'" style="display: inline-block; width: 50%">
             <mat-select formControlName="duplicateOf" placeholder="Duplicate of">
               <mat-option *ngFor="let issue of duplicatedIssueList | async" [disabled]="dupIssueOptionIsDisabled(issue)" [value]="issue.id">
-                <span class="mat-body-strong"> #{{issue.id}}: </span>  <span class="mat-body">{{issue.title}}</span>
-                <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="color: #f44336"> ({{getDisabledDupOptionErrorText(issue)}}) </span>
+                <span class="mat-body-strong"> #{{ issue.id }}: </span> <span class="mat-body">{{ issue.title }}</span>
+                <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="color: #f44336">
+                  ({{ getDisabledDupOptionErrorText(issue) }})
+                </span>
               </mat-option>
             </mat-select>
             <mat-error *ngIf="duplicateOf.errors && duplicateOf.errors['required'] && duplicateOf.touched">
@@ -33,26 +39,36 @@
 
       <div class="container" [style.display]="duplicated.value ? 'none' : 'grid'">
         <div class="left-half">
-          <app-label-dropdown [initialValue]="this.issue.severity" attributeName="severity" [dropdownForm]="newTeamResponseForm"></app-label-dropdown>
+          <app-label-dropdown
+            [initialValue]="this.issue.severity"
+            attributeName="severity"
+            [dropdownForm]="newTeamResponseForm"
+          ></app-label-dropdown>
         </div>
 
         <div class="right-half">
-          <app-label-dropdown [initialValue]="this.issue.type" attributeName="type" [dropdownForm]="newTeamResponseForm"></app-label-dropdown>
+          <app-label-dropdown
+            [initialValue]="this.issue.type"
+            attributeName="type"
+            [dropdownForm]="newTeamResponseForm"
+          ></app-label-dropdown>
         </div>
       </div>
 
       <div class="container" [style.display]="duplicated.value ? 'none' : 'grid'">
         <mat-form-field class="left-half">
           <mat-select placeholder="Assignees" formControlName="assignees" multiple>
-            <mat-option *ngFor="let member of teamMembers" [value]="member">{{member}}</mat-option>
+            <mat-option *ngFor="let member of teamMembers" [value]="member">{{ member }}</mat-option>
           </mat-select>
-          <mat-error *ngIf="assignees.errors && assignees.errors['required'] && assignees.touched">
-            Assignee(s) required.
-          </mat-error>
+          <mat-error *ngIf="assignees.errors && assignees.errors['required'] && assignees.touched"> Assignee(s) required. </mat-error>
         </mat-form-field>
 
         <div class="right-half">
-          <app-label-dropdown [initialValue]="this.issue.responseTag" attributeName="responseTag" [dropdownForm]="newTeamResponseForm"></app-label-dropdown>
+          <app-label-dropdown
+            [initialValue]="this.issue.responseTag"
+            attributeName="responseTag"
+            [dropdownForm]="newTeamResponseForm"
+          ></app-label-dropdown>
         </div>
       </div>
 
@@ -61,28 +77,55 @@
         [commentField]="this.newTeamResponseForm.get('description')"
         [commentForm]="this.newTeamResponseForm"
         [(isFormPending)]="this.isFormPending"
-        [(submitButtonText)]="this.submitButtonText">
+        [(submitButtonText)]="this.submitButtonText"
+      >
       </app-comment-editor>
 
       <div class="editor-actions">
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isFormPending"
-                mat-raised-button color="primary" (click)="viewUpdatedResponse()">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isFormPending"
+          mat-raised-button
+          color="primary"
+          (click)="viewUpdatedResponse()"
+        >
           View Updated Response
         </button>
-        <button class="editor-action" *ngIf="conflict" type="submit"
-                [disabled]="newTeamResponseForm.invalid || isFormPending" mat-raised-button color="warn">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="submit"
+          [disabled]="newTeamResponseForm.invalid || isFormPending"
+          mat-raised-button
+          color="warn"
+        >
           {{ submitButtonText }}
         </button>
-        <button type="submit" class="editor-action" *ngIf="!conflict"
-                [disabled]="newTeamResponseForm.invalid || isFormPending" mat-stroked-button color="primary">
+        <button
+          type="submit"
+          class="editor-action"
+          *ngIf="!conflict"
+          [disabled]="newTeamResponseForm.invalid || isFormPending"
+          mat-stroked-button
+          color="primary"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isFormPending" mat-stroked-button
-                color="warn" (click)="refresh()" matTooltip="Updated response will overwrite your changes">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isFormPending"
+          mat-stroked-button
+          color="warn"
+          (click)="refresh()"
+          matTooltip="Updated response will overwrite your changes"
+        >
           Cancel
         </button>
       </div>
     </div>
-
   </div>
 </form>

--- a/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
@@ -9,24 +9,9 @@ import { ConflictDialogComponent } from './conflict-dialog/conflict-dialog.compo
 import { NewTeamResponseComponent } from './new-team-response.component';
 
 @NgModule({
-  exports: [
-    NewTeamResponseComponent,
-    ConflictDialogComponent,
-  ],
-  declarations: [
-    NewTeamResponseComponent,
-    ConflictDialogComponent,
-  ],
-  imports: [
-    CommonModule,
-    CommentEditorModule,
-    SharedModule,
-    IssueComponentsModule,
-    LabelDropdownModule,
-    MarkdownModule.forChild(),
-  ],
-  entryComponents: [
-    ConflictDialogComponent,
-  ]
+  exports: [NewTeamResponseComponent, ConflictDialogComponent],
+  declarations: [NewTeamResponseComponent, ConflictDialogComponent],
+  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()],
+  entryComponents: [ConflictDialogComponent]
 })
-export class NewTeamResponseModule { }
+export class NewTeamResponseModule {}

--- a/src/app/shared/view-issue/team-response/team-response.component.css
+++ b/src/app/shared/view-issue/team-response/team-response.component.css
@@ -1,4 +1,4 @@
 span {
-    vertical-align: middle; 
-    margin-left: 5px;
+  vertical-align: middle;
+  margin-left: 5px;
 }

--- a/src/app/shared/view-issue/team-response/team-response.component.html
+++ b/src/app/shared/view-issue/team-response/team-response.component.html
@@ -1,12 +1,9 @@
-<h3 class="mat-title">
-  Team's Response</h3>
+<h3 class="mat-title">Team's Response</h3>
 <form [formGroup]="responseForm" #myForm="ngForm" (ngSubmit)="updateResponse(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
       <span> <strong> Team </strong> responded. </span>
-      <button style="float: right;" mat-button *ngIf="canEditIssue() && !isEditing" (click)="changeToEditMode()">
-        Edit
-      </button>
+      <button style="float: right" mat-button *ngIf="canEditIssue() && !isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div *ngIf="!isEditing" class="comment">
       <markdown [data]="issue.teamResponse"></markdown>
@@ -17,23 +14,42 @@
         [commentField]="this.responseForm.get('description')"
         [commentForm]="this.responseForm"
         [(isFormPending)]="this.isSavePending"
-        [(submitButtonText)]="this.submitButtonText">
+        [(submitButtonText)]="this.submitButtonText"
+      >
       </app-comment-editor>
       <div class="editor-actions">
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isSavePending"
-                mat-raised-button color="primary" (click)="viewChanges()">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isSavePending"
+          mat-raised-button
+          color="primary"
+          (click)="viewChanges()"
+        >
           View Updated Response
         </button>
-        <button class="editor-action" *ngIf="conflict" type="submit" [disabled]="responseForm.invalid || isSavePending"
-                mat-raised-button color="warn">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="submit"
+          [disabled]="responseForm.invalid || isSavePending"
+          mat-raised-button
+          color="warn"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" *ngIf="!conflict" type="submit" [disabled]="responseForm.invalid || isSavePending"
-                mat-stroked-button color="primary">
+        <button
+          class="editor-action"
+          *ngIf="!conflict"
+          type="submit"
+          [disabled]="responseForm.invalid || isSavePending"
+          mat-stroked-button
+          color="primary"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn"
-                (click)="cancelEditMode()">
+        <button class="editor-action" type="button" [disabled]="isSavePending" mat-stroked-button color="warn" (click)="cancelEditMode()">
           Cancel
         </button>
       </div>

--- a/src/app/shared/view-issue/team-response/team-response.module.ts
+++ b/src/app/shared/view-issue/team-response/team-response.module.ts
@@ -8,19 +8,8 @@ import { SharedModule } from '../../shared.module';
 import { TeamResponseComponent } from './team-response.component';
 
 @NgModule({
-  exports: [
-    TeamResponseComponent
-  ],
-  declarations: [
-    TeamResponseComponent,
-  ],
-  imports: [
-    CommonModule,
-    CommentEditorModule,
-    SharedModule,
-    IssueComponentsModule,
-    LabelDropdownModule,
-    MarkdownModule.forChild(),
-  ]
+  exports: [TeamResponseComponent],
+  declarations: [TeamResponseComponent],
+  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()]
 })
-export class TeamResponseModule { }
+export class TeamResponseModule {}

--- a/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.html
+++ b/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.html
@@ -1,7 +1,6 @@
 <div style="display: flex; margin-bottom: 20px; align-items: center">
-  <h1 mat-dialog-title style="margin: 0">{{ 'The content you are editing has changed'}}</h1>
-  <mat-slide-toggle style="display: inline-block; margin-left: 50px"
-                    color="primary" [checked]="showDiff" (change)="handleChangeShowDiff()">
+  <h1 mat-dialog-title style="margin: 0">{{ 'The content you are editing has changed' }}</h1>
+  <mat-slide-toggle style="display: inline-block; margin-left: 50px" color="primary" [checked]="showDiff" (change)="handleChangeShowDiff()">
     Show Difference
   </mat-slide-toggle>
   <button mat-icon-button color="default" style="margin: 0 0 0 auto" (click)="close()">
@@ -11,38 +10,41 @@
 
 <div mat-dialog-content>
   <mat-accordion [multi]="true">
-    <mat-expansion-panel class="full-width" *ngFor="let conflict of conflicts; index as i;" [expanded]="panelOpenStates[i]">
+    <mat-expansion-panel class="full-width" *ngFor="let conflict of conflicts; index as i" [expanded]="panelOpenStates[i]">
       <mat-expansion-panel-header>
         <mat-panel-title class="response-title">
-          <div class="question-mark"> ? </div>
+          <div class="question-mark">?</div>
           <markdown [data]="data.updatedResponses[i].getTitleInMarkDown()"></markdown>
         </mat-panel-title>
         <mat-panel-description>
           <mat-chip-list>
-            <mat-chip *ngIf="data.outdatedResponses[i].compareTo(data.updatedResponses[i]) === 0" style="margin-top: 10px;">
+            <mat-chip *ngIf="data.outdatedResponses[i].compareTo(data.updatedResponses[i]) === 0" style="margin-top: 10px">
               No Changes
             </mat-chip>
           </mat-chip-list>
         </mat-panel-description>
       </mat-expansion-panel-header>
-      <br>
+      <br />
       <markdown [data]="data.updatedResponses[i].description"></markdown>
-      <br>
-      <div *ngIf="(data.updatedResponses[i].isDisagree() === data.outdatedResponses[i].isDisagree()) || !showDiff" style="margin-bottom: 10px">
+      <br />
+      <div
+        *ngIf="data.updatedResponses[i].isDisagree() === data.outdatedResponses[i].isDisagree() || !showDiff"
+        style="margin-bottom: 10px"
+      >
         <mat-checkbox style="display: inline-block; width: 20%" [disabled]="true" [checked]="data.updatedResponses[i].isDisagree()">
           I disagree
         </mat-checkbox>
       </div>
       <div *ngIf="!data.outdatedResponses[i].isDisagree() && data.updatedResponses[i].isDisagree() && showDiff" class="checkbox-changes">
         <i style="color: green" class="material-icons-outlined">add_box</i>
-        <ins style="background: #d4fcbc; text-decoration: none;"> I disagree </ins>
+        <ins style="background: #d4fcbc; text-decoration: none"> I disagree </ins>
       </div>
       <div *ngIf="data.outdatedResponses[i].isDisagree() && !data.updatedResponses[i].isDisagree() && showDiff" class="checkbox-changes">
         <i style="color: red" class="material-icons-outlined">indeterminate_check_box</i>
         <del style="background: #fbb">I disagree</del>
       </div>
 
-      <mat-tab-group style="margin-bottom: 20px;" class="mat-elevation-z1" animationDuration="0ms">
+      <mat-tab-group style="margin-bottom: 20px" class="mat-elevation-z1" animationDuration="0ms">
         <mat-tab label="Markdown Text">
           <div class="tab-content" *ngIf="isReady">
             <div *ngIf="showDiff" [innerHTML]="diffHtmls[i]"></div>
@@ -51,7 +53,7 @@
         </mat-tab>
         <mat-tab label="Preview Updated Content">
           <div class="tab-content">
-            <markdown>{{conflict.updatedContent}}</markdown>
+            <markdown>{{ conflict.updatedContent }}</markdown>
           </div>
         </mat-tab>
       </mat-tab-group>

--- a/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.ts
+++ b/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.ts
@@ -6,7 +6,6 @@ import { TesterResponse } from '../../../../core/models/tester-response.model';
 import { IssueService } from '../../../../core/services/issue.service';
 import { LabelService } from '../../../../core/services/label.service';
 
-
 export interface TesterResponseConflictData {
   outdatedResponses: TesterResponse[];
   updatedResponses: TesterResponse[];
@@ -31,11 +30,15 @@ export class ConflictDialogComponent {
     @Inject(MAT_DIALOG_DATA) public data: TesterResponseConflictData,
     private sanitizer: DomSanitizer,
     public labelService: LabelService,
-    public issueService: IssueService) {
-
+    public issueService: IssueService
+  ) {
     for (let i = 0; i < data.updatedResponses.length; i++) {
-      this.conflicts.push(new Conflict(data.outdatedResponses[i].getDisagreementWithoutDefaultResponse(),
-        data.updatedResponses[i].getDisagreementWithoutDefaultResponse()));
+      this.conflicts.push(
+        new Conflict(
+          data.outdatedResponses[i].getDisagreementWithoutDefaultResponse(),
+          data.updatedResponses[i].getDisagreementWithoutDefaultResponse()
+        )
+      );
       this.diffHtmls.push(this.sanitizer.bypassSecurityTrustHtml(this.conflicts[i].getHtmlDiffString()));
       this.updatedHtmls.push(this.sanitizer.bypassSecurityTrustHtml(this.conflicts[i].getHtmlUpdatedString()));
       this.panelOpenStates.push(data.outdatedResponses[i].compareTo(data.updatedResponses[i]) !== 0);

--- a/src/app/shared/view-issue/tester-response/tester-response.component.css
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.css
@@ -1,6 +1,6 @@
 .container {
-    padding: 10px 20px 0 20px;
-    display: grid;
+  padding: 10px 20px 0 20px;
+  display: grid;
 }
 
 .mat-radio-button ~ .mat-radio-button {

--- a/src/app/shared/view-issue/tester-response/tester-response.component.html
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.html
@@ -4,67 +4,84 @@
     <div class="timeline-header">
       <span style="vertical-align: middle; margin-left: 5px" *ngIf="this.isNewResponse()"> Please verify the following item(s). </span>
       <span style="vertical-align: middle; margin-left: 5px" *ngIf="!this.isNewResponse()"> <strong>Tester</strong> responded. </span>
-      <button mat-button style="float: right;" *ngIf="!isEditing" (click)="changeToEditMode()">
-          Edit
-      </button>
+      <button mat-button style="float: right" *ngIf="!isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div>
       <div class="container" *ngFor="let response of issue.testerResponses; index as i; trackBy: trackDisagreeList">
         <div style="display: flex; align-items: center">
-          <div class="question-mark"> ? </div>
+          <div class="question-mark">?</div>
           <markdown [data]="response.getTitleInMarkDown()"></markdown>
         </div>
-        <br>
+        <br />
         <markdown [data]="response.description"></markdown>
-        <br>
+        <br />
         <div>
-          <mat-radio-group style="display: inline-block; width: 20%"
-                           aria-label="Select Agree or Disagree to Team's Response"
-                           [disableControl]="!isEditing"
-                           [id]="getDisagreeRadioFormId(i)"
-                           [formControlName]="getDisagreeRadioFormId(i)"
-                           (change)="handleChangeOfDisagreeRadioButton($event, i)">
-            <mat-radio-button [value]="false">
-              I Agree
-            </mat-radio-button>
-            <mat-radio-button [value]="true">
-              I Disagree
-            </mat-radio-button>
+          <mat-radio-group
+            style="display: inline-block; width: 20%"
+            aria-label="Select Agree or Disagree to Team's Response"
+            [disableControl]="!isEditing"
+            [id]="getDisagreeRadioFormId(i)"
+            [formControlName]="getDisagreeRadioFormId(i)"
+            (change)="handleChangeOfDisagreeRadioButton($event, i)"
+          >
+            <mat-radio-button [value]="false"> I Agree </mat-radio-button>
+            <mat-radio-button [value]="true"> I Disagree </mat-radio-button>
           </mat-radio-group>
         </div>
         <div *ngIf="testerResponseForm.get(getDisagreeRadioFormId(i)).value">
           <div>
-            <p style="font-weight: 500;"> Reason for Disagreement: </p>
+            <p style="font-weight: 500">Reason for Disagreement:</p>
             <markdown [data]="response.reasonForDisagreement" *ngIf="!isEditing"></markdown>
           </div>
           <div *ngIf="isEditing">
-            <app-comment-editor [commentField]="testerResponseForm.get(getTesterResponseFormId(i))"
-                                [id]="getTesterResponseFormId(i)"
-                                [commentForm]="testerResponseForm"
-                                [(isFormPending)]="isFormPending"
-                                [(submitButtonText)]="submitButtonText"
+            <app-comment-editor
+              [commentField]="testerResponseForm.get(getTesterResponseFormId(i))"
+              [id]="getTesterResponseFormId(i)"
+              [commentForm]="testerResponseForm"
+              [(isFormPending)]="isFormPending"
+              [(submitButtonText)]="submitButtonText"
             >
             </app-comment-editor>
           </div>
         </div>
-        <br> <markdown data="-------------------"></markdown> <br>
+        <br />
+        <markdown data="-------------------"></markdown> <br />
       </div>
       <mat-divider></mat-divider>
       <div class="editor-actions" *ngIf="isEditing">
-        <button class="editor-action" *ngIf="conflict" type="button" [disabled]="isFormPending"
-                mat-raised-button color="primary" (click)="viewChanges()">
+        <button
+          class="editor-action"
+          *ngIf="conflict"
+          type="button"
+          [disabled]="isFormPending"
+          mat-raised-button
+          color="primary"
+          (click)="viewChanges()"
+        >
           View Updated Response
         </button>
-        <button type="submit" [disabled]="testerResponseForm.invalid || isFormPending" mat-stroked-button
-                color="primary" *ngIf="!conflict">
+        <button type="submit" [disabled]="testerResponseForm.invalid || isFormPending" mat-stroked-button color="primary" *ngIf="!conflict">
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="submit" [disabled]="testerResponseForm.invalid || isFormPending"
-                mat-raised-button color="warn" *ngIf="conflict">
+        <button
+          class="editor-action"
+          type="submit"
+          [disabled]="testerResponseForm.invalid || isFormPending"
+          mat-raised-button
+          color="warn"
+          *ngIf="conflict"
+        >
           {{ submitButtonText }}
         </button>
-        <button class="editor-action" type="button" [disabled]="isFormPending" *ngIf="!this.isNewResponse()"
-                mat-stroked-button color="warn" (click)="cancelEditMode()">
+        <button
+          class="editor-action"
+          type="button"
+          [disabled]="isFormPending"
+          *ngIf="!this.isNewResponse()"
+          mat-stroked-button
+          color="warn"
+          (click)="cancelEditMode()"
+        >
           Cancel
         </button>
       </div>

--- a/src/app/shared/view-issue/tester-response/tester-response.module.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.module.ts
@@ -9,23 +9,9 @@ import { ConflictDialogComponent } from './conflict-dialog/conflict-dialog.compo
 import { TesterResponseComponent } from './tester-response.component';
 
 @NgModule({
-  exports: [
-    TesterResponseComponent
-  ],
-  declarations: [
-    TesterResponseComponent,
-    ConflictDialogComponent
-  ],
-  entryComponents: [
-    ConflictDialogComponent,
-  ],
-  imports: [
-    CommonModule,
-    CommentEditorModule,
-    SharedModule,
-    IssueComponentsModule,
-    LabelDropdownModule,
-    MarkdownModule.forChild(),
-  ]
+  exports: [TesterResponseComponent],
+  declarations: [TesterResponseComponent, ConflictDialogComponent],
+  entryComponents: [ConflictDialogComponent],
+  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()]
 })
-export class TesterResponseModule { }
+export class TesterResponseModule {}

--- a/src/app/shared/view-issue/view-issue.component.html
+++ b/src/app/shared/view-issue/view-issue.component.html
@@ -10,90 +10,127 @@
   <div class="row">
     <div class="column left">
       <!-- Tester's Post -->
-      <app-issue-description [isEditing]="isIssueDescriptionEditing" (changeEditState)="updateDescriptionEditState($event)"
+      <app-issue-description
+        [isEditing]="isIssueDescriptionEditing"
+        (changeEditState)="updateDescriptionEditState($event)"
         *ngIf="this.isComponentVisible(issueComponentsEnum.TESTER_POST)"
-        [issue]="issue" title="Description of Issue" (issueUpdated)="updateIssue($event)">
+        [issue]="issue"
+        title="Description of Issue"
+        (issueUpdated)="updateIssue($event)"
+      >
       </app-issue-description>
 
       <!-- Team's Response -->
-      <app-team-response *ngIf="this.isComponentVisible(issueComponentsEnum.TEAM_RESPONSE) && issue.teamResponse"
-                         [issue]="issue" [isEditing]="isTeamResponseEditing" (updateEditState)="updateTeamResponseEditState($event)"
-                         (issueUpdated)="updateIssue($event)">
+      <app-team-response
+        *ngIf="this.isComponentVisible(issueComponentsEnum.TEAM_RESPONSE) && issue.teamResponse"
+        [issue]="issue"
+        [isEditing]="isTeamResponseEditing"
+        (updateEditState)="updateTeamResponseEditState($event)"
+        (issueUpdated)="updateIssue($event)"
+      >
       </app-team-response>
 
       <!-- New Team's Response -->
-      <app-new-team-response *ngIf="this.isComponentVisible(issueComponentsEnum.NEW_TEAM_RESPONSE) &&
-        permissions.isTeamResponseEditable()  && !issue.teamResponse" [issue]="issue"
-        (issueUpdated)="updateIssue($event)">
+      <app-new-team-response
+        *ngIf="
+          this.isComponentVisible(issueComponentsEnum.NEW_TEAM_RESPONSE) && permissions.isTeamResponseEditable() && !issue.teamResponse
+        "
+        [issue]="issue"
+        (issueUpdated)="updateIssue($event)"
+      >
       </app-new-team-response>
 
       <!-- Tester's Response -->
-      <app-tester-response *ngIf="this.isComponentVisible(issueComponentsEnum.TESTER_RESPONSE) && issue.testerResponses
-        && issue.testerResponses.length !== 0" [issue]="issue" [isEditing]="isTesterResponseEditing"
-        (updateEditState)="updateTesterResponseEditState($event)" (issueUpdated)="updateIssue($event)">
+      <app-tester-response
+        *ngIf="this.isComponentVisible(issueComponentsEnum.TESTER_RESPONSE) && issue.testerResponses && issue.testerResponses.length !== 0"
+        [issue]="issue"
+        [isEditing]="isTesterResponseEditing"
+        (updateEditState)="updateTesterResponseEditState($event)"
+        (issueUpdated)="updateIssue($event)"
+      >
       </app-tester-response>
 
       <!-- Issue Disputes For Tutor's Response -->
-      <app-issue-dispute *ngIf="this.isComponentVisible(issueComponentsEnum.ISSUE_DISPUTE)" [issue]="issue"
-        (issueUpdated)="updateIssue($event)" [isEditing]="isTutorResponseEditing"
-                         (updateEditState)="updateTutorResponseEditState($event)">
+      <app-issue-dispute
+        *ngIf="this.isComponentVisible(issueComponentsEnum.ISSUE_DISPUTE)"
+        [issue]="issue"
+        (issueUpdated)="updateIssue($event)"
+        [isEditing]="isTutorResponseEditing"
+        (updateEditState)="updateTutorResponseEditState($event)"
+      >
       </app-issue-dispute>
     </div>
 
     <div class="column right">
-      <div *ngIf="(this.isComponentVisible(issueComponentsEnum.NEW_TEAM_RESPONSE) && issue.teamResponse) ||
-        (this.isComponentVisible(issueComponentsEnum.TESTER_RESPONSE) && this.userService.currentUser.role === userRole.Student) ||
-        this.isComponentVisible(issueComponentsEnum.ISSUE_DISPUTE) ||
-        (!this.isComponentVisible(issueComponentsEnum.TEAM_RESPONSE))">
+      <div
+        *ngIf="
+          (this.isComponentVisible(issueComponentsEnum.NEW_TEAM_RESPONSE) && issue.teamResponse) ||
+          (this.isComponentVisible(issueComponentsEnum.TESTER_RESPONSE) && this.userService.currentUser.role === userRole.Student) ||
+          this.isComponentVisible(issueComponentsEnum.ISSUE_DISPUTE) ||
+          !this.isComponentVisible(issueComponentsEnum.TEAM_RESPONSE)
+        "
+      >
+        <!-- Severity Label -->
+        <app-issue-label
+          *ngIf="this.isComponentVisible(issueComponentsEnum.SEVERITY_LABEL)"
+          [issue]="issue"
+          attributeName="severity"
+          (issueUpdated)="updateIssue($event)"
+        ></app-issue-label>
 
-      <!-- Severity Label -->
-      <app-issue-label *ngIf="this.isComponentVisible(issueComponentsEnum.SEVERITY_LABEL)" [issue]="issue"
-        attributeName="severity" (issueUpdated)="updateIssue($event)"></app-issue-label>
+        <!-- Bug Type Label -->
+        <div *ngIf="this.isComponentVisible(issueComponentsEnum.TYPE_LABEL)">
+          <mat-divider></mat-divider>
+          <app-issue-label [issue]="issue" attributeName="type" (issueUpdated)="updateIssue($event)"></app-issue-label>
+        </div>
 
-      <!-- Bug Type Label -->
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.TYPE_LABEL)">
-        <mat-divider></mat-divider>
-        <app-issue-label [issue]="issue" attributeName="type" (issueUpdated)="updateIssue($event)"></app-issue-label>
-      </div>
+        <!-- Response Label -->
+        <div *ngIf="this.isComponentVisible(issueComponentsEnum.RESPONSE_LABEL)">
+          <mat-divider></mat-divider>
+          <app-issue-label [issue]="issue" attributeName="responseTag" (issueUpdated)="updateIssue($event)"></app-issue-label>
+        </div>
 
-      <!-- Response Label -->
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.RESPONSE_LABEL)">
-        <mat-divider></mat-divider>
-        <app-issue-label [issue]="issue" attributeName="responseTag" (issueUpdated)="updateIssue($event)"></app-issue-label>
-      </div>
+        <!-- Assignee to this Issue -->
+        <div *ngIf="this.isComponentVisible(issueComponentsEnum.ASSIGNEE)">
+          <mat-divider></mat-divider>
+          <app-assignee-component [issue]="issue" [team]="issue.teamAssigned" (issueUpdated)="updateIssue($event)"></app-assignee-component>
+        </div>
 
-      <!-- Assignee to this Issue -->
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.ASSIGNEE)">
-        <mat-divider></mat-divider>
-        <app-assignee-component  [issue]="issue" [team]="issue.teamAssigned" (issueUpdated)="updateIssue($event)"></app-assignee-component>
-      </div>
+        <!-- Duplicate information -->
+        <div
+          *ngIf="this.isComponentVisible(issueComponentsEnum.DUPLICATE) && (issueService.getDuplicateIssuesFor(issue) | async).length !== 0"
+        >
+          <mat-divider></mat-divider>
+          <app-duplicated-issues-component [issue]="issue"></app-duplicated-issues-component>
+          <br />
+        </div>
+        <div
+          *ngIf="
+            this.isComponentVisible(issueComponentsEnum.DUPLICATE) &&
+            (issue.duplicateOf || (issueService.getDuplicateIssuesFor(issue) | async).length === 0)
+          "
+        >
+          <mat-divider></mat-divider>
+          <app-duplicate-of-component [issue]="issue" (issueUpdated)="updateIssue($event)"></app-duplicate-of-component>
+        </div>
 
-      <!-- Duplicate information -->
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.DUPLICATE) &&
-        (issueService.getDuplicateIssuesFor(issue) | async).length !== 0">
-        <mat-divider></mat-divider>
-        <app-duplicated-issues-component  [issue]="issue"></app-duplicated-issues-component>
-        <br>
-      </div>
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.DUPLICATE) &&
-        (issue.duplicateOf || (issueService.getDuplicateIssuesFor(issue) | async).length === 0)">
-        <mat-divider></mat-divider>
-        <app-duplicate-of-component [issue]="issue" (issueUpdated)="updateIssue($event)"></app-duplicate-of-component>
-      </div>
-
-      <!-- Faulty issue warning -->
-      <div style="margin-top: 15px; color: red" *ngIf="this.isComponentVisible(issueComponentsEnum.DUPLICATE) &&
-        ((issueService.getDuplicateIssuesFor(issue) | async).length !== 0) &&
-        (issue.duplicateOf || (issueService.getDuplicateIssuesFor(issue) | async).length === 0)">
+        <!-- Faulty issue warning -->
+        <div
+          style="margin-top: 15px; color: red"
+          *ngIf="
+            this.isComponentVisible(issueComponentsEnum.DUPLICATE) &&
+            (issueService.getDuplicateIssuesFor(issue) | async).length !== 0 &&
+            (issue.duplicateOf || (issueService.getDuplicateIssuesFor(issue) | async).length === 0)
+          "
+        >
           * Need your resolution. An issue cannot have both duplicated issues and duplicated status.
-      </div>
+        </div>
 
-      <!-- Unsure checkbox -->
-      <div *ngIf="this.isComponentVisible(issueComponentsEnum.UNSURE_CHECKBOX)">
-        <mat-divider></mat-divider>
-        <app-unsure-checkbox [issue]="issue" (issueUpdated)="updateIssue($event)"></app-unsure-checkbox>
-      </div>
-
+        <!-- Unsure checkbox -->
+        <div *ngIf="this.isComponentVisible(issueComponentsEnum.UNSURE_CHECKBOX)">
+          <mat-divider></mat-divider>
+          <app-unsure-checkbox [issue]="issue" (issueUpdated)="updateIssue($event)"></app-unsure-checkbox>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/shared/view-issue/view-issue.component.ts
+++ b/src/app/shared/view-issue/view-issue.component.ts
@@ -25,7 +25,7 @@ export enum ISSUE_COMPONENTS {
 export const SUBMIT_BUTTON_TEXT = {
   SUBMIT: 'Submit',
   SAVE: 'Save',
-  OVERWRITE: 'Overwrite',
+  OVERWRITE: 'Overwrite'
 };
 
 @Component({
@@ -48,11 +48,13 @@ export class ViewIssueComponent implements OnInit, OnDestroy, OnChanges {
   public readonly issueComponentsEnum = ISSUE_COMPONENTS;
   public readonly userRole = UserRole;
 
-  constructor(private errorHandlingService: ErrorHandlingService,
-              public permissions: PermissionService,
-              public userService: UserService,
-              public issueService: IssueService,
-              private phaseService: PhaseService) { }
+  constructor(
+    private errorHandlingService: ErrorHandlingService,
+    public permissions: PermissionService,
+    public userService: UserService,
+    public issueService: IssueService,
+    private phaseService: PhaseService
+  ) {}
 
   ngOnInit() {
     this.getAndPollIssue(this.issueId);
@@ -115,21 +117,28 @@ export class ViewIssueComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private pollIssue(id: number): void {
-    this.issueSubscription = this.issueService.pollIssue(id).subscribe((issue: Issue) => {
-      const updatedIssue = issue.clone(this.phaseService.currentPhase);
-      if (!this.isIssueLoading) {
-        // prevent updating of respective attributes while editing
-        if (this.isIssueDescriptionEditing ||
-            (this.isTeamResponseEditing || (!this.issue.teamResponse && updatedIssue.teamResponse)) ||
-            this.isTesterResponseEditing || this.isTutorResponseEditing) {
-          updatedIssue.retainResponses(this.phaseService.currentPhase, this.issue);
+    this.issueSubscription = this.issueService.pollIssue(id).subscribe(
+      (issue: Issue) => {
+        const updatedIssue = issue.clone(this.phaseService.currentPhase);
+        if (!this.isIssueLoading) {
+          // prevent updating of respective attributes while editing
+          if (
+            this.isIssueDescriptionEditing ||
+            this.isTeamResponseEditing ||
+            (!this.issue.teamResponse && updatedIssue.teamResponse) ||
+            this.isTesterResponseEditing ||
+            this.isTutorResponseEditing
+          ) {
+            updatedIssue.retainResponses(this.phaseService.currentPhase, this.issue);
+          }
         }
+        this.issue = updatedIssue;
+        this.isIssueLoading = false;
+      },
+      (error) => {
+        this.errorHandlingService.handleError(error, () => this.pollIssue(id));
       }
-      this.issue = updatedIssue;
-      this.isIssueLoading = false;
-    }, (error) => {
-      this.errorHandlingService.handleError(error, () => this.pollIssue(id));
-    });
+    );
   }
 
   private stopPolling(): void {

--- a/src/app/shared/view-issue/view-issue.module.ts
+++ b/src/app/shared/view-issue/view-issue.module.ts
@@ -12,12 +12,8 @@ import { TesterResponseModule } from './tester-response/tester-response.module';
 import { ViewIssueComponent } from './view-issue.component';
 
 @NgModule({
-  exports: [
-    ViewIssueComponent
-  ],
-  declarations: [
-    ViewIssueComponent
-  ],
+  exports: [ViewIssueComponent],
+  declarations: [ViewIssueComponent],
   imports: [
     CommonModule,
     CommentEditorModule,
@@ -28,7 +24,7 @@ import { ViewIssueComponent } from './view-issue.component';
     SharedModule,
     IssueComponentsModule,
     LabelDropdownModule,
-    MarkdownModule.forChild(),
+    MarkdownModule.forChild()
   ]
 })
-export class ViewIssueModule { }
+export class ViewIssueModule {}

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -3,5 +3,5 @@ import { AppConfig as ProdAppConfig } from './environment.prod';
 export const AppConfig = {
   ...ProdAppConfig,
   clientId: '54b9dcc49069dc2f018e',
-  origin: 'https://catcher-org.github.io',
+  origin: 'https://catcher-org.github.io'
 };

--- a/src/index.html
+++ b/src/index.html
@@ -1,16 +1,19 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <title>CATcher</title>
-  <meta charset="utf-8">
-  <base href="/">
+  <head>
+    <title>CATcher</title>
+    <meta charset="utf-8" />
+    <base href="/" />
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
-</head>
-<body>
-  <app-root>Loading...</app-root>
-</body>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <app-root>Loading...</app-root>
+  </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,4 +12,4 @@ platformBrowserDynamic()
   .bootstrapModule(AppModule, {
     preserveWhitespaces: false
   })
-  .catch(err => console.error(err));
+  .catch((err) => console.error(err));

--- a/src/markdown.css
+++ b/src/markdown.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: octicons-link;
-  src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==) format('woff');
+  src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==)
+    format('woff');
 }
 
 markdown {
@@ -8,7 +9,8 @@ markdown {
   -webkit-text-size-adjust: 100%;
   line-height: 1.5;
   color: #24292e;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
   font-size: 16px;
   word-wrap: break-word;
 }
@@ -70,7 +72,7 @@ markdown .pl-c2 {
 }
 
 markdown .pl-c2::before {
-  content: "^M";
+  content: '^M';
 }
 
 markdown .pl-sr .pl-cce {
@@ -191,7 +193,7 @@ markdown input {
   overflow: visible;
 }
 
-markdown [type="checkbox"] {
+markdown [type='checkbox'] {
   box-sizing: border-box;
   padding: 0;
 }
@@ -230,13 +232,13 @@ markdown hr {
 
 markdown hr::before {
   display: table;
-  content: "";
+  content: '';
 }
 
 markdown hr::after {
   display: table;
   clear: both;
-  content: "";
+  content: '';
 }
 
 markdown table {
@@ -322,14 +324,14 @@ markdown dd {
 }
 
 markdown code {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 12px;
 }
 
 markdown pre {
   margin-top: 0;
   margin-bottom: 0;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 12px;
 }
 
@@ -367,20 +369,20 @@ markdown .pl-6 {
 
 markdown::before {
   display: table;
-  content: "";
+  content: '';
 }
 
 markdown::after {
   display: table;
   clear: both;
-  content: "";
+  content: '';
 }
 
-markdown>*:first-child {
+markdown > *:first-child {
   margin-top: 0 !important;
 }
 
-markdown>*:last-child {
+markdown > *:last-child {
   margin-bottom: 0 !important;
 }
 
@@ -425,11 +427,11 @@ markdown blockquote {
   border-left: 0.25em solid #dfe2e5;
 }
 
-markdown blockquote>:first-child {
+markdown blockquote > :first-child {
   margin-top: 0;
 }
 
-markdown blockquote>:last-child {
+markdown blockquote > :last-child {
   margin-bottom: 0;
 }
 
@@ -534,11 +536,11 @@ markdown li {
   word-wrap: break-all;
 }
 
-markdown li>p {
+markdown li > p {
   margin-top: 16px;
 }
 
-markdown li+li {
+markdown li + li {
   margin-top: 0.25em;
 }
 
@@ -590,11 +592,11 @@ markdown img {
   background-color: #fff;
 }
 
-markdown img[align=right] {
+markdown img[align='right'] {
   padding-left: 20px;
 }
 
-markdown img[align=left] {
+markdown img[align='left'] {
   padding-right: 20px;
 }
 
@@ -602,7 +604,7 @@ markdown code {
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
-  background-color: rgba(27,31,35,0.05);
+  background-color: rgba(27, 31, 35, 0.05);
   border-radius: 3px;
 }
 
@@ -610,7 +612,7 @@ markdown pre {
   word-wrap: normal;
 }
 
-markdown pre>code {
+markdown pre > code {
   padding: 0;
   margin: 0;
   font-size: 100%;
@@ -659,7 +661,7 @@ markdown .full-commit .btn-outline:not(:disabled):hover {
 markdown kbd {
   display: inline-block;
   padding: 3px 5px;
-  font: 11px "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font: 11px 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   line-height: 10px;
   color: #444d56;
   vertical-align: middle;
@@ -670,7 +672,7 @@ markdown kbd {
   box-shadow: inset 0 -1px 0 #c6cbd1;
 }
 
-markdown :checked+.radio-label {
+markdown :checked + .radio-label {
   position: relative;
   z-index: 1;
   border-color: #0366d6;
@@ -680,7 +682,7 @@ markdown .task-list-item {
   list-style-type: none;
 }
 
-markdown .task-list-item+.task-list-item {
+markdown .task-list-item + .task-list-item {
   margin-top: 3px;
 }
 

--- a/src/polyfills-test.ts
+++ b/src/polyfills-test.ts
@@ -1,3 +1,2 @@
 import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';
-

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -55,8 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
-
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
 
@@ -7,8 +8,14 @@ html, body {
   height: 100%;
 }
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+html,
+body {
+  height: 100%;
+}
+body {
+  margin: 0;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+}
 
 /* Timeline comment style */
 .timeline-header {
@@ -96,7 +103,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 }
 
 .no-underline {
-  text-decoration: none!important;
+  text-decoration: none !important;
 }
 
 .grid-flush-left {
@@ -110,7 +117,7 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 }
 
 .mat-table tbody tr:hover td {
-  background-color: #E8E8EE;
+  background-color: #e8e8ee;
 }
 
 table {
@@ -133,7 +140,6 @@ table {
   margin-left: 10px !important;
 }
 
-
 .bold-name {
   font-weight: 500;
   font-size: 17px;
@@ -144,7 +150,7 @@ table {
 }
 
 .white-spinner circle {
-  stroke:white !important;
+  stroke: white !important;
 }
 
 .sync-spinner {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,19 +1,13 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import { getTestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import 'zone.js/dist/zone-testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('../tests', true, /\.spec\.ts$/);
 // And load the modules.

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -9,7 +9,5 @@
       "core-js/es6/": ["../node_modules/core-js/es/"]
     }
   },
-  "exclude": [
-    "**/*.spec.ts"
-  ]
+  "exclude": ["**/*.spec.ts"]
 }

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -2,27 +2,14 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
-    "types": [
-      "jasmine",
-      "node"
-    ],
+    "types": ["jasmine", "node"],
     "baseUrl": ".",
     "paths": {
       "core-js/es7/reflect": ["../node_modules/core-js/proposals/reflect-metadata"],
       "core-js/es6/": ["../node_modules/core-js/es/"]
     }
   },
-  "files": [
-    "test.ts",
-    "polyfills-test.ts"
-  ],
-  "include": [
-    "../tests/**/*.spec.ts",
-    "**/*.d.ts"
-  ],
-  "exclude": [
-    "dist",
-    "release",
-    "node_modules"
-  ]
+  "files": ["test.ts", "polyfills-test.ts"],
+  "include": ["../tests/**/*.spec.ts", "**/*.d.ts"],
+  "exclude": ["dist", "release", "node_modules"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "tslint-config-prettier"
+  ],
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],


### PR DESCRIPTION
### Summary:
Fixes #837 

### Changes Made:
* Apply prettier to src
* Run a one-time prettier across the codebase
* Rewrite an arrow function in line 51 of `comment-editor-component.ts` that causes prettier to add an extra semicolon that tslint doesn't like
* Install [tslint-config-prettier](https://github.com/prettier/tslint-config-prettier) to prevent future conflicts between prettier and tslint

Please remember to run `npm install` on your local computers after this is merged!

Note that the pretty-quick and husky packages are already installed, so prettier will automatically format all staged files before committing.

### Proposed Commit Message:
```
Apply prettier across the whole codebase

Currently, prettier is only applied to the tests and e2e directories

However, it is not applied to src, resulting in inconsistent formatting

Let's apply prettier to src, run prettier once to format the code, and
install tslint-config-prettier to prevent conflicts between tslint and
prettier in the future
```
