### PR TITLE
Fix require statements to stop deprecation warnings

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -30,7 +30,7 @@ import { ElectronService } from './electron.service';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { LoggingService } from './logging.service';
 
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
 const CATCHER_REPO = 'CATcher';
 const UNABLE_TO_OPEN_IN_BROWSER = 'Unable to open this issue in Browser';

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -11,7 +11,7 @@ import { Profile } from '../../models/profile.model';
 import { SessionData } from '../../models/session.model';
 import { LabelService } from '../label.service';
 
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 
 let ORG_NAME = '';
 let MOD_ORG = '';


### PR DESCRIPTION
### Summary:
Fixes #980 

### Changes Made:
* Fix require statements in GithubService and MockGithubService to use the updated syntax.

### Proposed Commit Message:
```
The require statements for octokit have been deprecated.

Let's update them with the new syntax.
```
