### PR TITLE
Fix labels on safari

### DIFF
--- a/src/app/shared/issue/label/label.component.css
+++ b/src/app/shared/issue/label/label.component.css
@@ -18,13 +18,10 @@
 
 .labelLine {
   display: grid;
-  grid-template-columns: auto 20%;
+  grid-template-columns: 3fr 1fr;
 }
 
 .labelInfo {
-  display: grid;
-  grid-template-columns: 20% auto;
-  align-items: center;
+  font-size: 1em;
   text-align: left;
-  grid-gap: 20%;
 }


### PR DESCRIPTION
### Summary:
Fixes #911 

### Changes Made:
* Change styles to ensure label displays nicely on safari
Safari:

<img width="295" alt="image" src="https://user-images.githubusercontent.com/67156011/178349390-f32eb7d9-bc1e-43c8-83df-081ff5141591.png">

Chrome:

<img width="259" alt="image" src="https://user-images.githubusercontent.com/67156011/178350064-8aabd398-8a58-469b-ab16-eb8843239781.png">


### Proposed Commit Message:
```
Fix small label text on safari

The text in the labels on safari is too small.

Let's adjust the text size such that it's more readable.
```
