### PR TITLE
Automate generation of list bullet points and numberings in markdown editor

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -376,6 +376,7 @@ export class CommentEditorComponent implements OnInit {
     const selectionEnd = this.commentTextArea.nativeElement.selectionEnd;
     const currentText = this.commentField.value;
     const end = currentText.slice(selectionEnd);
+    const start = currentText.slice(0, selectionStart);
 
     const lastLineStart = currentText.lastIndexOf('\n', selectionStart - 1) + 1;
     const lastLine = currentText.slice(lastLineStart, selectionStart);
@@ -392,7 +393,7 @@ export class CommentEditorComponent implements OnInit {
 
     // checks if the last line in before is a list item
     if (!matchResult) {
-      this.commentField.setValue(`${currentText.slice(0, selectionStart)}\n${end}`);
+      this.commentField.setValue(`${start}\n${end}`);
       this.commentTextArea.nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
       return;
     }
@@ -405,9 +406,9 @@ export class CommentEditorComponent implements OnInit {
       // delete the last line if the current bullet is empty
       newText = `${currentText.slice(0, lastLineStart)}${end}`;
     } else if (iterator.slice(-1) === '.') {
-      newText = `${currentText.slice(0, selectionStart)}\n${indent}${parseInt(iterator.slice(0, -1), 10) + 1}. ${end}`;
+      newText = `${start}\n${indent}${parseInt(iterator.slice(0, -1), 10) + 1}. ${end}`;
     } else {
-      newText = `${currentText.slice(0, selectionStart)}\n${indent}${iterator} ${end}`;
+      newText = `${start}\n${indent}${iterator} ${end}`;
     }
 
     this.commentField.setValue(newText);

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -381,7 +381,9 @@ export class CommentEditorComponent implements OnInit {
     const lastLine = currentText.slice(lastLineStart, selectionStart);
 
     let lastLineEnd = end.indexOf('\n');
-    if (lastLineEnd == -1) lastLineEnd = end.length;
+    if (lastLineEnd === -1) {
+      lastLineEnd = end.length;
+    }
 
     const lastLine2 = end.slice(0, lastLineEnd);
 
@@ -396,15 +398,14 @@ export class CommentEditorComponent implements OnInit {
     }
 
     const match2 = /^\s*(\[[ xX]\]\s*)?$/; // checks if it's an empty checkbox
-    let [_, indent, iterator, text] = [...matchResult];
+    const [_, indent, iterator, text] = [...matchResult];
     let newText: string;
 
-    if (match2.test(text) && lastLine2.trim().length == 0) {
+    if (match2.test(text) && lastLine2.trim().length === 0) {
       // delete the last line if the current bullet is empty
       newText = `${currentText.slice(0, lastLineStart)}${end}`;
-    } else if (iterator.slice(-1) == '.') {
-      let num = parseInt(iterator.slice(0, -1));
-      newText = `${currentText.slice(0, selectionStart)}\n${indent}${num + 1}. ${end}`;
+    } else if (iterator.slice(-1) === '.') {
+      newText = `${currentText.slice(0, selectionStart)}\n${indent}${parseInt(iterator.slice(0, -1), 10) + 1}. ${end}`;
     } else {
       newText = `${currentText.slice(0, selectionStart)}\n${indent}${iterator} ${end}`;
     }

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -448,7 +448,7 @@ export class CommentEditorComponent implements OnInit {
     }
     const [_, indent, iterator, text] = [...matchResult];
     const num = parseInt(iterator, 10);
-    if (indent === indentLevel && num == incrementIndexIf) {
+    if (indent === indentLevel && num === incrementIndexIf) {
       return `\n${indent}${num + 1}${text}${this.incrementOrderedItem(data, index, indentLevel, num + 1)}`;
     }
     return data.slice(startIndex);


### PR DESCRIPTION
### Summary:
Fixes #1156 

### Changes Made:
* Adds generation of new list items upon pressing of enter key by the user.

### Proposed Commit Message:
```
Currently no action is done when the user inserts a new line when modifying a list in the Markdown editor
Let's include in functionality to auto generate list bullet points/numberings.
```
