### PR TITLE
Implement Types instead of using Strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@angular/compiler-cli": "^9.1.13",
     "@angular/language-service": "^9.1.13",
     "@graphql-codegen/cli": "^2.6.4",
-    "@graphql-codegen/typescript": "1.17.7",
+    "@graphql-codegen/typescript": "^2.8.5",
     "@graphql-codegen/typescript-document-nodes": "1.17.7",
     "@graphql-codegen/typescript-operations": "^1.18.4",
     "@graphql-codegen/typescript-resolvers": "^1.20.0",

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -26,11 +26,11 @@ export class Issue {
   hiddenDataInDescription: HiddenData;
 
   /** Fields derived from Labels */
-  severity: string;
-  type: string;
+  severity: SEVERITY;
+  type: ATTRIBUTES;
   responseTag?: string;
   duplicated?: boolean;
-  status?: string;
+  status?: STATUS;
   pending?: string;
   unsure?: boolean;
   teamAssigned?: Team;
@@ -116,11 +116,11 @@ export class Issue {
     this.githubIssue = githubIssue;
 
     /** Fields derived from Labels */
-    this.severity = githubIssue.findLabel(GithubLabel.LABELS.severity);
-    this.type = githubIssue.findLabel(GithubLabel.LABELS.type);
+    this.severity = SEVERITY[githubIssue.findLabel(GithubLabel.LABELS.severity)];
+    this.type = ATTRIBUTES[githubIssue.findLabel(GithubLabel.LABELS.type)];
     this.responseTag = githubIssue.findLabel(GithubLabel.LABELS.response);
     this.duplicated = !!githubIssue.findLabel(GithubLabel.LABELS.duplicated, false);
-    this.status = githubIssue.findLabel(GithubLabel.LABELS.status);
+    this.status = STATUS[githubIssue.findLabel(GithubLabel.LABELS.status)];
     this.pending = githubIssue.findLabel(GithubLabel.LABELS.pending);
   }
 
@@ -322,6 +322,41 @@ export const ISSUE_TYPE_ORDER = { '-': 0, DocumentationBug: 1, FeatureFlaw: 2, F
 export enum STATUS {
   Incomplete = 'Incomplete',
   Done = 'Done'
+}
+
+export enum ATTRIBUTES {
+  Severity = 'severity',
+  Type = 'type',
+  Response = 'response',
+  ResponseTag = 'responseTag',
+  Status = 'status',
+  Undefined = 'undefined',
+  Others = 'others'
+} 
+
+export enum SEVERITY {
+  VeryLow = 'VeryLow',
+  Low = 'Low',
+  Medium = 'Medium',
+  High = 'High'
+}
+
+export enum BUG {
+  DocumentationBug = 'DocumentationBug',
+  FeatureFlaw = 'FeatureFlaw',
+  FunctionalityBug = 'FunctionalityBug'
+}
+
+export enum RESPONSE {
+  Accepted = 'Accepted',
+  CannotReproduce = 'CannotReproduce',
+  IssueUnclear = 'IssueUnclear',
+  NotInScope = 'NotInScope',
+  Rejected = 'Rejected'
+}
+
+export enum UNDEFINED {
+  Duplicate = 'Duplicate'
 }
 
 export enum FILTER {

--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -5,6 +5,8 @@ import { GithubLabel } from '../models/github/github-label.model';
 import { Label } from '../models/label.model';
 import { GithubService } from './github.service';
 
+import { ATTRIBUTES, SEVERITY, BUG, RESPONSE, STATUS, UNDEFINED } from '../models/issue.model'
+
 /* The threshold to decide if color is dark or light.
 A higher threshold value will result in more colors determined to be "dark".
 W3C recommendation is 0.179, but 0.184 is chosen so that some colors (like bright red)
@@ -92,29 +94,29 @@ export const LABEL_DEFINITIONS = {
 
 const REQUIRED_LABELS = {
   severity: {
-    VeryLow: new Label('severity', 'VeryLow', COLOR_RED_PALE, VERY_LOW_DEFINITION),
-    Low: new Label('severity', 'Low', COLOR_RED_LIGHT, LOW_DEFINITION),
-    Medium: new Label('severity', 'Medium', COLOR_RED, MEDIUM_DEFINITION),
-    High: new Label('severity', 'High', COLOR_RED_DARK, HIGH_DEFINITION)
+    VeryLow: new Label(ATTRIBUTES.Severity, SEVERITY.VeryLow, COLOR_RED_PALE, VERY_LOW_DEFINITION),
+    Low: new Label(ATTRIBUTES.Severity, SEVERITY.Low, COLOR_RED_LIGHT, LOW_DEFINITION),
+    Medium: new Label(ATTRIBUTES.Severity, SEVERITY.Medium, COLOR_RED, MEDIUM_DEFINITION),
+    High: new Label(ATTRIBUTES.Severity, SEVERITY.High, COLOR_RED_DARK, HIGH_DEFINITION)
   },
   type: {
-    DocumentationBug: new Label('type', 'DocumentationBug', COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
-    FeatureFlaw: new Label('type', 'FeatureFlaw', COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
-    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION)
+    DocumentationBug: new Label(ATTRIBUTES.Type, BUG.DocumentationBug, COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
+    FeatureFlaw: new Label(ATTRIBUTES.Type, BUG.FeatureFlaw, COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
+    FunctionalityBug: new Label(ATTRIBUTES.Type, BUG.FunctionalityBug, COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION)
   },
   response: {
-    Accepted: new Label('response', 'Accepted', COLOR_GREEN, ACCEPTED_DEFINITION),
-    CannotReproduce: new Label('response', 'CannotReproduce', COLOR_ORANGE_PALE, CANNOT_REPRODUCE_DEFINITION),
-    IssueUnclear: new Label('response', 'IssueUnclear', COLOR_ORANGE_LIGHT, ISSUE_UNCLEAR_DEFINITION),
-    NotInScope: new Label('response', 'NotInScope', COLOR_ORANGE_LIGHT, NOT_IN_SCOPE_DEFINITION),
-    Rejected: new Label('response', 'Rejected', COLOR_ORANGE, REJECTED_DEFINITION)
+    Accepted: new Label(ATTRIBUTES.Response, RESPONSE.Accepted, COLOR_GREEN, ACCEPTED_DEFINITION),
+    CannotReproduce: new Label(ATTRIBUTES.Response, RESPONSE.CannotReproduce, COLOR_ORANGE_PALE, CANNOT_REPRODUCE_DEFINITION),
+    IssueUnclear: new Label(ATTRIBUTES.Response, RESPONSE.IssueUnclear, COLOR_ORANGE_LIGHT, ISSUE_UNCLEAR_DEFINITION),
+    NotInScope: new Label(ATTRIBUTES.Response, RESPONSE.NotInScope, COLOR_ORANGE_LIGHT, NOT_IN_SCOPE_DEFINITION),
+    Rejected: new Label(ATTRIBUTES.Response, RESPONSE.Rejected, COLOR_ORANGE, REJECTED_DEFINITION)
   },
   status: {
-    Done: new Label('status', 'Done', COLOR_SILVER),
-    Incomplete: new Label('status', 'Incomplete', COLOR_BLACK)
+    Done: new Label(ATTRIBUTES.Status, STATUS.Done, COLOR_SILVER),
+    Incomplete: new Label(ATTRIBUTES.Status, STATUS.Incomplete, COLOR_BLACK)
   },
   others: {
-    duplicate: new Label(undefined, 'duplicate', COLOR_BLUE)
+    duplicate: new Label(ATTRIBUTES.Undefined, UNDEFINED.Duplicate, COLOR_BLUE)
   }
 };
 
@@ -196,14 +198,14 @@ export class LabelService {
    * @param attributeName: the type of the label
    * @return an array of label of that type
    */
-  getLabelList(attributeName: string): Label[] {
+  getLabelList(attributeName: ATTRIBUTES): Label[] {
     switch (attributeName) {
-      case 'severity':
+      case ATTRIBUTES.Severity:
         return LabelService.severityLabels;
-      case 'type':
+      case ATTRIBUTES.Type:
         return LabelService.typeLabels;
-      case 'responseTag':
-      case 'response':
+      case ATTRIBUTES.ResponseTag:
+      case ATTRIBUTES.Response:
         return LabelService.responseLabels;
     }
   }
@@ -212,13 +214,13 @@ export class LabelService {
    * Returns a title for the label type
    * @param attributeName: the type of the label
    */
-  getLabelTitle(attributeName: string): string {
+  getLabelTitle(attributeName: string | ATTRIBUTES): string {
     switch (attributeName) {
-      case 'severity':
+      case ATTRIBUTES.Severity:
         return DISPLAY_NAME_SEVERITY;
-      case 'type':
+      case ATTRIBUTES.Type:
         return DISPLAY_NAME_BUG_TYPE;
-      case 'responseTag':
+      case ATTRIBUTES.ResponseTag:
         return DISPLAY_NAME_RESPONSE;
     }
   }

--- a/src/app/shared/issue/label/label.component.ts
+++ b/src/app/shared/issue/label/label.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { first } from 'rxjs/operators';
 import { DialogService } from '../../..//core/services/dialog.service';
-import { Issue } from '../../../core/models/issue.model';
+import { ATTRIBUTES, Issue } from '../../../core/models/issue.model';
 import { Label } from '../../../core/models/label.model';
 import { ErrorHandlingService } from '../../../core/services/error-handling.service';
 import { IssueService } from '../../../core/services/issue.service';
@@ -35,7 +35,7 @@ export class LabelComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     // Get the list of labels based on their type (severity, type, response)
-    this.labelValues = this.labelService.getLabelList(this.attributeName);
+    this.labelValues = this.labelService.getLabelList(ATTRIBUTES[this.attributeName]);
   }
 
   ngOnChanges() {

--- a/src/app/shared/label-dropdown/label-dropdown.component.ts
+++ b/src/app/shared/label-dropdown/label-dropdown.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { DialogService } from '../..//core/services/dialog.service';
+import { ATTRIBUTES } from '../../core/models/issue.model';
 import { Label } from '../../core/models/label.model';
 import { LabelCategory, LabelService } from '../../core/services/label.service';
 
@@ -25,7 +26,7 @@ export class LabelDropdownComponent implements OnInit {
 
   ngOnInit() {
     this.selectedColor = this.labelService.getColorOfLabel(this.attributeName, this.initialValue);
-    this.labelList = this.labelService.getLabelList(this.attributeName);
+    this.labelList = this.labelService.getLabelList(ATTRIBUTES[this.attributeName]);
     this.dropdownControl = this.dropdownForm.get(this.attributeName);
   }
 


### PR DESCRIPTION


### Summary:
Fixes #976. 

### Changes Made:
* [Description of the changes made in your PR]
Implement TypeScript Enum class as stated in https://github.com/CATcher-org/CATcher/issues/976.
This improves the code quality and code reusability

### Proposed Commit Message:
```
Currently, fields like Attributes, Type and Status are processed as a 'string' type. This could decreases code readability and increase typographical error.

We improve code quality by abstracting these string inputs into an Enum class.
```
