### PR TITLE
Hotfix: Remove Assignees Check

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -274,7 +274,7 @@ export class GithubService {
       map((assignables: string[]) =>
         assignees.forEach((assignee) => {
           if (!assignables.includes(assignee)) {
-            throw new Error(`Cannot assign ${assignee} to the issue. Please check if ${assignee} is authorized.`);
+            // throw new Error(`Cannot assign ${assignee} to the issue. Please check if ${assignee} is authorized.`);
           }
         })
       )


### PR DESCRIPTION
### Summary:
Hotfixes for now #925

### Changes Made:
* Due to a bug with the retrieval of the assignees, where the first 30 assignees are only retrieved.
As a result, those after the first 30 assignees will be determined as "unauthorized" 
* The error to be thrown is remove for now. However, a proper fix for this will to be to fetch all the 
issues together 

### Proposed Commit Message:
```
Hotfix: Remove Assignees Check

There is a bug with the retrieval of the assignees where not all 
assignees are retrieved, causing unwanted errors to be thrown. 

Let's hotfix this temporarily be removing the errors to be thrown 
and do a proper fix in the next official release. 
```
