### PR TITLE
Detect if duplicate profile provided and notify user

### DIFF
--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.html
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.html
@@ -1,9 +1,6 @@
 <h1 mat-dialog-title>Error in "profiles.json" format</h1>
 <div mat-dialog-content>
-  <p align="center" style="max-width: 390px">
-    The format of the "profiles.json" file is not as required. You might not have included <code>profileName</code> and
-    <code>repoName</code> keys. Please refer to our User Guide for the correct format.
-  </p>
+  <p align="center" style="max-width: 390px" [innerHtml]="getProfileErrorMessage()"></p>
 </div>
 <div mat-dialog-actions align="center">
   <button mat-raised-button color="primary" (click)="onClick()">Ok</button>

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnInit, SecurityContext } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ProfilesComponent } from '../profiles.component';
@@ -35,6 +35,6 @@ export class JsonParseErrorDialogComponent implements OnInit {
    */
   getProfileErrorMessage() {
     const errorMessage = getErrorMessage(this.data);
-    return this.sanitizer.bypassSecurityTrustHtml(errorMessage);
+    return this.sanitizer.sanitize(SecurityContext.HTML, errorMessage);
   }
 }

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { DomSanitizer } from '@angular/platform-browser';
 import { ProfilesComponent } from '../profiles.component';
+import { getErrorMessage, PROFILE_ERRORS } from './json-parse-error-dialog.utils';
 
 /**
  * This Component is responsible for informing the user if there
@@ -13,7 +15,11 @@ import { ProfilesComponent } from '../profiles.component';
   styleUrls: ['./json-parse-error-dialog.component.css']
 })
 export class JsonParseErrorDialogComponent implements OnInit {
-  constructor(public dialogRef: MatDialogRef<ProfilesComponent>) {}
+  constructor(
+    public dialogRef: MatDialogRef<ProfilesComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: PROFILE_ERRORS,
+    private sanitizer: DomSanitizer
+  ) {}
 
   ngOnInit() {}
 
@@ -22,5 +28,13 @@ export class JsonParseErrorDialogComponent implements OnInit {
    */
   onClick(): void {
     this.dialogRef.close();
+  }
+
+  /**
+   * Get appropriate Error message.
+   */
+  getProfileErrorMessage() {
+    const errorMessage = getErrorMessage(this.data);
+    return this.sanitizer.bypassSecurityTrustHtml(errorMessage);
   }
 }

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.utils.ts
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.utils.ts
@@ -1,5 +1,6 @@
 const JSON_PARSE_ERROR_MESSAGE = `The format of the "profiles.json" file is not as required.
-You might not have included <code>profileName</code> and <code>repoName</code> keys. Please refer to our User Guide for the correct format.`;
+You might not have included <code>profileName</code> and <code>repoName</code> keys.
+Please refer to our User Guide for the correct format.`;
 
 const DUPLICATE_PROFILE_ERROR_MESSAGE = `You have already provided this profile.`;
 

--- a/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.utils.ts
+++ b/src/app/auth/profiles/json-parse-error-dialog/json-parse-error-dialog.utils.ts
@@ -1,0 +1,23 @@
+const JSON_PARSE_ERROR_MESSAGE = `The format of the "profiles.json" file is not as required.
+You might not have included <code>profileName</code> and <code>repoName</code> keys. Please refer to our User Guide for the correct format.`;
+
+const DUPLICATE_PROFILE_ERROR_MESSAGE = `You have already provided this profile.`;
+
+const PROFILE_ERRORS = {
+  JSON_PARSE_ERROR: 'JSON_PARSE_ERROR',
+  DUPLICATE_PROFILE_ERROR: 'DUPLICATE_PROFILE_ERROR'
+} as const;
+
+type PROFILE_ERRORS = typeof PROFILE_ERRORS[keyof typeof PROFILE_ERRORS];
+
+const getErrorMessage = (profileError: PROFILE_ERRORS) => {
+  switch (profileError) {
+    case PROFILE_ERRORS.DUPLICATE_PROFILE_ERROR:
+      return DUPLICATE_PROFILE_ERROR_MESSAGE;
+    case PROFILE_ERRORS.DUPLICATE_PROFILE_ERROR:
+    default:
+      return JSON_PARSE_ERROR_MESSAGE;
+  }
+};
+
+export { getErrorMessage, PROFILE_ERRORS };

--- a/src/app/core/services/profile.service.ts
+++ b/src/app/core/services/profile.service.ts
@@ -3,6 +3,7 @@ import { isValidProfile, Profile } from '../models/profile.model';
 import { GithubService } from './github.service';
 
 export const MALFORMED_PROFILES_ERROR: Error = new Error('profiles.json is malformed');
+export const DUPLICATE_PROFILE_EXISTS_ERROR: Error = new Error('duplicate profile exists');
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
### Summary
Currently, CATcher does not care if the profile that is provided has been provided before. Furthermore, the current Error Dialog box is not flexible enough to show other errors. Let's create a new type called PROFILE_ERRORS as well as helper methods that can provide us with the right error message to be displayed, based on the PROFILE_ERROR provided. This will allow the JsonParseErrorDialogComponent to display its own custom message. Let's also add methods to check if the profile which has been loaded on to CATcher has been added before.

### Changes Made:
* Addition of new utils file to define the right types
* Addition of new error and check of duplicate files in ProfilesComponent
* Modification of JsonParseErrorDialogComponent to display SafeHTML based on the error message provided.

### Proposed Commit Message:
```
Add checks to verify that the profile that has been provided by user has not been provided before.
```
