### PR TITLE
[Experimental]: Use Github markdown API for previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "diff-match-patch": "^1.0.4",
     "dompurify": "^2.3.1",
     "electron-log": "^4.4.1",
+    "github-markdown-css": "^5.1.0",
     "graphql": "^14.6.0",
     "graphql-tag": "2.11.0",
     "karma-spec-reporter": "0.0.32",

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -405,6 +405,16 @@ export class GithubService {
     return ORG_NAME.concat('/').concat(REPO);
   }
 
+  convertMarkdown(text: string): Observable<any> {
+    return from<string>(
+      octokit.markdown.render({
+        text,
+        mode: 'gfm',
+        context: this.getRepoURL()
+      })
+    );
+  }
+
   viewIssueInBrowser(id: number, event: Event) {
     if (id) {
       this.electronService.openLink('https://github.com/'.concat(this.getRepoURL()).concat('/issues/').concat(String(id)));

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="commentForm" style="min-height: 350px">
-  <mat-tab-group class="mat-elevation-z1" animationDuration="0ms">
+  <mat-tab-group class="mat-elevation-z1" animationDuration="0ms" (selectedTabChange)="handleTabChange($event)">
     <mat-tab label="Write">
       <div
         #dropArea
@@ -45,10 +45,12 @@
       </div>
     </mat-tab>
     <mat-tab label="Preview">
-      <div class="tab-content" style="min-height: 228px">
-        <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)"></markdown>
-        <div *ngIf="commentField.value === ''">Nothing to preview.</div>
-      </div>
+      <ng-template matTabContent>
+        <div class="tab-content" style="min-height: 228px">
+          <article class="markdown-body" *ngIf="commentField.value !== ''" [innerHTML]="convertedValue"></article>
+          <div *ngIf="commentField.value === ''">Nothing to preview.</div>
+        </div>
+      </ng-template>
     </mat-tab>
   </mat-tab-group>
 </form>


### PR DESCRIPTION
### Summary:
Fixes #916
This will solve almost all markdown related issues listed in there, with the exception of issue #820 (embedding video in editor).

Furthermore, this PR will unintentionally introduce a new feature: autolinks. In github issue and pr posts, if you type `#` followed by a number, github will automatically convert that to a link to the corresponding issue or PR in the same repository. This feature will be made possible with the use of github markdown API.

### Changes Made:
- [X] Use Github API to convert raw markdown text to html for previews
- [ ] Same as above, but for actual content displayed
- [X] Apply the same CSS as github

### Proposed Commit Message:
```
// TODO
Commit message to be used when the PR is merged
(NOTE: Wrap the body at 72 characters)
```
