### PR TITLE
Limit issue description length

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -24,10 +24,17 @@
             cdkAutosizeMaxRows="20"
             class="text-input-area"
             placeholder="{{ this.placeholderText }}"
+            maxlength="{{ this.maxLength }}"
           ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>
+          <mat-error *ngIf="commentField.errors && commentField.errors['maxLength']">
+            Description cannot exceed {{ maxLength }} characters.
+          </mat-error>
+          <mat-hint *ngIf="commentField.value?.length >= maxLength - 50">
+            {{ maxLength - commentField.value?.length }} character(s) remaining.
+          </mat-hint>
 
           <div class="drag-and-drop">
             <span *ngIf="!isInErrorState"> Attach files by dragging & dropping or select them by clicking here. </span>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -49,7 +49,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  maxLength = 40000;
+  @Input() maxLength = 40000;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -50,7 +50,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  @Input() maxLength = ISSUE_BODY_SIZE_LIMIT;
+  maxLength = ISSUE_BODY_SIZE_LIMIT;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { AbstractControl, FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup, Validators } from '@angular/forms';
 import * as DOMPurify from 'dompurify';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { LoggingService } from '../../core/services/logging.service';
@@ -49,6 +49,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
+  maxLength = 40000;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';
@@ -64,6 +65,7 @@ export class CommentEditorComponent implements OnInit {
     }
 
     this.initialSubmitButtonText = this.submitButtonText;
+    this.commentField.setValidators([Validators.maxLength(this.maxLength)]);
   }
 
   onDragEnter(event) {

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -14,6 +14,7 @@ const TIME_BETWEEN_UPLOADS_MS = 250;
 
 const MAX_UPLOAD_SIZE = (SHOWN_MAX_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 11MB to allow 10.x MB
 const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 6MB to allow 5.x MB
+const ISSUE_BODY_SIZE_LIMIT = 40000;
 
 @Component({
   selector: 'app-comment-editor',
@@ -49,7 +50,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  @Input() maxLength = 40000;
+  @Input() maxLength = ISSUE_BODY_SIZE_LIMIT;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';


### PR DESCRIPTION
### Summary:
Fixes #906 and #901

### Changes Made:
* Add a `maxLength` property to the comment-editor component class with a default value of 40000
* Assign the above value to the `maxLength` attribute of `textarea` in the template
* Add a hint label to display the number of remaining characters when the user enters more than 39949 characters

### Proposed Commit Message:
```
Limit the issue description length to 40000 characters

Currently, the character limit for issue descriptions (required
by GitHub APIs) is only validated after the user clicks submit.

Let's change it so that the character limit for issue descriptions
is imposed before submission.
```
