### PR TITLE
Fix #940 Deprecation - Update Codecov Action

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -6,9 +6,9 @@ name: Get Code Coverage Report
 
 on:
   push:
-    branches: [ master, release ]
+    branches: [master, release]
   pull_request:
-    branches: [ master, release ]
+    branches: [master, release]
 
 jobs:
   code-coverage:
@@ -24,6 +24,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test -- "--code-coverage"
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           directory: ./tests/coverage


### PR DESCRIPTION
### Summary:
Fixes #940

### Changes Made:
* Replace `v1` with `v3` for the Codecov GitHub Action in `coverage-report.yml`

### Proposed Commit Message:
```
Codecov Action v1 uses the deprecated Bash Uploader, which has been
replaced in subsequent versions.

Let's upgrade Codecov Action to v3.
```
