### PR TITLE
Remove certain buttons in markdown toolbar

### DIFF
--- a/src/app/shared/comment-editor/markdown-toolbar/markdown-toolbar.component.html
+++ b/src/app/shared/comment-editor/markdown-toolbar/markdown-toolbar.component.html
@@ -53,14 +53,4 @@
       </button>
     </md-header>
   </md-task-list>
-  <md-mention>
-    <button matTooltip="Mention a user" mat-icon-button color="accent">
-      <mat-icon>alternate_email</mat-icon>
-    </button>
-  </md-mention>
-  <md-ref>
-    <button matTooltip="Reference an issue, pull request or discussion" mat-icon-button color="accent">
-      <mat-icon>message</mat-icon>
-    </button>
-  </md-ref>
 </markdown-toolbar>

--- a/tests/app/shared/comment-editor/comment-editor.component.spec.ts
+++ b/tests/app/shared/comment-editor/comment-editor.component.spec.ts
@@ -56,8 +56,6 @@ describe('CommentEditor', () => {
       'md-unordered-list',
       'md-ordered-list',
       'md-task-list',
-      'md-mention',
-      'md-ref'
     ];
 
     it('should render a formatting toolbar', () => {
@@ -92,8 +90,6 @@ describe('CommentEditor', () => {
       'md-unordered-list': '- ',
       'md-ordered-list': '1. ',
       'md-task-list': `- [ ] `,
-      'md-mention': '@',
-      'md-ref': '#'
     };
 
     // simulate each button being clicked and check that the markups added to the text
@@ -133,8 +129,6 @@ describe('CommentEditor', () => {
       'md-unordered-list': `- ${highlightedText}`,
       'md-ordered-list': `1. ${highlightedText}`,
       'md-task-list': `- [ ] ${highlightedText}`,
-      'md-mention': `@${highlightedText}`,
-      'md-ref': `#${highlightedText}`
     };
 
     // simulate each button being clicked and check that the markups added to the text


### PR DESCRIPTION
### Summary:
Fixes #1178 

### Changes Made:
* `markdown-toolbar.component.html`: remove `md-mention` and `md-ref` buttons as they do not provide significant benefits in the context of a PE
* `comment-editor.component.spec.ts`: remove `md-mention` and `md-ref` from button tests

### Proposed Commit Message:
```
Remove certain buttons in markdown toolbar

"Mention a user" and "Reference an issue, pull request or discussion" 
buttons in the markdown toolbar do not provide significant benefits in 
the context of a PE due to the lack of functionality and intended 
anonymity in the PE environment.

Removing these buttons avoids any potential confusion among users 
arising from the lack of support for these buttons.

Let's avoid any confusion by removing these buttons from the markdown 
toolbar.
```
