### PR TITLE
Clear error toast when leaving issue page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandler, NgModule, NgZone } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { Apollo, ApolloModule } from 'apollo-angular';
 import { HttpLink, HttpLinkModule } from 'apollo-angular-link-http';
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
@@ -98,7 +98,13 @@ import { SharedModule } from './shared/shared.module';
   entryComponents: [UserConfirmationComponent, SessionFixConfirmationComponent, LabelDefinitionPopupComponent]
 })
 export class AppModule {
-  constructor(private apollo: Apollo, private httpLink: HttpLink, private authService: AuthService) {
+  constructor(
+    private apollo: Apollo,
+    private httpLink: HttpLink,
+    private authService: AuthService,
+    private router: Router,
+    private errorHandlingService: ErrorHandlingService
+  ) {
     const URI = 'https://api.github.com/graphql';
     const basic = setContext(() => {
       return { headers: { Accept: 'charset=utf-8' } };
@@ -114,6 +120,11 @@ export class AppModule {
     this.apollo.create({
       link: link,
       cache: cache
+    });
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        this.errorHandlingService.clearError();
+      }
     });
   }
 }

--- a/src/app/core/services/error-handling.service.ts
+++ b/src/app/core/services/error-handling.service.ts
@@ -72,4 +72,8 @@ export class ErrorHandlingService implements ErrorHandler {
   private handleGeneralError(error: string): void {
     this.snackBar.openFromComponent(GeneralMessageErrorComponent, { data: { message: error } });
   }
+
+  clearError() {
+    this.snackBar.dismiss();
+  }
 }


### PR DESCRIPTION
### Summary:
Fixes #816 

### Changes Made:
* Clear the error toast when leaving the issue page

### Proposed Commit Message:
```
Clear error toast when leaving the issue page.

The error toast still persists when leaving the issue
page. This can be confusing for users, as they might
assume that the error is occurring on the new page.

Let's clear the error toast when leaving the issue
page to improve the UX.
```
