### PR TITLE
Abstract code to find comments that match a template to the Template class

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -135,7 +135,7 @@ export class Issue {
     issue.teamAssigned = teamData;
     issue.assignees = githubIssue.assignees.map((assignee) => assignee.login);
 
-    issue.teamResponseError = template.parseError;
+    issue.teamResponseError = template.parseFailure;
     issue.issueComment = template.comment;
     issue.teamResponse = template.teamResponse && Issue.updateTeamResponse(template.teamResponse.content);
     issue.duplicateOf = template.duplicateOf && template.duplicateOf.issueNumber;
@@ -150,7 +150,7 @@ export class Issue {
     const teamAcceptedTemplate = new TeamAcceptedTemplate(githubIssue.comments);
 
     issue.githubComments = githubIssue.comments;
-    issue.testerResponseError = testerResponseTemplate.parseError && !teamAcceptedTemplate.teamAccepted;
+    issue.testerResponseError = testerResponseTemplate.parseFailure && teamAcceptedTemplate.parseFailure;
     issue.teamAccepted = teamAcceptedTemplate.teamAccepted;
     issue.issueComment = testerResponseTemplate.comment;
     issue.teamResponse = testerResponseTemplate.teamResponse && Issue.updateTeamResponse(testerResponseTemplate.teamResponse.content);

--- a/src/app/core/models/templates/team-accepted-template.model.ts
+++ b/src/app/core/models/templates/team-accepted-template.model.ts
@@ -12,7 +12,7 @@ export class TeamAcceptedTemplate extends Template {
 
     this.findConformingComment(githubComments);
 
-    if (this.getParseFailure()) {
+    if (this.parseFailure) {
       return;
     }
 

--- a/src/app/core/models/templates/team-accepted-template.model.ts
+++ b/src/app/core/models/templates/team-accepted-template.model.ts
@@ -7,12 +7,12 @@ export const TeamAcceptedHeader = { teamAccepted: new Header(TeamAcceptedMessage
 export class TeamAcceptedTemplate extends Template {
   teamAccepted?: boolean;
 
-  constructor(githubIssueComments: GithubComment[]) {
+  constructor(githubComments: GithubComment[]) {
     super(Object.values(TeamAcceptedHeader));
 
-    const teamAcceptedComment = githubIssueComments.find((comment) => this.test(comment.body));
+    this.findConformingComment(githubComments);
 
-    if (teamAcceptedComment === undefined) {
+    if (this.getParseFailure()) {
       return;
     }
 

--- a/src/app/core/models/templates/team-response-template.model.ts
+++ b/src/app/core/models/templates/team-response-template.model.ts
@@ -13,15 +13,13 @@ export class TeamResponseTemplate extends Template {
   teamResponse: Section;
   duplicateOf: DuplicateOfSection;
   comment: IssueComment;
-  parseError: boolean;
 
   constructor(githubComments: GithubComment[]) {
     super(Object.values(TeamResponseHeaders));
 
     const templateConformingComment = this.findConformingComment(githubComments);
 
-    if (this.getParseFailure()) {
-      this.parseError = true;
+    if (this.parseFailure) {
       return;
     }
 

--- a/src/app/core/models/templates/team-response-template.model.ts
+++ b/src/app/core/models/templates/team-response-template.model.ts
@@ -19,10 +19,12 @@ export class TeamResponseTemplate extends Template {
     super(Object.values(TeamResponseHeaders));
 
     const templateConformingComment = this.findConformingComment(githubComments);
+
     if (this.getParseFailure()) {
       this.parseError = true;
       return;
     }
+
     this.comment = <IssueComment>{
       ...templateConformingComment,
       description: templateConformingComment.body,

--- a/src/app/core/models/templates/team-response-template.model.ts
+++ b/src/app/core/models/templates/team-response-template.model.ts
@@ -18,18 +18,18 @@ export class TeamResponseTemplate extends Template {
   constructor(githubComments: GithubComment[]) {
     super(Object.values(TeamResponseHeaders));
 
-    const comment = githubComments.find((githubComment: GithubComment) => this.test(githubComment.body));
-    if (comment === undefined) {
+    const templateConformingComment = this.findConformingComment(githubComments);
+    if (this.getParseFailure()) {
       this.parseError = true;
       return;
     }
     this.comment = <IssueComment>{
-      ...comment,
-      description: comment.body,
-      createdAt: comment.created_at,
-      updatedAt: comment.updated_at
+      ...templateConformingComment,
+      description: templateConformingComment.body,
+      createdAt: templateConformingComment.created_at,
+      updatedAt: templateConformingComment.updated_at
     };
-    const commentsContent: string = comment.body;
+    const commentsContent: string = templateConformingComment.body;
     this.teamResponse = this.parseTeamResponse(commentsContent);
     this.duplicateOf = this.parseDuplicateOf(commentsContent);
   }

--- a/src/app/core/models/templates/template.model.ts
+++ b/src/app/core/models/templates/template.model.ts
@@ -43,10 +43,6 @@ export abstract class Template {
     }
     return templateConformingComment;
   }
-
-  getParseFailure(): boolean {
-    return this.parseFailure;
-  }
 }
 
 export class Header {

--- a/src/app/core/models/templates/template.model.ts
+++ b/src/app/core/models/templates/template.model.ts
@@ -1,8 +1,10 @@
+import { GithubComment } from '../github/github-comment.model';
 import { SectionalDependency } from './sections/section.model';
 
 export abstract class Template {
   headers: Header[];
   regex: RegExp;
+  parseFailure: boolean;
 
   protected constructor(headers: Header[]) {
     this.headers = headers;
@@ -29,6 +31,21 @@ export abstract class Template {
     }
     this.regex.lastIndex = 0;
     return numOfMatch >= this.headers.length;
+  }
+
+  /**
+   * Finds a comment that conforms to the template
+   */
+  findConformingComment(githubComments: GithubComment[]): GithubComment {
+    const templateConformingComment = githubComments.find((githubComment) => this.test(githubComment.body));
+    if (templateConformingComment === undefined) {
+      this.parseFailure = true;
+    }
+    return templateConformingComment;
+  }
+
+  getParseFailure(): boolean {
+    return this.parseFailure;
   }
 }
 

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -16,15 +16,13 @@ export class TesterResponseTemplate extends Template {
   comment: IssueComment;
   teamChosenSeverity?: string;
   teamChosenType?: string;
-  parseError: boolean;
 
   constructor(githubComments: GithubComment[]) {
     super(Object.values(TesterResponseHeaders));
 
     const templateConformingComment = this.findConformingComment(githubComments);
 
-    if (this.getParseFailure()) {
-      this.parseError = true;
+    if (this.parseFailure) {
       return;
     }
 

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -18,11 +18,11 @@ export class TesterResponseTemplate extends Template {
   teamChosenType?: string;
   parseError: boolean;
 
-  constructor(githubIssueComments: GithubComment[]) {
+  constructor(githubComments: GithubComment[]) {
     super(Object.values(TesterResponseHeaders));
 
-    const templateConformingComment = githubIssueComments.find((comment) => this.test(comment.body));
-    if (templateConformingComment === undefined) {
+    const templateConformingComment = this.findConformingComment(githubComments);
+    if (this.getParseFailure()) {
       this.parseError = true;
       return;
     }

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -22,6 +22,7 @@ export class TesterResponseTemplate extends Template {
     super(Object.values(TesterResponseHeaders));
 
     const templateConformingComment = this.findConformingComment(githubComments);
+
     if (this.getParseFailure()) {
       this.parseError = true;
       return;

--- a/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
@@ -16,7 +16,7 @@ export class TutorModerationTodoTemplate extends Template {
 
     const templateConformingComment = this.findConformingComment(githubComments);
 
-    if (this.getParseFailure()) {
+    if (this.parseFailure) {
       return;
     }
 

--- a/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
+++ b/src/app/core/models/templates/tutor-moderation-todo-template.model.ts
@@ -14,14 +14,17 @@ export class TutorModerationTodoTemplate extends Template {
   constructor(githubComments: GithubComment[]) {
     super(Object.values(tutorModerationTodoHeaders));
 
-    const templateConformingComment = githubComments.find((comment) => this.test(comment.body));
-    if (templateConformingComment) {
-      this.comment = <IssueComment>{
-        ...templateConformingComment,
-        description: templateConformingComment.body
-      };
-      this.moderation = this.parseModeration(this.comment.description);
+    const templateConformingComment = this.findConformingComment(githubComments);
+
+    if (this.getParseFailure()) {
+      return;
     }
+
+    this.comment = <IssueComment>{
+      ...templateConformingComment,
+      description: templateConformingComment.body
+    };
+    this.moderation = this.parseModeration(this.comment.description);
   }
 
   parseModeration(toParse: string): ModerationSection {


### PR DESCRIPTION
### Summary:
Fixes #903

### Changes Made:
* Create `findConformingComment` method in `Template` class
* Add new attribute `parseFailure` in `Template` class
* Use `findConformingComment` and `parseFailure` in template subclasses
* Standardise some variable names across template subclasses
* Refactor `TutorModerationTodoTemplate` to use guard clause
* Remove `parseError` attribute from `TeamResponseTemplate` and `TesterResponseTemplate`
* Use `parseFailure` in `Issue` instead of `parseError`

### Proposed Commit Message:
```
Abstract code to find comments that match a template to superclass

There is some duplicated code across 4 templates that deal with finding
a comment that conforms to the comment template. 

Let's abstract this code into the Template superclass and create a new
parseFailure attribute inside Template. Let's also use this opportunity
to standardise the variable names across the templates. Lastly, let's
use parseFailure in Issue. 
```
