### PR TITLE
Fix duplicate select error message

### DIFF
--- a/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
+++ b/src/app/shared/issue/duplicateOf/duplicate-of.component.ts
@@ -91,7 +91,7 @@ export class DuplicateOfComponent implements OnInit, OnDestroy {
   }
 
   getDisabledDupOptionErrorText(issue: Issue): string {
-    return this.dupIssueOptionIsDisabled(issue) ? 'A duplicated issue' : '';
+    return this.dupIssueOptionIsDisabled(issue) ? 'Duplicate of #' + issue.duplicateOf : '';
   }
 
   handleCheckboxChange(event) {

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.ts
@@ -179,7 +179,7 @@ export class NewTeamResponseComponent implements OnInit, OnDestroy {
   }
 
   getDisabledDupOptionErrorText(issue: Issue): string {
-    return this.dupIssueOptionIsDisabled(issue) ? 'A duplicated issue' : '';
+    return this.dupIssueOptionIsDisabled(issue) ? 'Duplicate of #' + issue.duplicateOf : '';
   }
 
   handleChangeOfDuplicateCheckbox(event: MatCheckboxChange) {


### PR DESCRIPTION
### Summary:
Fixes #873 that was affected by PR #913.

### Changes Made:
* Change duplicate error text to show the duplicate issue number

### Proposed Commit Message:
```
Fix duplicate select error message

A previous PR caused the duplicate error text message in the selection menu
to be rolled back to the old message.

Let's change it back so that the message becomes 'Duplicate of #x'.
```
