### PR TITLE
Fix Error [ERR_REQUIRE_ESM]

### DIFF
--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 
 const nodeUrl = require('url');
 const Logger = require('electron-log');
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(args[0], ...args.slice(1)));
+const fetch = require('node-fetch');
 
 const CLIENT_ID = '6750652c0c9001314434';
 const BASE_URL = 'https://github.com';

--- a/electron-utils/oauth.ts
+++ b/electron-utils/oauth.ts
@@ -2,8 +2,8 @@ import { BrowserWindow, shell } from 'electron';
 import { v4 as uuid } from 'uuid';
 
 const nodeUrl = require('url');
-const fetch = require('node-fetch');
 const Logger = require('electron-log');
+const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(args[0], ...args.slice(1)));
 
 const CLIENT_ID = '6750652c0c9001314434';
 const BASE_URL = 'https://github.com';
@@ -24,7 +24,7 @@ export function getAccessToken(window: BrowserWindow, repoPermissionLevel: strin
       const accessTokenUrl = `${ACCESS_TOKEN_URL}/${code}`;
       return fetch(accessTokenUrl)
         .then((res) => res.json())
-        .then((data) => {
+        .then((data: { error }) => {
           if (data.error) {
             throw new Error(data.error);
           }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "moment": "^2.24.0",
     "ngx-markdown": "^9.1.1",
     "ngx-mat-select-search": "^3.3.3",
-    "node-fetch": "^3.3.0",
+    "node-fetch": "^2.6.8",
     "rxjs": "6.6.7",
     "tslib": "^1.10.0",
     "uuid": "7.0.3",


### PR DESCRIPTION
### Summary:
Fixes #1112 

### Changes Made:
* Downgrade the node-fetch version to version 2, as recommended in https://www.npmjs.com/package/node-fetch?activeTab=readme#loading-and-configuring-the-module.

### Proposed Commit Message:
```
Fix Error [ERR_REQUIRE_ESM]

node-fetch v3 is an ESM-only module, so we cannot use the CommonJS
require statement. Instead, we can downgrade to version 2.
```
