### PR TITLE
Remove duplication of accessTokenUrl

### DIFF
--- a/src/environments/environment.gen.ts
+++ b/src/environments/environment.gen.ts
@@ -1,4 +1,4 @@
-const BaseConfig = {
+export const BaseConfig = {
   githubUrl: 'https://github.com',
   accessTokenUrl: 'https://catcher-auth.herokuapp.com/authenticate',
   clientDataUrl: 'https://raw.githubusercontent.com/CATcher-org/client_data/master/profiles-dev.json'

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
+import { BaseConfig } from './environment.gen';
+
 const appSetting = require('../../package.json');
 
 export const AppConfig = {
@@ -6,7 +8,7 @@ export const AppConfig = {
   test: false,
   clientId: '5e1ed08cff7f0de1d68d',
   githubUrl: 'https://github.com',
-  accessTokenUrl: 'https://catcher-auth.herokuapp.com/authenticate',
+  accessTokenUrl: BaseConfig.accessTokenUrl,
   clientDataUrl: 'https://raw.githubusercontent.com/CATcher-org/client_data/master/profiles.json',
   origin: 'https://catcher-org.github.io'
 };


### PR DESCRIPTION
### Summary:
Fixes https://github.com/CATcher-org/CATcher/issues/787

### Changes Made:
* Exported our BaseConfig in environment.gen.ts and imported it in environment.prod.ts as stated in the issue.
* I thought of creating a constant variable and exporting it, but I felt that this way is cleaner because this allows us to easily see that the accessTokenUrl is part of the BaseConfig. Thoughts?

### Proposed Commit Message:
```
Remove duplication of accessTokenUrl

Previously, accessTokenUrl was in two places so we have
to change both when the url is changed.

Lets remove duplication of the accessTokenUrl to avoid
code duplication and keep a single source of truth.
```
