### PR TITLE
Fix title overflow bug

### DIFF
--- a/src/app/shared/issue/title/title.component.css
+++ b/src/app/shared/issue/title/title.component.css
@@ -7,6 +7,7 @@
 
 .title {
   margin: 0 0 16px;
+  overflow-wrap: anywhere;
 }
 
 .title-button {


### PR DESCRIPTION
### Summary:
Fixes #1008 

### Changes Made:
* Fix bug where an extremely long title for an issue overflows out of the screen if the title contains no spaces.

#### Before fix
<img width="976" alt="before" src="https://user-images.githubusercontent.com/34131671/195594921-2c8b352f-844a-4ec5-b68f-e2a2155dc7a6.png">

#### After fix
<img width="982" alt="after" src="https://user-images.githubusercontent.com/34131671/195594930-fcb31b30-f316-465b-8afc-ab800f309b27.png">

### Proposed Commit Message:
```
Fix bug where an extremely long title for an issue
overflows out of the screen if the title contains no spaces.

Currently, a long title that exceeds the screen width will
only be wrapped at points where there is a space. If there
are no spaces, then no line breaks can be introduced, which
causes the title to just overflow out of the screen width.

To fix this, lets add a CSS rule to allow line breaks to be
introduced anywhere in the title.
```
