### PR TITLE
Use pagination for fetching labels

### DIFF
--- a/graphql/queries/fetch-labels.graphql
+++ b/graphql/queries/fetch-labels.graphql
@@ -4,6 +4,7 @@ query FetchLabels($owner: String!, $name: String!) {
       edges {
         node {
           ...issueLabel
+          description
         }
       }
     }

--- a/graphql/queries/fetch-labels.graphql
+++ b/graphql/queries/fetch-labels.graphql
@@ -1,7 +1,8 @@
-query FetchLabels($owner: String!, $name: String!) {
+query FetchLabels($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {
-    labels(first: 100) {
+    labels(first: 100, after: $cursor) {
       edges {
+        cursor
         node {
           ...issueLabel
           description

--- a/graphql/queries/fetch-labels.graphql
+++ b/graphql/queries/fetch-labels.graphql
@@ -1,0 +1,11 @@
+query FetchLabels($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    labels(first: 100) {
+      edges {
+        node {
+          ...issueLabel
+        }
+      }
+    }
+  }
+}

--- a/src/app/core/models/github/github-label.model.ts
+++ b/src/app/core/models/github/github-label.model.ts
@@ -21,6 +21,7 @@ export class GithubLabel {
   category: string;
   label: string;
   url: string;
+  description: string;
 
   constructor(githubLabels: {}) {
     Object.assign(this, githubLabels);
@@ -41,6 +42,10 @@ export class GithubLabel {
 
   getValue(): string {
     return this.label;
+  }
+
+  getDescription(): string {
+    return this.description;
   }
 
   isCategorical(): boolean {

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -259,23 +259,10 @@ export class GithubService {
     );
   }
 
-  fetchAllLabels(): Observable<Array<{}>> {
-    return this.fetchAllLabelsGraphQL().pipe(
-      map((labels: GithubLabel[]) => {
-        return labels.map((label) => {
-          return {
-            name: label.name,
-            id: label.id,
-            color: label.color,
-            url: label.url
-          };
-        });
-      }),
-      catchError((err) => throwError('Failed to fetch labels.'))
-    );
-  }
-
-  fetchAllLabelsGraphQL(): Observable<Array<GithubLabel>> {
+  /**
+   * Fetches all labels in the current repository.
+   */
+  fetchAllLabels(): Observable<Array<GithubLabel>> {
     const githubLabels = this.fetchGraphqlList<FetchLabelsQuery, GithubLabel>(
       FetchLabels,
       { owner: ORG_NAME, name: REPO },
@@ -283,7 +270,7 @@ export class GithubService {
       GithubLabel
     );
 
-    return githubLabels;
+    return githubLabels.pipe(catchError((err) => throwError('Failed to fetch labels.')));
   }
 
   /**

--- a/tests/services/label.service.spec.ts
+++ b/tests/services/label.service.spec.ts
@@ -77,28 +77,24 @@ describe('LabelService: toLabel()', () => {
     labelService = null;
   });
 
-  it('should be severity.Low label', () => {
-    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_LOW_SEVERITY);
+  it('should convert a GithubLabel object to a corresponding Label object', () => {
+    const lowSeverityLabel = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_LOW_SEVERITY);
 
-    expect(label.labelCategory).toBe(LabelConstant.SEVERITY);
-    expect(label.labelValue).toBe(LabelConstant.SEVERITY_LOW);
-    expect(label.labelColor).toBe(LabelConstant.COLOR_SEVERITY_LOW);
-  });
+    expect(lowSeverityLabel.labelCategory).toBe(LabelConstant.SEVERITY);
+    expect(lowSeverityLabel.labelValue).toBe(LabelConstant.SEVERITY_LOW);
+    expect(lowSeverityLabel.labelColor).toBe(LabelConstant.COLOR_SEVERITY_LOW);
 
-  it('should be type.FunctionalityBug label', () => {
-    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_FUNCTIONALITY_BUG);
+    const functionalityBugLabel = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_FUNCTIONALITY_BUG);
 
-    expect(label.labelCategory).toBe(LabelConstant.TYPE);
-    expect(label.labelValue).toBe(LabelConstant.TYPE_FUNCTIONALITY_BUG);
-    expect(label.labelColor).toBe(LabelConstant.COLOR_TYPE_FUNCTIONALITY_BUG);
-  });
+    expect(functionalityBugLabel.labelCategory).toBe(LabelConstant.TYPE);
+    expect(functionalityBugLabel.labelValue).toBe(LabelConstant.TYPE_FUNCTIONALITY_BUG);
+    expect(functionalityBugLabel.labelColor).toBe(LabelConstant.COLOR_TYPE_FUNCTIONALITY_BUG);
 
-  it('should be tutorial.CS2103T-W12 label', () => {
-    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_TUTORIAL_LABEL);
+    const tutoriallabel = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_TUTORIAL_LABEL);
 
-    expect(label.labelCategory).toBe('tutorial');
-    expect(label.labelValue).toBe('CS2103T-W12');
-    expect(label.labelColor).toBe('c2e0c6');
+    expect(tutoriallabel.labelCategory).toBe('tutorial');
+    expect(tutoriallabel.labelValue).toBe('CS2103T-W12');
+    expect(tutoriallabel.labelColor).toBe('c2e0c6');
   });
 });
 

--- a/tests/services/label.service.spec.ts
+++ b/tests/services/label.service.spec.ts
@@ -1,10 +1,11 @@
 import { of } from 'rxjs';
+import { GithubLabel } from '../../src/app/core/models/github/github-label.model';
 import { Label } from '../../src/app/core/models/label.model';
 import { LABEL_DEFINITIONS, LabelService } from '../../src/app/core/services/label.service';
+import * as GithubLabelConstant from '../constants/githublabel.constants';
 import * as LabelConstant from '../constants/label.constants';
 
 let labelService: LabelService;
-let labelList: Label[];
 let githubService: any;
 
 describe('LabelService', () => {
@@ -67,34 +68,37 @@ describe('LabelService', () => {
   });
 });
 
-describe('LabelService: parseLabelData()', () => {
+describe('LabelService: toLabel()', () => {
   beforeAll(() => {
     labelService = new LabelService(null);
-    labelList = labelService.parseLabelData(LabelConstant.SOME_TEAM_RESPONSE_PHASE_LABELS);
   });
 
   afterAll(() => {
     labelService = null;
   });
 
-  it('should be response.Accepted label', () => {
-    expect(labelList[0].labelCategory).toBe(LabelConstant.RESPONSE);
-    expect(labelList[0].labelValue).toBe(LabelConstant.RESPONSE_ACCEPTED);
-    expect(labelList[0].labelColor).toBe(LabelConstant.COLOR_RESPONSE_ACCEPTED);
+  it('should be severity.Low label', () => {
+    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_LOW_SEVERITY);
+
+    expect(label.labelCategory).toBe(LabelConstant.SEVERITY);
+    expect(label.labelValue).toBe(LabelConstant.SEVERITY_LOW);
+    expect(label.labelColor).toBe(LabelConstant.COLOR_SEVERITY_LOW);
   });
 
-  it('should be severity.Low', () => {
-    expect(labelList[1].labelCategory).toBe(LabelConstant.SEVERITY);
-    expect(labelList[1].labelValue).toBe(LabelConstant.SEVERITY_LOW);
-    expect(labelList[1].labelColor).toBe(LabelConstant.COLOR_SEVERITY_LOW);
-    expect(labelList[1].labelDefinition).toBe(LABEL_DEFINITIONS.severityLow);
+  it('should be type.FunctionalityBug label', () => {
+    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_FUNCTIONALITY_BUG);
+
+    expect(label.labelCategory).toBe(LabelConstant.TYPE);
+    expect(label.labelValue).toBe(LabelConstant.TYPE_FUNCTIONALITY_BUG);
+    expect(label.labelColor).toBe(LabelConstant.COLOR_TYPE_FUNCTIONALITY_BUG);
   });
 
-  it('should be type.FunctionalityBug', () => {
-    expect(labelList[2].labelCategory).toBe(LabelConstant.TYPE);
-    expect(labelList[2].labelValue).toBe(LabelConstant.TYPE_FUNCTIONALITY_BUG);
-    expect(labelList[2].labelColor).toBe(LabelConstant.COLOR_TYPE_FUNCTIONALITY_BUG);
-    expect(labelList[2].labelDefinition).toBe(LABEL_DEFINITIONS.typeFunctionalityBug);
+  it('should be tutorial.CS2103T-W12 label', () => {
+    const label = labelService.toLabel(GithubLabelConstant.GITHUB_LABEL_TUTORIAL_LABEL);
+
+    expect(label.labelCategory).toBe('tutorial');
+    expect(label.labelValue).toBe('CS2103T-W12');
+    expect(label.labelColor).toBe('c2e0c6');
   });
 });
 


### PR DESCRIPTION
### Summary:
Partially addresses #928 by using pagination for fetching all labels in a repository.

### Changes Made:
- Converted to graphql query to fetch labels
- Fetch labels across multiple pages with the use of `fetchGraphqlList`
- Refactored `labelService.synchronizeRemoteLabels` to use `GithubLabel` objects instead of untyped json objects.

### Proposed Commit Message:
```
Use pagination for fetching labels

Previously, fetchAllLabels assumes all labels will be returned in the 
first page of an API call. Whenever the API supports pagination, we 
must check if there are more results left and retrieve them too.

Let's use pagination to ensure we retrieve all labels properly.
```
