### PR TITLE
Fix unauthorized assignee bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "main": "main.js",
   "scripts": {
     "postinstall": "npm run postinstall:electron && electron-builder install-app-deps",

--- a/src/app/auth/confirm-login/confirm-login.component.ts
+++ b/src/app/auth/confirm-login/confirm-login.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { flatMap } from 'rxjs/operators';
+import { Phase } from '../../core/models/phase.model';
 import { AuthService, AuthState } from '../../core/services/auth.service';
 import { ElectronService } from '../../core/services/electron.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
@@ -55,10 +56,17 @@ export class ConfirmLoginComponent implements OnInit {
    * Will complete the process of logging in the given user.
    */
   completeLoginProcess(): void {
+    const hasTeamResponsePhase = this.phaseService.sessionData.openPhases.includes(Phase.phaseTeamResponse);
     this.authService.changeAuthState(AuthState.AwaitingAuthentication);
     this.phaseService.setPhaseOwners(this.currentSessionOrg, this.username);
-    this.userService
-      .createUserModel(this.username)
+    (hasTeamResponsePhase
+      ? this.userService.createUserModel(
+          this.username,
+          this.phaseService.getPhaseOwner(Phase.phaseTeamResponse),
+          this.phaseService.sessionData.phaseTeamResponse
+        )
+      : this.userService.createUserModel(this.username)
+    )
       .pipe(
         flatMap(() => this.phaseService.sessionSetup()),
         flatMap(() => this.githubEventService.setLatestChangeEvent())

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -262,6 +262,7 @@ export class GithubService {
   /**
    * Checks if the given list of users are allowed to be assigned to an issue during Team Response Phase.
    * @param assignees - GitHub usernames to be checked
+   * @return Observable of array of users who are not assignable
    */
   areUsersAssignable(assignees: string[], teamResponseOwner: string, teamResponseRepo: string): Observable<string[]> {
     let responseInFirstPage: GithubResponse<any>;

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, EMPTY, forkJoin, Observable, of, Subscription, throwError, timer } from 'rxjs';
+import { BehaviorSubject, EMPTY, forkJoin, Observable, of, Subscription, timer } from 'rxjs';
 import { catchError, exhaustMap, finalize, flatMap, map } from 'rxjs/operators';
 import { IssueComment } from '../models/comment.model';
 import { GithubComment } from '../models/github/github-comment.model';
@@ -134,11 +134,6 @@ export class IssueService {
       .pipe(map((response: GithubIssue) => this.createIssueModel(response)));
   }
 
-  updateIssueWithAssigneeCheck(issue: Issue): Observable<Issue> {
-    const assignees = this.phaseService.currentPhase === Phase.phaseModeration ? [] : issue.assignees;
-    return this.githubService.areUsersAssignable(assignees).pipe(flatMap(() => this.updateIssue(issue)));
-  }
-
   updateIssue(issue: Issue): Observable<Issue> {
     const assignees = this.phaseService.currentPhase === Phase.phaseModeration ? [] : issue.assignees;
     return this.githubService
@@ -190,16 +185,11 @@ export class IssueService {
 
   createTeamResponse(issue: Issue): Observable<Issue> {
     const teamResponse = issue.createGithubTeamResponse();
-    return this.githubService.areUsersAssignable(issue.assignees || []).pipe(
-      flatMap(() =>
-        this.githubService.createIssueComment(issue.id, teamResponse).pipe(
-          flatMap((githubComment: GithubComment) => {
-            issue.githubComments = [githubComment, ...issue.githubComments.filter((c) => c.id !== githubComment.id)];
-            return this.updateIssue(issue);
-          })
-        )
-      ),
-      catchError((err) => throwError(err))
+    return this.githubService.createIssueComment(issue.id, teamResponse).pipe(
+      flatMap((githubComment: GithubComment) => {
+        issue.githubComments = [githubComment, ...issue.githubComments.filter((c) => c.id !== githubComment.id)];
+        return this.updateIssue(issue);
+      })
     );
   }
 

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -152,6 +152,10 @@ export class MockGithubService {
     return Promise.resolve(mockResponse);
   }
 
+  areUsersAssignable(assignees: string[], teamResponseOwner: string, teamResponseRepo: string) {
+    return of([]);
+  }
+
   reset(): void {
     // Function currently exists to prevent errors when logout is clicked and
     // services reset.

--- a/src/app/shared/issue/assignee/assignee.component.ts
+++ b/src/app/shared/issue/assignee/assignee.component.ts
@@ -54,7 +54,7 @@ export class AssigneeComponent implements OnInit {
     const newIssue = this.issue.clone(this.phaseService.currentPhase);
     const oldAssignees = newIssue.assignees;
     newIssue.assignees = this.assignees;
-    this.issueService.updateIssueWithAssigneeCheck(newIssue).subscribe(
+    this.issueService.updateIssue(newIssue).subscribe(
       (updatedIssue: Issue) => {
         this.issueUpdated.emit(updatedIssue);
         // Update assignees of duplicate issues

--- a/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
+++ b/tests/app/phase-team-response/issues-faulty/issues-faulty.component.spec.ts
@@ -11,7 +11,7 @@ describe('IssuesFaultyComponent', () => {
     const dummyIssue = Issue.createPhaseTeamResponseIssue(ISSUE_WITH_EMPTY_DESCRIPTION, dummyTeam);
     let issueService: IssueService;
     let issuesFaultyComponent: IssuesFaultyComponent;
-    const userService = new UserService(null, null);
+    const userService = new UserService(null, null, null);
     userService.currentUser = USER_Q;
     const DUMMY_DUPLICATE_ISSUE_ID = 1;
     const DUMMY_RESPONSE = 'dummy response';

--- a/tests/app/phase-team-response/issues-pending/issues-pending.component.spec.ts
+++ b/tests/app/phase-team-response/issues-pending/issues-pending.component.spec.ts
@@ -12,7 +12,7 @@ describe('IssuesPendingComponent', () => {
     let dummyIssue: Issue;
     let issuesPendingComponent: IssuesPendingComponent;
     const issueService: IssueService = new IssueService(null, null, null, null, null);
-    const userService: UserService = new UserService(null, null);
+    const userService: UserService = new UserService(null, null, null);
     userService.currentUser = USER_Q;
     const DUMMY_DUPLICATE_ISSUE_ID = 1;
     const DUMMY_RESPONSE = 'dummy response';

--- a/tests/app/phase-team-response/issues-responded/issues-responded.component.spec.ts
+++ b/tests/app/phase-team-response/issues-responded/issues-responded.component.spec.ts
@@ -13,7 +13,7 @@ describe('IssuesRespondedComponent', () => {
     let dummyIssue: Issue;
 
     const issueService = new IssueService(null, null, null, null, null);
-    const userService = new UserService(null, null);
+    const userService = new UserService(null, null, null);
     userService.currentUser = USER_Q;
     const issuesRespondedComponent = new IssuesRespondedComponent(issueService, userService);
     issuesRespondedComponent.ngOnInit();

--- a/tests/app/shared/issue/assignee/assignee.component.spec.ts
+++ b/tests/app/shared/issue/assignee/assignee.component.spec.ts
@@ -51,12 +51,7 @@ describe('AssigneeComponent', () => {
   });
 
   const phaseService: any = jasmine.createSpyObj('PhaseService', [], { currentPhase: Phase.phaseTeamResponse });
-  const issueService: any = jasmine.createSpyObj('IssueService', [
-    'getDuplicateIssuesFor',
-    'getLatestIssue',
-    'updateIssue',
-    'updateIssueWithAssigneeCheck'
-  ]);
+  const issueService: any = jasmine.createSpyObj('IssueService', ['getDuplicateIssuesFor', 'getLatestIssue', 'updateIssue']);
   const permissionsService: any = jasmine.createSpyObj('PermissionService', ['isIssueLabelsEditable']);
 
   beforeEach(async(() => {
@@ -131,7 +126,7 @@ describe('AssigneeComponent', () => {
     const updatedDuplicateIssue = duplicateIssue.clone(phaseService.currentPhase);
     updatedDuplicateIssue.assignees = [testStudent.loginId];
 
-    expect(issueService.updateIssueWithAssigneeCheck).toHaveBeenCalledWith(updatedIssue);
+    expect(issueService.updateIssue).toHaveBeenCalledWith(updatedIssue);
     expect(issueService.updateIssue).toHaveBeenCalledWith(updatedDuplicateIssue);
   });
 
@@ -149,7 +144,7 @@ describe('AssigneeComponent', () => {
 
   function dispatchClosedEvent() {
     const matSelectElement: HTMLElement = debugElement.query(By.css('.mat-select')).nativeElement;
-    issueService.updateIssueWithAssigneeCheck.and.callFake((updatedIssue: Issue) => of(updatedIssue));
+    issueService.updateIssue.and.callFake((updatedIssue: Issue) => of(updatedIssue));
     matSelectElement.dispatchEvent(new Event('closed'));
     fixture.detectChanges();
   }

--- a/tests/services/permissions.service.spec.ts
+++ b/tests/services/permissions.service.spec.ts
@@ -19,7 +19,7 @@ const testAdmin = {
   role: UserRole.Admin
 };
 
-const mockUserService = new UserService(null, null);
+const mockUserService = new UserService(null, null, null);
 const mockPhaseService = new PhaseService(null, null, null);
 const permissionService = new PermissionService(mockUserService, mockPhaseService);
 

--- a/tests/services/repo-creator.service.spec.ts
+++ b/tests/services/repo-creator.service.spec.ts
@@ -19,7 +19,7 @@ let userService: UserService;
 
 describe('RepoCreatorService', () => {
   beforeEach(() => {
-    userService = new UserService(null, null);
+    userService = new UserService(null, null, null);
     githubService = jasmine.createSpyObj('GithubService', ['isRepositoryPresent', 'createRepository']);
     matDialog = jasmine.createSpyObj('MatDialog', ['open']);
     matDialogRef = jasmine.createSpyObj('MatDialogRef<SessionFixConfirmationComponent>', ['afterClosed']);

--- a/tests/services/user.service.spec.ts
+++ b/tests/services/user.service.spec.ts
@@ -29,7 +29,7 @@ describe('UserService', () => {
     });
 
     it('should authorize User despite loginId being of different casing', () => {
-      const userService = new UserService(null, dataService);
+      const userService = new UserService(null, dataService, null);
       userService.createUserModel(USER_JUNWEI.loginId).subscribe((user) => {
         expect(user).toBeDefined();
       });
@@ -40,7 +40,7 @@ describe('UserService', () => {
     });
 
     it('throws an error if the user is unauthorized', (done) => {
-      const userService = new UserService(null, dataService);
+      const userService = new UserService(null, dataService, null);
       userService.createUserModel('RandomUser').subscribe(
         (user) => {
           fail('This test case should have failed.');
@@ -56,7 +56,7 @@ describe('UserService', () => {
 });
 
 async function createAndVerifyUser(loginId: string, expectedUser: User) {
-  const userService = new UserService(null, dataService);
+  const userService = new UserService(null, dataService, null);
   const actualUser = await userService.createUserModel(loginId).toPromise();
   expect(actualUser).toEqual(expectedUser);
 }


### PR DESCRIPTION
### Summary:
Fixes #925 

### Changes Made:
* Call the list assignees api with 100 users per page and until all allowed assignees are returned.
* Shift the assignee checks to the log in stage, if the Team Response phase is open.
* Display any unauthorized assignees upon user login.

### Proposed Commit Message:
```
Fix unauthorized assignee bugs

Currently, the call to the list assignee github api will only check
against the first 30 allowed assignees in the repo. This is due
to Github API splitting the data into pages of no more than
100 users.

Let's do the following:
* Call the list assignees api with 100 users per page and until all
  allowed assignees are returned.
* Shift the assignee checks to the log in stage, if the Team
  Response phase is open.
* Display any unauthorized assignees upon user login.
```
