### PR TITLE
Fix #1014 Tester responses: All bugs are marked as 'Faulty Issues'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "main": "main.js",
   "scripts": {
     "postinstall": "npm run postinstall:electron && electron-builder install-app-deps",

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -5,7 +5,7 @@ import { buildTeamResponseSectionParser } from './section-parsers/common-parsers
 import { TesterResponseSectionParser } from './section-parsers/tester-response-section-parser.model';
 import { Template } from './template.model';
 
-const { coroutine, many1, str, whitespace } = require('arcsecond');
+const { coroutine, many1, str, optionalWhitespace, possibly, whitespace } = require('arcsecond');
 
 interface TesterResponseParseResult {
   teamResponse: string;

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -15,12 +15,17 @@ interface TesterResponseParseResult {
   teamChosenType: string;
 }
 
+const GITHUB_UI_EDIT_WARNING =
+  '[IMPORTANT!: Please do not edit or reply to this comment using the GitHub UI. You can respond to it using CATcher during the next phase of the PE]';
 const TESTER_RESPONSES_HEADER = '# Items for the Tester to Verify';
 const DISAGREE_CHECKBOX_DESCRIPTION = 'I disagree';
 
 const TeamResponseSectionParser = buildTeamResponseSectionParser(TESTER_RESPONSES_HEADER);
 
 export const TesterResponseParser = coroutine(function* () {
+  yield possibly(str(GITHUB_UI_EDIT_WARNING));
+  yield optionalWhitespace;
+
   const teamResponse = yield TeamResponseSectionParser;
 
   // parse tester responses from comment

--- a/tests/constants/githubcomment.constants.ts
+++ b/tests/constants/githubcomment.constants.ts
@@ -18,6 +18,7 @@ export const EMPTY_TEAM_RESPONSE: GithubComment = {
 // Type and severity disagreeement
 export const TEAM_RESPONSE_MULTIPLE_DISAGREEMENT = {
   body:
+    '[IMPORTANT!: Please do not edit or reply to this comment using the GitHub UI. You can respond to it using CATcher during the next phase of the PE]\n\n' +
     "# Team's Response\n" +
     'This is a dummy team response comment: ' +
     'Thanks for the feedback\n\n' +


### PR DESCRIPTION
### Summary:
Fixes #1014 

### Changes Made:
* Update tester response parser to take into account message warning against editing issue on GitHub directly. Note that the parser still works if the message is not in the issue comment
* Update test to include this message

### Proposed Commit Message:
```
Update Tester Response Parser to account for editing on GitHub warning

A message warning students against responding to the issue directly
on GitHub was added to the Tester Response comment, causing the parser
to mark all issues as faulty as this message was not originally in the
parser.

Let's add this message into the parser so that it can parse tester
response comments correctly, and let's update the tests to include
this message
```
