### PR TITLE
Fix title component so that text and buttons are inline

### DIFF
--- a/src/app/shared/issue/title/title.component.css
+++ b/src/app/shared/issue/title/title.component.css
@@ -10,5 +10,6 @@
 }
 
 .title-button {
-  margin: 5px 5px 16px;
+  margin: 5px;
+  float: right;
 }

--- a/src/app/shared/issue/title/title.component.css
+++ b/src/app/shared/issue/title/title.component.css
@@ -1,10 +1,14 @@
+.row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
 .title {
   margin: 0 0 16px;
-  display: inline-block;
 }
 
 .title-button {
-  display: inline-block;
-  float: right;
-  margin: 5px;
+  margin: 5px 5px 16px;
 }

--- a/src/app/shared/issue/title/title.component.html
+++ b/src/app/shared/issue/title/title.component.html
@@ -1,19 +1,21 @@
-<div *ngIf="!isEditing">
+<div *ngIf="!isEditing" class="row">
   <h1 class="mat-display-1 title">
     {{ issue.title }} <span style="color: #a3aab1">#{{ issue.id }}</span>
   </h1>
-  <button
-    *ngIf="permissions.isIssueCreatable()"
-    mat-stroked-button
-    color="primary"
-    class="title-button"
-    [routerLink]="'/' + phaseService.currentPhase + '/issues/new'"
-  >
-    New Issue
-  </button>
-  <button *ngIf="permissions.isIssueTitleEditable()" mat-stroked-button color="primary" class="title-button" (click)="changeToEditMode()">
-    Edit
-  </button>
+  <div class="row">
+    <button *ngIf="permissions.isIssueTitleEditable()" mat-stroked-button color="primary" class="title-button" (click)="changeToEditMode()">
+      Edit
+    </button>
+    <button
+      *ngIf="permissions.isIssueCreatable()"
+      mat-stroked-button
+      color="primary"
+      class="title-button"
+      [routerLink]="'/' + phaseService.currentPhase + '/issues/new'"
+    >
+      New Issue
+    </button>
+  </div>
 </div>
 
 <div *ngIf="isEditing">


### PR DESCRIPTION
### Summary:
Fixes #905

### Changes Made:
* Change the title component so that the `Edit` and `New issue` buttons remain inline with the text even when the text is long.
* The full text is shown, and the buttons are aligned to the top of the text.

Before change:

![image](https://user-images.githubusercontent.com/76725246/178203183-de5ce07a-06b6-42f0-915a-133e54349937.png)

After change:

![image](https://user-images.githubusercontent.com/76725246/178205308-c59d1d6e-4e39-44c5-925c-07f720fed1f8.png)

### Proposed Commit Message:
```
Fix the title component so that the text and buttons are inline

Currently, the Edit and New issue buttons are displaced 
when the issue title is long.

Let's change it so that the issue title text and the buttons 
are always inline.
```
