### PR TITLE
Use existing label colors in github

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -154,6 +154,18 @@ export class LabelService {
   }
 
   /**
+   * Updates the required label to be in sync with the labels on the GitHub repository.
+   */
+  public static updateRequiredLabelColor(labelColor: string, label: Label) {
+    const labelArray = LabelService.allLabelArrays[label.labelCategory];
+
+    if (labelArray) {
+      const requiredLabel = labelArray.find((requiredLabel: Label) => requiredLabel.labelValue === label.labelValue);
+      requiredLabel.labelColor = labelColor;
+    }
+  }
+
+  /**
    * Returns an custom operator which helps to
    * synchronise the labels in our application
    * with the remote repository.
@@ -269,8 +281,8 @@ export class LabelService {
         if (nameMatchedLabels[0].equals(label)) {
           // the label exists exactly as expected -> do nothing
         } else {
-          // the label exists but the color does not match
-          this.githubService.updateLabel(label.getFormattedName(), label.labelColor);
+          // the label exists but the color does not match -> update the required label's color to the one in github
+          LabelService.updateRequiredLabelColor(nameMatchedLabels[0].labelColor, label);
         }
       } else {
         throw new Error('Unexpected error: the repo has multiple labels with the same name ' + label.getFormattedName());


### PR DESCRIPTION
### Summary:
Fixes https://github.com/CATcher-org/CATcher/issues/924

Pictures:
Labels in github (one of them I changed to yellow):
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/45702380/176480783-240c8159-e4c3-41b8-8d99-a3a9d230317f.png">
Labels in CATcher (corresponding one is yellow):
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/45702380/176480880-3d5743f3-ad28-4193-8709-07b24050c299.png">

### Changes Made:
* Now if the label already exists in the repo, it uses that color instead of assigning our own color.
* If we have optional chaining(link to issue https://github.com/CATcher-org/CATcher/issues/953), it will look slightly cleaner:
```
const requiredLabel = LabelService.allLabelArrays[label.labelCategory]?.find(
  (requiredLabel: Label) => requiredLabel.labelValue === label.labelValue
);

if (requiredLabel) {
  requiredLabel.labelColor = labelColor;
}
```

### Proposed Commit Message:
```
Use existing label colors when they exist in GitHub

Currently, label colors on Github are overrided by the default required 
colors given by CATcher.
  
Let's change the required label to be in sync with the labels on 
the GitHub repository instead.
```
