### PR TITLE
Fix image uploads not working

### DIFF
--- a/src/app/shared/comment-editor/upload-text-insertor.ts
+++ b/src/app/shared/comment-editor/upload-text-insertor.ts
@@ -65,9 +65,9 @@ function replacePlaceholderString(
   commentField: AbstractControl,
   commentTextArea: ElementRef<HTMLTextAreaElement>
 ) {
-  const cursorPosition = this.commentTextArea.nativeElement.selectionEnd;
+  const cursorPosition = commentTextArea.nativeElement.selectionEnd;
   const insertingString = `[Uploading ${filename}...]`;
-  const startIndexOfString = this.commentField.value.indexOf(insertingString);
+  const startIndexOfString = commentField.value.indexOf(insertingString);
   const endIndexOfString = startIndexOfString + insertingString.length;
   const endOfInsertedString = startIndexOfString + insertedString.length;
   const differenceInLength = endOfInsertedString - endIndexOfString;
@@ -78,6 +78,6 @@ function replacePlaceholderString(
       ? cursorPosition
       : cursorPosition + differenceInLength; // after the uploading text
 
-  commentField.setValue(this.commentField.value.replace(insertingString, insertedString));
+  commentField.setValue(commentField.value.replace(insertingString, insertedString));
   commentTextArea.nativeElement.setSelectionRange(newCursorPosition, newCursorPosition);
 }


### PR DESCRIPTION
### Summary:
Fixes #1004 


### Changes Made:
* The use of this keyword before commentTextArea and commentField in a non-OOP context causes it to reference `undefined`, hence the bug.
* Remove reference to `this` keyword In `upload-text-insertor.ts` lines 68, 70, 81


### Proposed Commit Message:
```
Fix image uploads not working

There is a bug where the program references undefined when an 
image/video is uploaded. This is caused by the use of the `this` 
keyword in the function `replacePlaceholderString`, which is not a 
method of any class.

Let's remove the `this` keyword in `replacePlaceholderString`.
```
