### PR TITLE
Add video tag to uploaded videos

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -255,10 +255,10 @@ export class CommentEditorComponent implements OnInit {
     return toInsert;
   }
 
-  private getNewCursorPosition(insertingString: string, insertedString: string) {
+  private getNewCursorPosition(filename: string, insertedString: string) {
     const cursorPosition = this.commentTextArea.nativeElement.selectionEnd;
-    const startIndexOfString = this.commentField.value.indexOf(insertingString);
-    const endIndexOfString = startIndexOfString + insertingString.length;
+    const startIndexOfString = this.commentField.value.indexOf(`[Uploading ${filename}...]`);
+    const endIndexOfString = startIndexOfString + `[Uploading ${filename}...]`.length;
     const endOfInsertedString = startIndexOfString + insertedString.length;
     const differenceInLength = endOfInsertedString - endIndexOfString;
     const newCursorPosition =
@@ -275,7 +275,7 @@ export class CommentEditorComponent implements OnInit {
     const insertedString = `<video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video>`;
     const insertingString = `[Uploading ${filename}...]`;
 
-    const newCursorPosition = this.getNewCursorPosition(insertingString, insertedString);
+    const newCursorPosition = this.getNewCursorPosition(filename, insertedString);
 
     this.commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
 
@@ -286,7 +286,7 @@ export class CommentEditorComponent implements OnInit {
     const insertedString = `[${filename}](${uploadUrl})`;
     const insertingString = `[Uploading ${filename}...]`;
 
-    const newCursorPosition = this.getNewCursorPosition(insertingString, insertedString);
+    const newCursorPosition = this.getNewCursorPosition(filename, insertedString);
 
     this.commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -257,8 +257,9 @@ export class CommentEditorComponent implements OnInit {
 
   private getNewCursorPosition(filename: string, insertedString: string) {
     const cursorPosition = this.commentTextArea.nativeElement.selectionEnd;
-    const startIndexOfString = this.commentField.value.indexOf(`[Uploading ${filename}...]`);
-    const endIndexOfString = startIndexOfString + `[Uploading ${filename}...]`.length;
+    const insertingString = `[Uploading ${filename}...]`;
+    const startIndexOfString = this.commentField.value.indexOf(insertingString);
+    const endIndexOfString = startIndexOfString + insertingString.length;
     const endOfInsertedString = startIndexOfString + insertedString.length;
     const differenceInLength = endOfInsertedString - endIndexOfString;
     const newCursorPosition =

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -277,7 +277,7 @@ export class CommentEditorComponent implements OnInit {
   }
 
   private insertUploadUrlVideo(filename: string, uploadUrl: string) {
-    const insertedString = `<video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video>`;
+    const insertedString = `<i><video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video><br>video:${uploadUrl}</i>`;
 
     this.replacePlaceholderString(filename, insertedString);
   }

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -255,7 +255,7 @@ export class CommentEditorComponent implements OnInit {
     return toInsert;
   }
 
-  private getNewCursorPosition(filename: string, insertedString: string) {
+  private replacePlaceholderString(filename: string, insertedString: string) {
     const cursorPosition = this.commentTextArea.nativeElement.selectionEnd;
     const insertingString = `[Uploading ${filename}...]`;
     const startIndexOfString = this.commentField.value.indexOf(insertingString);
@@ -269,29 +269,19 @@ export class CommentEditorComponent implements OnInit {
         ? cursorPosition
         : cursorPosition + differenceInLength; // after the uploading text
 
-    return newCursorPosition;
+    this.commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
+    this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
   }
 
   private insertUploadUrlVideo(filename: string, uploadUrl: string) {
     const insertedString = `<video controls><source src="${uploadUrl}" type="video/mp4">Your browser does not support the video tag.</video>`;
-    const insertingString = `[Uploading ${filename}...]`;
 
-    const newCursorPosition = this.getNewCursorPosition(filename, insertedString);
-
-    this.commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
-
-    this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
+    this.replacePlaceholderString(filename, insertedString);
   }
 
   private insertUploadUrl(filename: string, uploadUrl: string) {
     const insertedString = `[${filename}](${uploadUrl})`;
-    const insertingString = `[Uploading ${filename}...]`;
-
-    const newCursorPosition = this.getNewCursorPosition(filename, insertedString);
-
-    this.commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
-
-    this.commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
+    this.replacePlaceholderString(filename, insertedString);
   }
 
   private removeHighlightBorderStyle() {


### PR DESCRIPTION
### Summary:
Fixes https://github.com/CATcher-org/CATcher/issues/820

A potential issue is that video tags don't get shown in the actual Github issue due to the differences in our markdown and Github's (related issue https://github.com/CATcher-org/CATcher/issues/916). Sample issue: https://github.com/kevinchua6/bugreporting/issues/8

A possible way to fix this is to place _both_ the url and the video tag when we upload videos so that feature parity is maintained (so that video urls can still be seen in Github issues instead of a blank). Any thoughts? @damithc 

### Changes Made:
* Added `<video>` html tags when uploading videos
* Ensures that uploaded video does not shift the cursor when typing while video is being uploaded
* Refactored cursor logic to accommodate this

### Proposed Commit Message:
```
Add video tag to uploaded videos

Currently, uploaded videos just give a hyperlink to
the video instead being embedded.

Let's convenience users who use videos to describe 
bugs / workarounds by allowing them to play videos
that they have uploaded.
```
