### PR TITLE
Fix peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/jasminewd2": "2.0.8",
     "@types/node": "^15.6.1",
     "angular-cli-ghpages": "^1.0.0-rc.2",
-    "codelyzer": "^5.1.2",
+    "codelyzer": "^6.0.2",
     "graphql-codegen-fragment-matcher": "^0.18.2",
     "husky": "^4.2.5",
     "jasmine": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "graphql-codegen-fragment-matcher": "^0.18.2",
     "husky": "^4.2.5",
     "jasmine": "^3.9.0",
-    "jasmine-core": "~3.5.0",
+    "jasmine-core": "~3.8.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.0.0",
     "karma-chrome-launcher": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "graphql-tag": "2.11.0",
     "karma-spec-reporter": "0.0.32",
     "moment": "^2.24.0",
-    "ngx-markdown": "^9.1.1",
+    "ngx-markdown": "^10.1.1",
     "ngx-mat-select-search": "^3.3.3",
     "node-fetch": "^2.6.8",
     "rxjs": "6.6.7",


### PR DESCRIPTION
### Summary:
- Partially address #1192 
- Resolves some missing peer dependencies which would eventually cause npm7+ to throw errors when we migrate to Node 16. Currently, these missing peer dependencies only throw warnings on npm6:
![image](https://github.com/CATcher-org/CATcher/assets/72195240/1e69e164-5ac1-4c9d-aa90-b03676f7e1f9)

Tested on Node 14 and Node 16.

### Changes Made:
- Bump `ngx-markdown` from 9.1.1 to 10.1.1
  -  As we have already moved on to Angular 10, it is [recommended ](https://github.com/jfcere/ngx-markdown/releases/tag/v10.0.0)that we upgrade this library to v10.

- Bump `codelyzer` from 5.1.2 to 6.0.2
  - codelyzer@5.1.2 required Angular 9 as a peer dependency. Since we have upgraded to Angular 10, we should bump codelyzer to a version that accepts Angular v10 as peer dependency.

- Bump `jasmine-core` from ~3.5.0 to ~3.8.0
  - `karma-jasmine-html-reporter` released minor version 1.7.0, which [dropped ](https://github.com/angular/angular-cli/issues/21326#issuecomment-877576859) [support ](https://github.com/dfederm/karma-jasmine-html-reporter/releases/tag/v1.7.0)for jasmine-core@3.5.0, causing a broken peer dependency. Let's bump jasmine-core up to ~3.8.0 to meet the new requirement.
  - You can see `jasmine-core`'s changelog from 3.50 to 3.80 [here](https://github.com/jasmine/jasmine/blob/main/release_notes/3.6.0.md)

### Proposed Commit Message:
```
Fix broken peer dependencies

Let's bump some of our libraries to a more updated version to resolve 
missing peer dependencies.
```
