### PR TITLE
Fix TesterResponse & IssueDispute representation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "main": "main.js",
   "scripts": {
     "postinstall": "npm run postinstall:electron && electron-builder install-app-deps",

--- a/src/app/core/models/issue-dispute.model.ts
+++ b/src/app/core/models/issue-dispute.model.ts
@@ -3,7 +3,7 @@ export class IssueDispute {
   readonly TODO_DESCRIPTION = 'Done';
   readonly INITIAL_RESPONSE = '[replace this with your explanation]';
   readonly TITLE_PREFIX = '## :question: ';
-  readonly LINE_BREAK = '-------------------\n';
+  readonly LINE_BREAK = '<catcher-end-of-segment><hr>\n';
   title: string; // e.g Issue severity
   description: string; // e.g Team says: xxx\n Tester says: xxx.
   tutorResponse: string; // e.g Not justified. I've changed it back.

--- a/src/app/core/models/tester-response.model.ts
+++ b/src/app/core/models/tester-response.model.ts
@@ -4,7 +4,7 @@ export class TesterResponse {
   readonly TITLE_PREFIX = '## :question: ';
   readonly DISAGREEMENT_PREFIX = '**Reason for disagreement:** ';
   readonly INITIAL_RESPONSE = '[replace this with your explanation]';
-  readonly LINE_BREAK = '-------------------\n';
+  readonly LINE_BREAK = '<catcher-end-of-segment><hr>\n';
   title: string; // e.g Issue Severity
   description: string; // e.g Team chose `Low`. Originally `High`.
   disagreeCheckbox: Checkbox; // e.g - [x] I disagree


### PR DESCRIPTION
### Summary:
Fixes #1173 

### Changes Made:
- Update `TesterResponse` string representation
- Update `IssueDispute` string representation
- Update version in `package.json` to 3.4.7

### Commit Message:
```
Fix TesterResponse & IssueDispute representation

Let's update the string representation of TesterResponse and
IssueDispute to use the new line separator <catcher-end-of-segment><hr>
instead of `--------------`.
```