### PR TITLE
[Experimental] Enable persistent login access for CATcher

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -62,6 +62,7 @@ export class AuthComponent implements OnInit, OnDestroy {
     const state = this.activatedRoute.snapshot.queryParamMap.get('state');
 
     if (this.authService.isAuthenticated()) {
+      this.currentUserName = this.userService.currentUser.loginId;
       this.router.navigate([this.phaseService.currentPhase]);
       return;
     }

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -189,7 +189,8 @@ export class AuthComponent implements OnInit, OnDestroy {
   private initAccessTokenSubscription() {
     this.accessTokenSubscription = this.authService.accessToken
       .pipe(
-        filter((token: string) => !!token),
+        // Ensure token is non-empty and user is starting a new login session
+        filter((token: string) => !!token && !this.authService.isProcessingAutoLogin.getValue()),
         flatMap(() => this.userService.getAuthenticatedUser())
       )
       .subscribe((user: GithubUser) => {

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, CanLoad, Route, Router, RouterStateSnapshot, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs';
+import { filter, first, map, single, tap } from 'rxjs/operators';
 import { AuthService } from '../services/auth.service';
 
 @Injectable({
@@ -10,6 +11,18 @@ export class AuthGuard implements CanActivate, CanLoad {
   constructor(private auth: AuthService, private router: Router) {}
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    if (this.auth.isProcessingAutoLogin.getValue()) {
+      return this.auth.isProcessingAutoLogin.pipe(
+        filter((val) => !val), // wait until it is no longer processing,
+        first(),
+        map(() => this.auth.isAuthenticated()),
+        tap((isAuth) => {
+          if (!isAuth) {
+            this.router.navigate(['']);
+          }
+        })
+      );
+    }
     if (this.auth.isAuthenticated()) {
       return true;
     } else {
@@ -19,6 +32,17 @@ export class AuthGuard implements CanActivate, CanLoad {
   }
 
   canLoad(route: Route, segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean {
+    if (this.auth.isProcessingAutoLogin.getValue()) {
+      return this.auth.isProcessingAutoLogin.pipe(
+        single((val) => !val), // wait until it is no longer processing,
+        map(() => this.auth.isAuthenticated()),
+        tap((isAuth) => {
+          if (!isAuth) {
+            this.router.navigate(['']);
+          }
+        })
+      );
+    }
     if (this.auth.isAuthenticated()) {
       return true;
     } else {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -420,6 +420,10 @@ export class GithubService {
     this.issueQueryRefs.clear();
   }
 
+  removeAuth(): void {
+    octokit = new Octokit();
+  }
+
   getProfilesData(): Promise<Response> {
     return fetch(AppConfig.clientDataUrl);
   }


### PR DESCRIPTION
### Summary:
Fixes the issue of CATcher not having any persistent logins. This means that users will have to constantly get a new access token from github via the gatekeeper backend server, whenever the user refreshes the page. If the user does this frequently, Github might detect too many logins at the same time and request the user to reauthenticate themselves.

### Changes Made:
- [X] Stores the access token in Local Storage (Note that this is not a secure way to store, because it is vulnerable to XSS)
- [ ] Store token in a more secure location (to be discussed)
- [ ] Redirect users to the same page if refreshed, instead of going to the confirming login page.

### Proposed Commit Message:
```
Enable persistent login access for CATcher

CATcher does not have any persistent user authentication feature.
Currently, users will have to constantly log in and request a new
access token each time they refresh or open the CATcher web app.
Doing so frequently can cause Github to detect too many logins in
a short time. It also cause inconvenience to users.

Let's save the access token somewhere secure so that users can
reuse the access token each time they access the CATcher web app.
```
