### PR TITLE
Fix new issue label dropdown position

### DIFF
--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -7,6 +7,7 @@
       (selectionChange)="setSelectedLabelColor($event.value)"
       [ngStyle]="this.labelService.setLabelStyle(this.selectedColor, 'inline-block')"
       required
+      disableOptionCentering
     >
       <mat-select-trigger>
         {{ dropdownControl.value }}


### PR DESCRIPTION
### Summary:
Fixes #830

### Changes Made:
* Disable option centering for label dropdown menu so that it does not cover label title.

Before change:
![image](https://user-images.githubusercontent.com/76725246/180634693-073d9416-db67-4cd4-a146-b14b51d7389c.png)

After change:
![image](https://user-images.githubusercontent.com/76725246/180634781-e666ae5c-b7e1-4650-9037-22085ac2bdeb.png)
### Proposed Commit Message:
```
Fix the label dropdown component so that the dropdown menu
does not cover the label title

Currently, the label dropdown menu covers the label title.

Let's change it so that the dropdown menu is positioned below
the label title.
```
