### PR TITLE
Remove no-unused-variable warning 

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -72,7 +72,6 @@
     "no-host-metadata-property": true,
     "no-input-rename": true,
     "no-output-rename": true,
-    "no-unused-variable": [true, { "ignore-pattern": "^_" }],
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,


### PR DESCRIPTION
### Summary:
Fixes https://github.com/CATcher-org/CATcher/issues/952

Related warning is now gone:
![image](https://user-images.githubusercontent.com/45702380/177184538-d4450dd5-0ce2-43e8-9c16-f85485112377.png)


### Changes Made:
* Removed depreciated config option in tslint.json

### Proposed Commit Message:
```
Remove no-unused-variable warning

Currently, we have a no-unused-variable 
warning which is depreciated.

Let's remove it so that we do not leave
depreciated warnings which can clutter
our codebase.
```
