### PR TITLE
Fix defunct links

### DIFF
--- a/src/app/core/models/github/cache-manager/issue-last-modified-manager.model.ts
+++ b/src/app/core/models/github/cache-manager/issue-last-modified-manager.model.ts
@@ -1,6 +1,6 @@
 /**
  * A model that is used to manage the last modified timing of individual issues.
- * Example of a single issue: https://developer.github.com/v3/issues/#get-a-single-issue
+ * Example of a single issue: https://docs.github.com/en/rest/issues/issues#get-an-issue
  */
 export class IssueLastModifiedManagerModel {
   // A mapping from issue ID to their respective last modified timing

--- a/src/app/core/models/github/cache-manager/issues-cache-manager.model.ts
+++ b/src/app/core/models/github/cache-manager/issues-cache-manager.model.ts
@@ -3,7 +3,7 @@ import { GithubResponse } from '../github-response.model';
 
 /**
  * A model that is used to manage the cache of multiple list of issues paginated by pages.
- * Example of a single list of issues: https://developer.github.com/v3/issues/#list-issues-for-a-repository
+ * Example of a single list of issues: https://docs.github.com/en/rest/issues/issues#list-repository-issues
  */
 export class IssuesCacheManager {
   // An array of cache github responses containing the array of GithubIssue as its data

--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -17,7 +17,7 @@ export interface RestGithubIssueFilterData {
 }
 /**
  * A filter to filter out the issues to retrieve from github.
- * Ref: https://developer.github.com/v3/issues/#parameters-3
+ * Ref: https://docs.github.com/en/rest/issues/issues#list-repository-issues
  * */
 export default class RestGithubIssueFilter implements RestGithubIssueFilterData {
   state?: RestGithubIssueState;

--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -17,7 +17,7 @@ export interface RestGithubIssueFilterData {
 }
 /**
  * A filter to filter out the issues to retrieve from github.
- * Ref: https://docs.github.com/en/rest/issues/issues#list-repository-issues
+ * Ref: https://docs.github.com/en/rest/issues/issues#list-repository-issues--parameters
  * */
 export default class RestGithubIssueFilter implements RestGithubIssueFilterData {
   state?: RestGithubIssueState;

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -39,7 +39,7 @@ export class ErrorHandlingService implements ErrorHandler {
       .join('\n');
   }
 
-  // Ref: https://developer.github.com/v3/#client-errors
+  // Ref: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#client-errors
   private handleHttpError(error: HttpErrorResponse | RequestError, actionCallback?: () => void): void {
     // Angular treats 304 Not Modified as an error, we will ignore it.
     if (error.status === 304) {

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -89,7 +89,7 @@ export class PhaseService {
 
   /**
    * Determines the github's level of repo permission required for the phase.
-   * Ref: https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
+   * Ref: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
    */
   githubRepoPermissionLevel(): string {
     if (this.sessionData.openPhases.includes(Phase.phaseModeration)) {

--- a/src/app/shared/lib/github-paginator-parser.ts
+++ b/src/app/shared/lib/github-paginator-parser.ts
@@ -17,7 +17,7 @@ export function getNumberOfPages<T>(response: GithubResponse<T>): number {
  * Will return in the format of { paginateAction: number }
  * Example { next: '15', last: '34', first: '1', prev: '13' }
  *
- * ref: https://developer.github.com/v3/guides/traversing-with-pagination/
+ * ref: https://docs.github.com/en/rest/guides/traversing-with-pagination
  *
  * @param linkStr represent the pagination string provided by github API.
  *


### PR DESCRIPTION
### Summary:
 Due to Github changing their documentation url from `https://developer.github.com/v3` to `https://docs.github.com/` sometime between 2020 and 2022, some of the links to github documentation have become defunct. 

### Changes Made:
Updated the links found in inline documentation. 
The old links were checked using `archive.org` to ensure the new link is correct.

### Proposed Commit Message:
```
Update defunct Github doc references

Due to Github changing their documentation URL from 
https://developer.github.com/v3 to https://docs.github.com/, some of 
the links found in the comments no longer direct users to the 
correct page.

Let's update these links with the latest version to ensure developers 
can find these references easily.
```
