### PR TITLE
Add new modal for successful profile parsing and loading

### DIFF
--- a/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.html
+++ b/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content>
   <p align="center" style="max-width: 390px">
     You have successfully loaded the profile with
-    <code>profileName: "{{ this.loadedProfile.profileName }}"</code> and <code>repoName: "{{ this.loadedProfile.repoName }}"</code>!
+    <code>profileName: "{{ data.profileName }}"</code> and <code>repoName: "{{ data.repoName }}"</code>!
   </p>
 </div>
 <div mat-dialog-actions align="center">

--- a/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.html
+++ b/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.html
@@ -1,0 +1,10 @@
+<h1 mat-dialog-title>Success!</h1>
+<div mat-dialog-content>
+  <p align="center" style="max-width: 390px">
+    You have successfully loaded the profile with
+    <code>profileName: "{{ this.loadedProfile.profileName }}"</code> and <code>repoName: "{{ this.loadedProfile.repoName }}"</code>!
+  </p>
+</div>
+<div mat-dialog-actions align="center">
+  <button mat-raised-button color="primary" (click)="onClick()">Ok</button>
+</div>

--- a/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
+++ b/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Profile } from '../../../core/models/profile.model';
+import { ProfilesComponent } from '../profiles.component';
+
+/**
+ * This Component is responsible for informing the user if the profile
+ * that was selected was successfully loaded.
+ */
+
+@Component({
+  selector: 'app-profile-parse-success-dialog',
+  templateUrl: './profile-parse-success-dialog.component.html',
+  styleUrls: ['./profile-parse-success-dialog.component.css']
+})
+export class ProfileParseSuccessDialog implements OnInit {
+  @Input() loadedProfile: Profile;
+
+  constructor(public dialogRef: MatDialogRef<ProfilesComponent>) {}
+
+  ngOnInit() {}
+
+  /**
+   * Closes the Dialog
+   */
+  onClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
+++ b/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Profile } from '../../../core/models/profile.model';
 import { ProfilesComponent } from '../profiles.component';
 
@@ -14,9 +14,7 @@ import { ProfilesComponent } from '../profiles.component';
   styleUrls: ['./profile-parse-success-dialog.component.css']
 })
 export class ProfileParseSuccessDialog implements OnInit {
-  @Input() loadedProfile: Profile;
-
-  constructor(public dialogRef: MatDialogRef<ProfilesComponent>) {}
+  constructor(public dialogRef: MatDialogRef<ProfilesComponent>, @Inject(MAT_DIALOG_DATA) public data: Profile) {}
 
   ngOnInit() {}
 

--- a/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
+++ b/src/app/auth/profiles/profile-parse-success-dialog/profile-parse-success-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Profile } from '../../../core/models/profile.model';
 import { ProfilesComponent } from '../profiles.component';
 
@@ -13,7 +13,7 @@ import { ProfilesComponent } from '../profiles.component';
   templateUrl: './profile-parse-success-dialog.component.html',
   styleUrls: ['./profile-parse-success-dialog.component.css']
 })
-export class ProfileParseSuccessDialog implements OnInit {
+export class ProfileParseSuccessDialogComponent implements OnInit {
   constructor(public dialogRef: MatDialogRef<ProfilesComponent>, @Inject(MAT_DIALOG_DATA) public data: Profile) {}
 
   ngOnInit() {}

--- a/src/app/auth/profiles/profiles.component.ts
+++ b/src/app/auth/profiles/profiles.component.ts
@@ -5,7 +5,7 @@ import { isValidProfile, Profile } from '../../core/models/profile.model';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { MALFORMED_PROFILES_ERROR, ProfileService } from '../../core/services/profile.service';
 import { JsonParseErrorDialogComponent } from './json-parse-error-dialog/json-parse-error-dialog.component';
-import { ProfileParseSuccessDialog } from './profile-parse-success-dialog/profile-parse-success-dialog.component';
+import { ProfileParseSuccessDialogComponent } from './profile-parse-success-dialog/profile-parse-success-dialog.component';
 
 @Component({
   selector: 'app-profiles',
@@ -117,7 +117,7 @@ export class ProfilesComponent implements OnInit {
    * Makes Successful Profile Load dialog visible to the user
    */
   openSuccessfulProfileLoadingDialog(loadedProfile: Profile): void {
-    this.dialog.open(ProfileParseSuccessDialog, { data: loadedProfile });
+    this.dialog.open(ProfileParseSuccessDialogComponent, { data: loadedProfile });
   }
 
   /**

--- a/src/app/auth/profiles/profiles.component.ts
+++ b/src/app/auth/profiles/profiles.component.ts
@@ -5,6 +5,7 @@ import { isValidProfile, Profile } from '../../core/models/profile.model';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { MALFORMED_PROFILES_ERROR, ProfileService } from '../../core/services/profile.service';
 import { JsonParseErrorDialogComponent } from './json-parse-error-dialog/json-parse-error-dialog.component';
+import { ProfileParseSuccessDialog } from './profile-parse-success-dialog/profile-parse-success-dialog.component';
 
 @Component({
   selector: 'app-profiles',
@@ -42,7 +43,7 @@ export class ProfilesComponent implements OnInit {
     fileDirectory: null
   };
 
-  constructor(public errorDialog: MatDialog, public profileService: ProfileService, public errorHandlingService: ErrorHandlingService) {}
+  constructor(public dialog: MatDialog, public profileService: ProfileService, public errorHandlingService: ErrorHandlingService) {}
 
   ngOnInit() {
     this.initProfiles();
@@ -75,6 +76,9 @@ export class ProfilesComponent implements OnInit {
           this.profileService.validateProfiles(profiles);
           this.profiles = profiles.concat(this.profiles).filter((p) => !!p);
           target.value = '';
+          // should only be one profile by virtue of validateProfiles, choose the first profile
+          const loadedProfile = profiles[0] as Profile;
+          this.openSuccessfulProfileLoadingDialog(loadedProfile);
         } catch (e) {
           this.openErrorDialog();
         }
@@ -106,7 +110,14 @@ export class ProfilesComponent implements OnInit {
    * Makes Error dialog visible to the user.
    */
   openErrorDialog(): void {
-    this.errorDialog.open(JsonParseErrorDialogComponent);
+    this.dialog.open(JsonParseErrorDialogComponent);
+  }
+
+  /**
+   * Makes Successful Profile Load dialog visible to the user
+   */
+  openSuccessfulProfileLoadingDialog(loadedProfile: Profile): void {
+    this.dialog.open(ProfileParseSuccessDialog, { data: loadedProfile });
   }
 
   /**


### PR DESCRIPTION
### Summary:
Fixes #1074 

### Changes Made:
*  Add a new dialog component called ProfileParseSuccessDialogComponent which displays the profileName and repoName of the profile that was added
* Rename the MatDialog param for ProfilesComponent from errorDialog to just dialog, since it would be used to open the ProfileParseSuccessDialogComponent as well.

### Proposed Commit Message:
`Add new dialog to let users know that a new profile has been loaded.`
Commit message to be used when the PR is merged
(NOTE: Wrap the body at 72 characters)
```
