### PR TITLE
Make Issue Tables collapsible in Team and Tester Response phase

### DIFF
--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
@@ -5,6 +5,21 @@
   text-align: center;
 }
 
+.mat-expansion-panel {
+  margin-bottom: 10px;
+}
+
+.mat-expansion-panel-header-title {
+  flex-basis: 15%;
+  font-size: x-large;
+  align-self: center;
+}
+
+.mat-expansion-panel-header-description {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 .title {
   color: black;
   margin: 0;

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.css
@@ -7,6 +7,7 @@
 
 .mat-expansion-panel {
   margin-bottom: 10px;
+  min-width: 1050px;
 }
 
 .mat-expansion-panel-header-title {

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel-header [expandedHeight]="'70px'">
     <mat-panel-title> Faulty Issues </mat-panel-title>
     <mat-panel-description>
-      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+      <mat-form-field class="full-grid-width" *ngIf="panelOpenState">
         <input
           matInput
           (click)="$event.stopPropagation()"

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -1,9 +1,5 @@
 <div>
-  <mat-grid-list cols="3" rowHeight="80px">
-    <mat-grid-tile>
-      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0px">Faulty Issues</h1></div>
-    </mat-grid-tile>
-
+  <mat-grid-list cols="3" rowHeight="60px">
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
         <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -1,11 +1,18 @@
-<div>
-  <mat-grid-list cols="3" rowHeight="60px">
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
+<mat-expansion-panel expanded (opened)="panelOpenState = true" (closed)="panelOpenState = false">
+  <mat-expansion-panel-header [expandedHeight]="'70px'">
+    <mat-panel-title> Faulty Issues </mat-panel-title>
+    <mat-panel-description>
+      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+        <input
+          matInput
+          (click)="$event.stopPropagation()"
+          (keyup)="applyFilter($event.target.value)"
+          (keydown.space)="$event.stopPropagation()"
+          (keydown.enter)="$event.stopPropagation()"
+          placeholder="Search"
+        />
       </mat-form-field>
-    </mat-grid-tile>
-  </mat-grid-list>
-
+    </mat-panel-description>
+  </mat-expansion-panel-header>
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
-</div>
+</mat-expansion-panel>

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.ts
@@ -14,6 +14,7 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 })
 export class IssuesFaultyComponent implements OnInit, OnChanges {
   displayedColumns: string[];
+  panelOpenState = true;
   filter: (issue: Issue) => boolean;
 
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.FIX_ISSUE];

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.css
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.css
@@ -4,6 +4,19 @@
   justify-content: center;
   text-align: center;
 }
+.mat-expansion-panel {
+  margin-bottom: 10px;
+}
+
+.mat-expansion-panel-header-title {
+  font-size: x-large;
+  align-self: center;
+}
+
+.mat-expansion-panel-header-description {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+}
 
 .title {
   color: black;

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.css
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.css
@@ -4,6 +4,7 @@
   justify-content: center;
   text-align: center;
 }
+
 .mat-expansion-panel {
   margin-bottom: 10px;
 }

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.css
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.css
@@ -7,6 +7,7 @@
 
 .mat-expansion-panel {
   margin-bottom: 10px;
+  min-width: 1050px;
 }
 
 .mat-expansion-panel-header-title {

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.css
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.css
@@ -10,6 +10,7 @@
 }
 
 .mat-expansion-panel-header-title {
+  flex-basis: 15%;
   font-size: x-large;
   align-self: center;
 }

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -1,11 +1,3 @@
 <div>
-  <mat-grid-list cols="3" rowHeight="60px">
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
-      </mat-form-field>
-    </mat-grid-tile>
-  </mat-grid-list>
-
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
 </div>

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -2,19 +2,16 @@
   <mat-expansion-panel-header [expandedHeight]="'70px'">
     <mat-panel-title> Issues Pending Response </mat-panel-title>
     <mat-panel-description>
-      <div class="grid-item">
-        <mat-form-field style="width: 100%" *ngIf="panelOpenState">
-          <input
-            matInput
-            (click)="$event.stopPropagation()"
-            (keyup)="applyFilter($event.target.value)"
-            (keydown.space)="$event.stopPropagation()"
-            (keydown.enter)="$event.stopPropagation()"
-            placeholder="Search"
-          />
-        </mat-form-field>
-      </div>
-      <div class="grid-item"></div>
+      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+        <input
+          matInput
+          (click)="$event.stopPropagation()"
+          (keyup)="applyFilter($event.target.value)"
+          (keydown.space)="$event.stopPropagation()"
+          (keydown.enter)="$event.stopPropagation()"
+          placeholder="Search"
+        />
+      </mat-form-field>
     </mat-panel-description>
   </mat-expansion-panel-header>
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -1,3 +1,21 @@
-<div>
+<mat-expansion-panel expanded (opened)="panelOpenState = true" (closed)="panelOpenState = false">
+  <mat-expansion-panel-header [expandedHeight]="'70px'">
+    <mat-panel-title> Issues Pending Response </mat-panel-title>
+    <mat-panel-description>
+      <div class="grid-item">
+        <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+          <input
+            matInput
+            (click)="$event.stopPropagation()"
+            (keyup)="applyFilter($event.target.value)"
+            (keydown.space)="$event.stopPropagation()"
+            (keydown.enter)="$event.stopPropagation()"
+            placeholder="Search"
+          />
+        </mat-form-field>
+      </div>
+      <div class="grid-item"></div>
+    </mat-panel-description>
+  </mat-expansion-panel-header>
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
-</div>
+</mat-expansion-panel>

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel-header [expandedHeight]="'70px'">
     <mat-panel-title> Issues Pending Response </mat-panel-title>
     <mat-panel-description>
-      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+      <mat-form-field class="full-grid-width" *ngIf="panelOpenState">
         <input
           matInput
           (click)="$event.stopPropagation()"

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -1,9 +1,5 @@
 <div>
-  <mat-grid-list cols="3" rowHeight="80px">
-    <mat-grid-tile>
-      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0">Issues Pending Response</h1></div>
-    </mat-grid-tile>
-
+  <mat-grid-list cols="3" rowHeight="60px">
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
         <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.ts
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.ts
@@ -14,6 +14,7 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 })
 export class IssuesPendingComponent implements OnInit, OnChanges {
   displayedColumns;
+  panelOpenState = true;
   filter: (issue: Issue) => boolean;
 
   readonly actionButtons: ACTION_BUTTONS[] = [

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.css
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.css
@@ -5,6 +5,21 @@
   text-align: center;
 }
 
+.mat-expansion-panel {
+  margin-bottom: 10px;
+}
+
+.mat-expansion-panel-header-title {
+  flex-basis: 15%;
+  font-size: x-large;
+  align-self: center;
+}
+
+.mat-expansion-panel-header-description {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 .title {
   color: black;
   margin: 0;

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.css
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.css
@@ -7,6 +7,7 @@
 
 .mat-expansion-panel {
   margin-bottom: 10px;
+  min-width: 1050px;
 }
 
 .mat-expansion-panel-header-title {

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -2,7 +2,7 @@
   <mat-expansion-panel-header [expandedHeight]="'70px'">
     <mat-panel-title>Issues Responded</mat-panel-title>
     <mat-panel-description>
-      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+      <mat-form-field class="full-grid-width" *ngIf="panelOpenState">
         <input
           matInput
           (click)="$event.stopPropagation()"

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -1,11 +1,18 @@
-<div>
-  <mat-grid-list cols="3" rowHeight="60px">
-    <mat-grid-tile>
-      <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
+<mat-expansion-panel expanded (opened)="panelOpenState = true" (closed)="panelOpenState = false">
+  <mat-expansion-panel-header [expandedHeight]="'70px'">
+    <mat-panel-title>Issues Responded</mat-panel-title>
+    <mat-panel-description>
+      <mat-form-field style="width: 100%" *ngIf="panelOpenState">
+        <input
+          matInput
+          (click)="$event.stopPropagation()"
+          (keyup)="applyFilter($event.target.value)"
+          (keydown.space)="$event.stopPropagation()"
+          (keydown.enter)="$event.stopPropagation()"
+          placeholder="Search"
+        />
       </mat-form-field>
-    </mat-grid-tile>
-  </mat-grid-list>
-
+    </mat-panel-description>
+  </mat-expansion-panel-header>
   <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
-</div>
+</mat-expansion-panel>

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -1,9 +1,5 @@
 <div>
-  <mat-grid-list cols="3" rowHeight="80px">
-    <mat-grid-tile>
-      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0px">Issues Responded</h1></div>
-    </mat-grid-tile>
-
+  <mat-grid-list cols="3" rowHeight="60px">
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
         <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.ts
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.ts
@@ -13,6 +13,7 @@ import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/
 })
 export class IssuesRespondedComponent implements OnInit, OnChanges {
   displayedColumns: string[];
+  panelOpenState = true;
   filter: (issue: Issue) => boolean;
 
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB, ACTION_BUTTONS.MARK_AS_PENDING, ACTION_BUTTONS.FIX_ISSUE];

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -11,6 +11,10 @@
   padding: 30px 20px;
 }
 
+.mat-grid-list {
+  min-width: 1050px;
+}
+
 .mat-raised-button {
   margin-left: 20px;
   margin-bottom: 20px;

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -20,8 +20,23 @@
   margin-bottom: 10px;
 }
 
+.search-bar {
+  pointer-events: auto;
+}
+
+.align-header {
+  display: flex;
+  align-items: baseline;
+}
+
 .mat-expansion-panel-header-title {
   font-size: x-large;
+  align-self: center;
+}
+
+.mat-expansion-panel-header-description {
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
 }
 
 .mat-column-actions {

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -20,10 +20,6 @@
   margin-bottom: 10px;
 }
 
-.search-bar {
-  pointer-events: auto;
-}
-
 .mat-expansion-panel-header-title {
   font-size: x-large;
   align-self: center;

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -14,6 +14,20 @@
 .panel-buttons {
   display: flex;
   justify-content: center;
+  padding-bottom: 20px;
+}
+
+.mat-raised-button {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.mat-accordion .mat-expansion-panel {
+  margin-bottom: 10px;
+}
+
+.mat-expansion-panel-header-title {
+  font-size: x-large;
 }
 
 .mat-column-actions {

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -16,20 +16,6 @@
   margin-bottom: 20px;
 }
 
-.mat-accordion .mat-expansion-panel {
-  margin-bottom: 10px;
-}
-
-.mat-expansion-panel-header-title {
-  font-size: x-large;
-  align-self: center;
-}
-
-.mat-expansion-panel-header-description {
-  display: inline-grid;
-  grid-template-columns: 1fr 1fr;
-}
-
 .mat-column-actions {
   width: 80px;
   text-align: center;

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -11,6 +11,11 @@
   padding: 30px 20px;
 }
 
+.panel-buttons {
+  display: flex;
+  justify-content: center;
+}
+
 .mat-column-actions {
   width: 80px;
   text-align: center;

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -24,11 +24,6 @@
   pointer-events: auto;
 }
 
-.align-header {
-  display: flex;
-  align-items: baseline;
-}
-
 .mat-expansion-panel-header-title {
   font-size: x-large;
   align-self: center;

--- a/src/app/phase-team-response/phase-team-response.component.css
+++ b/src/app/phase-team-response/phase-team-response.component.css
@@ -11,15 +11,9 @@
   padding: 30px 20px;
 }
 
-.panel-buttons {
-  display: flex;
-  justify-content: center;
-  padding-bottom: 20px;
-}
-
 .mat-raised-button {
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: 20px;
+  margin-bottom: 20px;
 }
 
 .mat-accordion .mat-expansion-panel {

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -26,30 +26,7 @@
   </mat-grid-list>
 
   <mat-accordion multi>
-    <mat-expansion-panel expanded (opened)="pendingPanelOpenState = true" (closed)="pendingPanelOpenState = false">
-      <mat-expansion-panel-header class="align-header" [expandedHeight]="'70px'">
-        <mat-panel-title> Issues Pending Response </mat-panel-title>
-        <mat-panel-description>
-          <div class="grid-item">
-            <mat-form-field style="width: 100%" *ngIf="pendingPanelOpenState">
-              <input
-                matInput
-                class="search-bar"
-                (click)="$event.stopPropagation()"
-                (keyup)="issuesPending.applyFilter($event.target.value)"
-                (keydown.space)="$event.stopPropagation()"
-                (keydown.enter)="$event.stopPropagation()"
-                placeholder="Search"
-              />
-            </mat-form-field>
-          </div>
-          <div class="grid-item"></div>
-        </mat-panel-description>
-      </mat-expansion-panel-header>
-
-      <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
-    </mat-expansion-panel>
-
+    <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
     <mat-expansion-panel expanded>
       <mat-expansion-panel-header>
         <mat-panel-title> Faulty Issues </mat-panel-title>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -12,7 +12,29 @@
     </mat-menu>
   </div>
 
-  <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
-  <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
-  <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
+  <mat-accordion class="example-headers-align">
+    <mat-expansion-panel [expanded]="step === 0" (opened)="step = 0">
+      <mat-expansion-panel-header>
+        <mat-panel-title> Issues Pending Response </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
+    </mat-expansion-panel>
+
+    <mat-expansion-panel [expanded]="step === 1" (opened)="step = 1">
+      <mat-expansion-panel-header>
+        <mat-panel-title> Issues Responded </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
+    </mat-expansion-panel>
+
+    <mat-expansion-panel [expanded]="step === 2" (opened)="step = 2">
+      <mat-expansion-panel-header>
+        <mat-panel-title> Faulty Issues </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
+    </mat-expansion-panel>
+  </mat-accordion>
 </div>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -1,21 +1,29 @@
 <div>
-  <div style="text-align: center; margin-bottom: 20px">
-    <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id }} </span>
-    <button *ngIf="teamList" [matMenuTriggerFor]="teamMenu" mat-icon-button>
-      <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> settings </mat-icon>
-    </button>
+  <mat-grid-list cols="3" rowHeight="60px">
+    <mat-grid-tile> </mat-grid-tile>
 
-    <mat-menu #teamMenu>
-      <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList" (click)="updateDisplayedTeam(team)">
-        <span> {{ team }} </span>
-      </button>
-    </mat-menu>
-  </div>
+    <mat-grid-tile>
+      <div style="margin-bottom: 20px">
+        <span class="mat-display-1"> {{ teamList ? teamFilter : userService.currentUser.team.id }} </span>
+        <button *ngIf="teamList" [matMenuTriggerFor]="teamMenu" mat-icon-button>
+          <mat-icon style="font-size: 20px; margin-bottom: 7px; color: #586069"> settings </mat-icon>
+        </button>
 
-  <div class="panel-buttons">
-    <button mat-raised-button (click)="accordion.openAll()">Expand All</button>
-    <button mat-raised-button (click)="accordion.closeAll()">Collapse All</button>
-  </div>
+        <mat-menu #teamMenu>
+          <button mat-menu-item [disabled]="team === teamFilter" *ngFor="let team of teamList" (click)="updateDisplayedTeam(team)">
+            <span> {{ team }} </span>
+          </button>
+        </mat-menu>
+      </div>
+    </mat-grid-tile>
+
+    <mat-grid-tile>
+      <div class="grid-flush-right">
+        <button mat-raised-button (click)="accordion.openAll()">Expand All</button>
+        <button mat-raised-button (click)="accordion.closeAll()">Collapse All</button>
+      </div>
+    </mat-grid-tile>
+  </mat-grid-list>
 
   <mat-accordion multi>
     <mat-expansion-panel expanded>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -37,6 +37,8 @@
                 class="search-bar"
                 (click)="$event.stopPropagation()"
                 (keyup)="issuesPending.applyFilter($event.target.value)"
+                (keydown.space)="$event.stopPropagation()"
+                (keydown.enter)="$event.stopPropagation()"
                 placeholder="Search"
               />
             </mat-form-field>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -12,12 +12,15 @@
     </mat-menu>
   </div>
 
-  <div>
+  <div class="panel-buttons">
+    <button mat-raised-button (click)="accordion.openAll()">Expand All</button>
     <button mat-raised-button (click)="accordion.closeAll()">Collapse All</button>
   </div>
 
-  <mat-accordion class="example-headers-align" multi>
-    <mat-expansion-panel>
+  <br />
+
+  <mat-accordion multi>
+    <mat-expansion-panel expanded>
       <mat-expansion-panel-header>
         <mat-panel-title> Issues Pending Response </mat-panel-title>
       </mat-expansion-panel-header>
@@ -25,20 +28,20 @@
       <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
     </mat-expansion-panel>
 
-    <mat-expansion-panel>
-      <mat-expansion-panel-header>
-        <mat-panel-title> Issues Responded </mat-panel-title>
-      </mat-expansion-panel-header>
-
-      <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
-    </mat-expansion-panel>
-
-    <mat-expansion-panel>
+    <mat-expansion-panel expanded>
       <mat-expansion-panel-header>
         <mat-panel-title> Faulty Issues </mat-panel-title>
       </mat-expansion-panel-header>
 
       <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
+    </mat-expansion-panel>
+
+    <mat-expansion-panel expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title> Issues Responded </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
     </mat-expansion-panel>
   </mat-accordion>
 </div>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -12,8 +12,12 @@
     </mat-menu>
   </div>
 
-  <mat-accordion class="example-headers-align">
-    <mat-expansion-panel [expanded]="step === 0" (opened)="step = 0">
+  <div>
+    <button mat-raised-button (click)="accordion.closeAll()">Collapse All</button>
+  </div>
+
+  <mat-accordion class="example-headers-align" multi>
+    <mat-expansion-panel>
       <mat-expansion-panel-header>
         <mat-panel-title> Issues Pending Response </mat-panel-title>
       </mat-expansion-panel-header>
@@ -21,7 +25,7 @@
       <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
     </mat-expansion-panel>
 
-    <mat-expansion-panel [expanded]="step === 1" (opened)="step = 1">
+    <mat-expansion-panel>
       <mat-expansion-panel-header>
         <mat-panel-title> Issues Responded </mat-panel-title>
       </mat-expansion-panel-header>
@@ -29,7 +33,7 @@
       <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
     </mat-expansion-panel>
 
-    <mat-expansion-panel [expanded]="step === 2" (opened)="step = 2">
+    <mat-expansion-panel>
       <mat-expansion-panel-header>
         <mat-panel-title> Faulty Issues </mat-panel-title>
       </mat-expansion-panel-header>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -28,13 +28,6 @@
   <mat-accordion multi>
     <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
     <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
-
-    <mat-expansion-panel expanded>
-      <mat-expansion-panel-header>
-        <mat-panel-title> Issues Responded </mat-panel-title>
-      </mat-expansion-panel-header>
-
-      <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
-    </mat-expansion-panel>
+    <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
   </mat-accordion>
 </div>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -26,9 +26,14 @@
   </mat-grid-list>
 
   <mat-accordion multi>
-    <mat-expansion-panel expanded>
-      <mat-expansion-panel-header>
+    <mat-expansion-panel expanded (opened)="pendingPanelOpenState = true" (closed)="pendingPanelOpenState = false">
+      <mat-expansion-panel-header [expandedHeight]="'60px'">
         <mat-panel-title> Issues Pending Response </mat-panel-title>
+        <mat-panel-description>
+          <mat-form-field *ngIf="pendingPanelOpenState">
+            <input matInput (keyup)="issuesPending.applyFilter($event.target.value)" placeholder="Search" />
+          </mat-form-field>
+        </mat-panel-description>
       </mat-expansion-panel-header>
 
       <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -27,12 +27,21 @@
 
   <mat-accordion multi>
     <mat-expansion-panel expanded (opened)="pendingPanelOpenState = true" (closed)="pendingPanelOpenState = false">
-      <mat-expansion-panel-header [expandedHeight]="'60px'">
+      <mat-expansion-panel-header class="align-header" [expandedHeight]="'70px'">
         <mat-panel-title> Issues Pending Response </mat-panel-title>
         <mat-panel-description>
-          <mat-form-field *ngIf="pendingPanelOpenState">
-            <input matInput (keyup)="issuesPending.applyFilter($event.target.value)" placeholder="Search" />
-          </mat-form-field>
+          <div class="grid-item">
+            <mat-form-field style="width: 100%" *ngIf="pendingPanelOpenState">
+              <input
+                matInput
+                class="search-bar"
+                (click)="$event.stopPropagation()"
+                (keyup)="issuesPending.applyFilter($event.target.value)"
+                placeholder="Search"
+              />
+            </mat-form-field>
+          </div>
+          <div class="grid-item"></div>
         </mat-panel-description>
       </mat-expansion-panel-header>
 

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -27,13 +27,7 @@
 
   <mat-accordion multi>
     <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
-    <mat-expansion-panel expanded>
-      <mat-expansion-panel-header>
-        <mat-panel-title> Faulty Issues </mat-panel-title>
-      </mat-expansion-panel-header>
-
-      <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
-    </mat-expansion-panel>
+    <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>
 
     <mat-expansion-panel expanded>
       <mat-expansion-panel-header>

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -17,8 +17,6 @@
     <button mat-raised-button (click)="accordion.closeAll()">Collapse All</button>
   </div>
 
-  <br />
-
   <mat-accordion multi>
     <mat-expansion-panel expanded>
       <mat-expansion-panel-header>

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -5,6 +5,7 @@ import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
 import { IssueService } from '../core/services/issue.service';
 import { UserService } from '../core/services/user.service';
+import { IssuesPendingComponent } from './issues-pending/issues-pending.component';
 
 @Component({
   selector: 'app-phase-team-response',
@@ -13,8 +14,10 @@ import { UserService } from '../core/services/user.service';
 })
 export class PhaseTeamResponseComponent implements OnInit {
   @ViewChild(MatAccordion, { static: false }) accordion: MatAccordion;
+  @ViewChild(IssuesPendingComponent, { static: true }) issuesPending: IssuesPendingComponent;
 
   public teamFilter = 'All Teams';
+  pendingPanelOpenState = true;
 
   constructor(public userService: UserService, private dataService: DataService, private issueService: IssueService) {}
 

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -14,10 +14,8 @@ import { IssuesPendingComponent } from './issues-pending/issues-pending.componen
 })
 export class PhaseTeamResponseComponent implements OnInit {
   @ViewChild(MatAccordion, { static: false }) accordion: MatAccordion;
-  @ViewChild(IssuesPendingComponent, { static: true }) issuesPending: IssuesPendingComponent;
 
   public teamFilter = 'All Teams';
-  pendingPanelOpenState = true;
 
   constructor(public userService: UserService, private dataService: DataService, private issueService: IssueService) {}
 

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatAccordion } from '@angular/material';
 import { IssuesFilter } from '../core/models/issue.model';
 import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
@@ -11,6 +12,8 @@ import { UserService } from '../core/services/user.service';
   styleUrls: ['./phase-team-response.component.css']
 })
 export class PhaseTeamResponseComponent implements OnInit {
+  @ViewChild(MatAccordion, { static: false }) accordion: MatAccordion;
+
   public teamFilter = 'All Teams';
 
   constructor(public userService: UserService, private dataService: DataService, private issueService: IssueService) {}

--- a/src/app/phase-team-response/phase-team-response.component.ts
+++ b/src/app/phase-team-response/phase-team-response.component.ts
@@ -5,7 +5,6 @@ import { Phase } from '../core/models/phase.model';
 import { DataService } from '../core/services/data.service';
 import { IssueService } from '../core/services/issue.service';
 import { UserService } from '../core/services/user.service';
-import { IssuesPendingComponent } from './issues-pending/issues-pending.component';
 
 @Component({
   selector: 'app-phase-team-response',

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -1,11 +1,9 @@
-
 <mat-table [dataSource]="this.issues" matSort class="mat-elevation-z8">
-
   <!-- ID Column -->
   <ng-container matColumnDef="id">
     <mat-header-cell *matHeaderCellDef mat-sort-header> ID </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-      <span (click)="$event.stopPropagation()" style="cursor: default;">{{issue.id}}</span>
+      <span (click)="$event.stopPropagation()" style="cursor: default">{{ issue.id }}</span>
     </mat-cell>
   </ng-container>
 
@@ -13,29 +11,37 @@
   <ng-container matColumnDef="title">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Title </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-      <a class="no-underline link-grey-dark" [routerLink]="'issues/' + issue.id"> {{this.fitTitleText(issue.title)}} </a>
+      <a class="no-underline link-grey-dark" [routerLink]="'issues/' + issue.id"> {{ this.fitTitleText(issue.title) }} </a>
     </mat-cell>
   </ng-container>
 
   <!-- Team Assigned Column -->
   <ng-container *ngIf="userService.currentUser.role !== 'Student'" matColumnDef="teamAssigned">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Team </mat-header-cell>
-    <mat-cell *matCellDef="let issue"> {{ issue.teamAssigned && issue.teamAssigned.id || '-'}} </mat-cell>
+    <mat-cell *matCellDef="let issue"> {{ (issue.teamAssigned && issue.teamAssigned.id) || '-' }} </mat-cell>
   </ng-container>
 
   <!-- Type Column -->
   <ng-container matColumnDef="type">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Type </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-          <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
-              {{issue.type || '-'}}
-          </span>
-          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" style="display: inline; padding: 1px 2px">
-            <mat-icon style="vertical-align: middle;">arrow_right_alt</mat-icon>
-          </span>
-          <span *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type" (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))">
-            {{issue.teamChosenType}}
-          </span>
+      <span (click)="$event.stopPropagation()" [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.type))">
+        {{ issue.type || '-' }}
+      </span>
+      <span
+        *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type"
+        (click)="$event.stopPropagation()"
+        style="display: inline; padding: 1px 2px"
+      >
+        <mat-icon style="vertical-align: middle">arrow_right_alt</mat-icon>
+      </span>
+      <span
+        *ngIf="issue.teamChosenType && issue.teamChosenType != issue.type"
+        (click)="$event.stopPropagation()"
+        [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.teamChosenType))"
+      >
+        {{ issue.teamChosenType }}
+      </span>
     </mat-cell>
   </ng-container>
 
@@ -43,11 +49,11 @@
   <ng-container matColumnDef="severity">
     <mat-header-cell *matHeaderCellDef mat-sort-header> Severity </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-      <span 
+      <span
         (click)="$event.stopPropagation()"
         [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.severity))"
       >
-        {{issue.severity || '-'}}
+        {{ issue.severity || '-' }}
       </span>
       <span
         *ngIf="issue.teamChosenSeverity && issue.teamChosenSeverity != issue.severity"
@@ -75,7 +81,7 @@
         *ngIf="issue.responseTag"
         [ngStyle]="this.labelService.setLabelStyle(this.labelService.getColorOfLabel(issue.responseTag))"
       >
-        {{issue.responseTag}}
+        {{ issue.responseTag }}
       </span>
       <span *ngIf="!issue.responseTag" style="margin-left: 10%">
         <mat-icon matTooltip="Should not be empty" matTooltipPosition="above" color="warn">warning</mat-icon>
@@ -87,11 +93,11 @@
   <ng-container matColumnDef="assignees">
     <mat-header-cell mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-      <span (click)="$event.stopPropagation()" style="cursor: default;" *ngIf="issue.assignees.length !== 0">
-        {{issue.assignees.join(', ')}}
+      <span (click)="$event.stopPropagation()" style="cursor: default" *ngIf="issue.assignees.length !== 0">
+        {{ issue.assignees.join(', ') }}
       </span>
       <span *ngIf="issue.assignees.length === 0" style="margin-left: 5%">
-        <mat-icon matTooltip="We strongly recommend assigning all issues to someone" matTooltipPosition="above" style="color: #FFAB40;">
+        <mat-icon matTooltip="We strongly recommend assigning all issues to someone" matTooltipPosition="above" style="color: #ffab40">
           warning
         </mat-icon>
       </span>
@@ -102,12 +108,10 @@
   <ng-container matColumnDef="duplicatedIssues">
     <mat-header-cell *matHeaderCellDef> Duplicates </mat-header-cell>
     <mat-cell *matCellDef="let issue">
-      <div *ngIf="(issueService.getDuplicateIssuesFor(issue) | async).length === 0">
-        -
-      </div>
+      <div *ngIf="(issueService.getDuplicateIssuesFor(issue) | async).length === 0">-</div>
       <mat-chip-list
-        *ngFor="let duplicateIssue of (issueService.getDuplicateIssuesFor(issue) | async)"
-        style="display: inline-block; margin-left: 5px;"
+        *ngFor="let duplicateIssue of issueService.getDuplicateIssuesFor(issue) | async"
+        style="display: inline-block; margin-left: 5px"
       >
         <mat-chip
           [routerLink]="['issues/' + duplicateIssue.id]"
@@ -115,7 +119,7 @@
           matTooltipPosition="above"
           style="font-size: 12px; cursor: pointer"
         >
-          #{{duplicateIssue.id}}
+          #{{ duplicateIssue.id }}
         </mat-chip>
       </mat-chip-list>
     </mat-cell>
@@ -153,7 +157,7 @@
         mat-button
         matTooltip="View this issue on GitHub"
         *ngIf="this.isActionVisible(action_buttons.VIEW_IN_WEB)"
-        (click)="this.viewIssueInBrowser(issue.id)" 
+        (click)="this.viewIssueInBrowser(issue.id, $event)"
         style="transform: scale(0.8)"
       >
         <mat-icon>open_in_new</mat-icon>
@@ -224,7 +228,7 @@
 
   <mat-header-row *matHeaderRowDef="this.headers"></mat-header-row>>
   <mat-row
-    *matRowDef="let issue; columns: this.headers;"
+    *matRowDef="let issue; columns: this.headers"
     (click)="this.logIssueEditRouting(issue.id)"
     [routerLink]="'issues/' + issue.id"
     style="cursor: pointer"


### PR DESCRIPTION
### Summary:
Fixes #871

### Changes Made:
* Put the issue tables in their own expansion panel
* Integrate the search bar with the expansion panel header
* Add buttons to expand and collapse all the tables

The final result looks like this:
![catcher accordion multi panel v4](https://user-images.githubusercontent.com/68138671/154018258-1560ea35-e454-4111-8711-899455bcb782.gif)

This PR is on hold while waiting for #877 and #767 to be done. Once those 2 PRs are merged, then I can implement this for the Tester Response phase.

### Proposed Commit Message:
```
Commit message to be used when the PR is merged
(NOTE: Wrap the body at 72 characters)
```
