### PR TITLE
Improve Duplicate Issue Search in Team Response Phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "karma-spec-reporter": "0.0.32",
     "moment": "^2.24.0",
     "ngx-markdown": "^8.2.1",
+    "ngx-mat-select-search": "^1.8.0",
     "node-fetch": "^2.6.0",
     "rxjs": "6.5.3",
     "tslib": "^1.9.0",

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.html
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.html
@@ -19,18 +19,26 @@
 
   <mat-select
     [style.display]="isEditing ? 'block' : 'none'"
+    style="width: 100%"
     class="no-arrow"
     placeholder="-"
     [value]="issue.duplicateOf"
     (selectionChange)="updateDuplicateStatus($event)"
     (openedChange)="handleSelectionOpenChange($event)"
   >
+    <mat-option>
+      <ngx-mat-select-search
+        placeholderLabel="Search issues"
+        noEntriesFoundLabel="No issues found"
+        [formControl]="searchFilterCtrl"
+      ></ngx-mat-select-search>
+    </mat-option>
     <mat-select-trigger></mat-select-trigger>
     <mat-option
       [matTooltip]="issue.title"
       [matTooltipDisabled]="!isTooltipNecessary(issue)"
       [matTooltipPosition]="'left'"
-      *ngFor="let issue of duplicatedIssueList | async"
+      *ngFor="let issue of filteredDuplicateIssueList | async"
       [disabled]="dupIssueOptionIsDisabled(issue)"
       [value]="issue.id"
     >

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatCheckbox, MatSelect, MatSelectChange } from '@angular/material';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
@@ -72,7 +72,7 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
     this.searchFilterCtrl.valueChanges.pipe(takeUntil(this._onDestroy)).subscribe((_) => this.filterIssues());
   }
 
-  filterIssues(): void {
+  private filterIssues(): void {
     this.changeFilter(this.duplicatedIssueList, this.searchFilterCtrl.value).subscribe((issues) =>
       this.filteredDuplicateIssueList.next(issues)
     );
@@ -96,7 +96,7 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
       if (SEVERITY_ORDER[this.issue.severity] > SEVERITY_ORDER[issue.severity]) {
         reason.push('Issue of lower priority');
       } else if (issue.duplicated || !!issue.duplicateOf) {
-        reason.push('A duplicated issue');
+        reason.push('Duplicate of #' + issue.duplicateOf);
       }
     }
     return reason.join(', ');
@@ -140,7 +140,7 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
     return clone;
   }
 
-  changeFilter(issuesObservable: Observable<Issue[]>, searchInputString): Observable<Issue[]> {
+  private changeFilter(issuesObservable: Observable<Issue[]>, searchInputString): Observable<Issue[]> {
     return issuesObservable.pipe(
       first(),
       map((issues) => {

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -144,12 +144,7 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
     return issuesObservable.pipe(
       first(),
       map((issues) => {
-        return applySearchFilter(
-          searchInputString,
-          [TABLE_COLUMNS.ID, TABLE_COLUMNS.DUPLICATED_ISSUES, TABLE_COLUMNS.TITLE],
-          this.issueService,
-          issues
-        );
+        return applySearchFilter(searchInputString, [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE], this.issueService, issues);
       })
     );
   }

--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -1,12 +1,15 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatCheckbox, MatSelect, MatSelectChange } from '@angular/material';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, ReplaySubject, Subject } from 'rxjs';
+import { first, map, takeUntil } from 'rxjs/operators';
 import { Issue, SEVERITY_ORDER } from '../../../core/models/issue.model';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { IssueService } from '../../../core/services/issue.service';
 import { PermissionService } from '../../../core/services/permission.service';
 import { PhaseService } from '../../../core/services/phase.service';
+import { TABLE_COLUMNS } from '../../issue-tables/issue-tables-columns';
+import { applySearchFilter } from '../../issue-tables/search-filter';
 
 @Component({
   selector: 'app-duplicate-of-component',
@@ -14,9 +17,11 @@ import { PhaseService } from '../../../core/services/phase.service';
   styleUrls: ['./duplicate-of.component.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class DuplicateOfComponent implements OnInit {
+export class DuplicateOfComponent implements OnInit, OnDestroy {
   isEditing = false;
   duplicatedIssueList: Observable<Issue[]>;
+  searchFilterCtrl: FormControl = new FormControl();
+  filteredDuplicateIssueList: ReplaySubject<Issue[]> = new ReplaySubject<Issue[]>(1);
 
   @Input() issue: Issue;
 
@@ -24,6 +29,9 @@ export class DuplicateOfComponent implements OnInit {
 
   @ViewChild(MatSelect, { static: true }) duplicateOfSelection: MatSelect;
   @ViewChild(MatCheckbox, { static: true }) duplicatedCheckbox: MatCheckbox;
+
+  // A subject that will emit a signal when this component is being destroyed
+  private _onDestroy = new Subject<void>();
 
   // Max chars visible for a duplicate entry in duplicates dropdown list.
   readonly MAX_TITLE_LENGTH_FOR_DUPLICATE_ISSUE = 17;
@@ -52,8 +60,22 @@ export class DuplicateOfComponent implements OnInit {
     return issue.title.length > maxTitleLength;
   }
 
+  ngOnDestroy(): void {
+    this._onDestroy.next(); // Emits the destroy signal
+    this._onDestroy.complete();
+  }
+
   ngOnInit() {
     this.duplicatedIssueList = this.getDupIssueList();
+    // Populate the filtered list with all the issues first
+    this.duplicatedIssueList.pipe(first()).subscribe((issues) => this.filteredDuplicateIssueList.next(issues));
+    this.searchFilterCtrl.valueChanges.pipe(takeUntil(this._onDestroy)).subscribe((_) => this.filterIssues());
+  }
+
+  filterIssues(): void {
+    this.changeFilter(this.duplicatedIssueList, this.searchFilterCtrl.value).subscribe((issues) =>
+      this.filteredDuplicateIssueList.next(issues)
+    );
   }
 
   updateDuplicateStatus(event: MatSelectChange) {
@@ -116,6 +138,20 @@ export class DuplicateOfComponent implements OnInit {
     }
     clone.issueComment.description = clone.createGithubTeamResponse();
     return clone;
+  }
+
+  changeFilter(issuesObservable: Observable<Issue[]>, searchInputString): Observable<Issue[]> {
+    return issuesObservable.pipe(
+      first(),
+      map((issues) => {
+        return applySearchFilter(
+          searchInputString,
+          [TABLE_COLUMNS.ID, TABLE_COLUMNS.DUPLICATED_ISSUES, TABLE_COLUMNS.TITLE],
+          this.issueService,
+          issues
+        );
+      })
+    );
   }
 
   private getDupIssueList(): Observable<Issue[]> {

--- a/src/app/shared/issue/issue-components.module.ts
+++ b/src/app/shared/issue/issue-components.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { MatProgressBarModule } from '@angular/material';
 import { MarkdownModule } from 'ngx-markdown';
+import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { CommentEditorModule } from '../comment-editor/comment-editor.module';
 import { SharedModule } from '../shared.module';
 import { AssigneeComponent } from './assignee/assignee.component';
@@ -13,7 +14,7 @@ import { TitleComponent } from './title/title.component';
 import { UnsureCheckboxComponent } from './unsure-checkbox/unsure-checkbox.component';
 
 @NgModule({
-  imports: [SharedModule, CommentEditorModule, MatProgressBarModule, MarkdownModule.forChild()],
+  imports: [SharedModule, CommentEditorModule, MatProgressBarModule, NgxMatSelectSearchModule, MarkdownModule.forChild()],
   declarations: [
     TitleComponent,
     DescriptionComponent,

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -17,7 +17,18 @@
 
           <mat-form-field [style.visibility]="!duplicated.value ? 'hidden' : 'visible'" style="display: inline-block; width: 50%">
             <mat-select formControlName="duplicateOf" placeholder="Duplicate of">
-              <mat-option *ngFor="let issue of duplicatedIssueList | async" [disabled]="dupIssueOptionIsDisabled(issue)" [value]="issue.id">
+              <mat-option>
+                <ngx-mat-select-search
+                  placeholderLabel="Search issues"
+                  noEntriesFoundLabel="No issues found"
+                  [formControl]="searchFilterCtrl"
+                ></ngx-mat-select-search>
+              </mat-option>
+              <mat-option
+                *ngFor="let issue of filteredDuplicateIssueList | async"
+                [disabled]="dupIssueOptionIsDisabled(issue)"
+                [value]="issue.id"
+              >
                 <span class="mat-body-strong"> #{{ issue.id }}: </span> <span class="mat-body">{{ issue.title }}</span>
                 <span *ngIf="dupIssueOptionIsDisabled(issue)" class="mat-caption" style="color: #f44336">
                   ({{ getDisabledDupOptionErrorText(issue) }})

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -89,12 +89,7 @@ export class NewTeamResponseComponent implements OnInit, OnDestroy {
     return issuesObservable.pipe(
       first(),
       map((issues) => {
-        return applySearchFilter(
-          searchInputString,
-          [TABLE_COLUMNS.ID, TABLE_COLUMNS.DUPLICATED_ISSUES, TABLE_COLUMNS.TITLE],
-          this.issueService,
-          issues
-        );
+        return applySearchFilter(searchInputString, [TABLE_COLUMNS.ID, TABLE_COLUMNS.TITLE], this.issueService, issues);
       })
     );
   }

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -1,9 +1,9 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FormBuilder, FormGroup, NgForm, Validators } from '@angular/forms';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, NgForm, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material';
 import { MatCheckboxChange } from '@angular/material/checkbox';
-import { Observable, throwError } from 'rxjs';
-import { finalize, flatMap, map } from 'rxjs/operators';
+import { Observable, ReplaySubject, Subject, throwError } from 'rxjs';
+import { finalize, first, flatMap, map, takeUntil } from 'rxjs/operators';
 import { IssueComment } from '../../../core/models/comment.model';
 import { Conflict } from '../../../core/models/conflict/conflict.model';
 import { Issue, SEVERITY_ORDER, STATUS } from '../../../core/models/issue.model';
@@ -11,6 +11,8 @@ import { ErrorHandlingService } from '../../../core/services/error-handling.serv
 import { IssueService } from '../../../core/services/issue.service';
 import { LabelService } from '../../../core/services/label.service';
 import { PhaseService } from '../../../core/services/phase.service';
+import { TABLE_COLUMNS } from '../../issue-tables/issue-tables-columns';
+import { applySearchFilter } from '../../issue-tables/search-filter';
 import { SUBMIT_BUTTON_TEXT } from '../view-issue.component';
 import { ConflictDialogComponent } from './conflict-dialog/conflict-dialog.component';
 
@@ -19,11 +21,13 @@ import { ConflictDialogComponent } from './conflict-dialog/conflict-dialog.compo
   templateUrl: './new-team-response.component.html',
   styleUrls: ['./new-team-response.component.css']
 })
-export class NewTeamResponseComponent implements OnInit {
+export class NewTeamResponseComponent implements OnInit, OnDestroy {
   newTeamResponseForm: FormGroup;
   teamMembers: string[];
   duplicatedIssueList: Observable<Issue[]>;
   conflict: Conflict;
+  searchFilterCtrl: FormControl = new FormControl();
+  filteredDuplicateIssueList: ReplaySubject<Issue[]> = new ReplaySubject<Issue[]>(1);
 
   isFormPending = false;
 
@@ -31,6 +35,9 @@ export class NewTeamResponseComponent implements OnInit {
 
   @Input() issue: Issue;
   @Output() issueUpdated = new EventEmitter<Issue>();
+
+  // A subject that will emit a signal when this component is being destroyed
+  private _onDestroy = new Subject<void>();
 
   constructor(
     public issueService: IssueService,
@@ -46,6 +53,9 @@ export class NewTeamResponseComponent implements OnInit {
       return member.loginId;
     });
     this.duplicatedIssueList = this.getDupIssueList();
+    // Populate the filtered list with all the issues first
+    this.duplicatedIssueList.pipe(first()).subscribe((issues) => this.filteredDuplicateIssueList.next(issues));
+    this.searchFilterCtrl.valueChanges.pipe(takeUntil(this._onDestroy)).subscribe((_) => this.filterIssues());
     this.newTeamResponseForm = this.formBuilder.group({
       description: [''],
       severity: [this.issue.severity, Validators.required],
@@ -67,6 +77,31 @@ export class NewTeamResponseComponent implements OnInit {
       this.responseTag.updateValueAndValidity();
     });
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SUBMIT;
+  }
+
+  private filterIssues(): void {
+    this.changeFilter(this.duplicatedIssueList, this.searchFilterCtrl.value).subscribe((issues) =>
+      this.filteredDuplicateIssueList.next(issues)
+    );
+  }
+
+  private changeFilter(issuesObservable: Observable<Issue[]>, searchInputString): Observable<Issue[]> {
+    return issuesObservable.pipe(
+      first(),
+      map((issues) => {
+        return applySearchFilter(
+          searchInputString,
+          [TABLE_COLUMNS.ID, TABLE_COLUMNS.DUPLICATED_ISSUES, TABLE_COLUMNS.TITLE],
+          this.issueService,
+          issues
+        );
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this._onDestroy.next(); // Emits the destroy signal
+    this._onDestroy.complete();
   }
 
   submitNewTeamResponse(form: NgForm) {
@@ -154,7 +189,7 @@ export class NewTeamResponseComponent implements OnInit {
       if (SEVERITY_ORDER[this.severity.value] > SEVERITY_ORDER[issue.severity]) {
         reason.push('Issue of lower priority');
       } else if (issue.duplicated || !!issue.duplicateOf) {
-        reason.push('A duplicated issue');
+        reason.push('Duplicate of #' + issue.duplicateOf);
       }
     }
     return reason.join(', ');

--- a/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MarkdownModule } from 'ngx-markdown';
+import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { CommentEditorModule } from '../../comment-editor/comment-editor.module';
 import { IssueComponentsModule } from '../../issue/issue-components.module';
 import { LabelDropdownModule } from '../../label-dropdown/label-dropdown.module';
@@ -11,7 +12,15 @@ import { NewTeamResponseComponent } from './new-team-response.component';
 @NgModule({
   exports: [NewTeamResponseComponent, ConflictDialogComponent],
   declarations: [NewTeamResponseComponent, ConflictDialogComponent],
-  imports: [CommonModule, CommentEditorModule, SharedModule, IssueComponentsModule, LabelDropdownModule, MarkdownModule.forChild()],
+  imports: [
+    CommonModule,
+    CommentEditorModule,
+    SharedModule,
+    IssueComponentsModule,
+    LabelDropdownModule,
+    MarkdownModule.forChild(),
+    NgxMatSelectSearchModule
+  ],
   entryComponents: [ConflictDialogComponent]
 })
 export class NewTeamResponseModule {}


### PR DESCRIPTION
### Summary:
Fixes #873

### Changes Made:
- [X] Add a search bar to the selection menu so that users can search for the issues that they want to mark as duplicate. (This uses a [third-party component](https://github.com/bithost-gmbh/ngx-mat-select-search).)
![search-select](https://user-images.githubusercontent.com/47494777/155889947-d1d854bb-130e-45b6-9d79-a81473501762.gif)
- [X] Change the disabled error text for issues that have already been duplicated to `Duplicate of #ISSUE_NUMBER` instead of `A duplicated issue`.
- ~~To remove duplicated code in duplicate-of component and new-team-response component.~~ (Todo in another PR)

### Proposed Commit Message:
```
Improve Duplicate Issue Search in Team Response Phase

Choosing an issue as the parent of a duplicate issue can be
challenging. Users can receive close to a hundred issues in
the Team Response Phase so they would need to scroll
through everything to find the correct issue.

Let's add a search bar in the selection dropdown menu for
users to search for the parent issue by name or ID. Also, let's
include the ID of the parent duplicate issue for issues that
has already been duplicated, to ease the finding of the parent
issue.
```
