### PR TITLE
Fix comment-editor.component tests

### DIFF
--- a/tests/app/shared/comment-editor/comment-editor.component.spec.ts
+++ b/tests/app/shared/comment-editor/comment-editor.component.spec.ts
@@ -107,7 +107,7 @@ describe('CommentEditor', () => {
         buttonDe.nativeElement.click();
 
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
+        await fixture.whenStable().then(() => {
           const textBox: any = debugElement.query(By.css('textarea')).nativeElement;
           expect(textBox.value).toEqual(expectedMarkup);
         });
@@ -157,7 +157,7 @@ describe('CommentEditor', () => {
         buttonDe.nativeElement.click();
         fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
+        await fixture.whenStable().then(() => {
           expect(textBoxDe.nativeElement.value).toEqual(expectedMarkup);
         });
       });
@@ -194,7 +194,7 @@ describe('CommentEditor', () => {
       textBox.value = '123';
       textBox.dispatchEvent(new Event('input'));
 
-      fixture.whenStable().then(() => {
+      await fixture.whenStable().then(() => {
         expect(textBox.value).toEqual('123');
       });
     });


### PR DESCRIPTION
### Summary:
Fixes #1199 

### Changes Made:
* Fix bugged `async` tests by adding `await` like so
```
      await fixture.whenStable().then(() => {
```

### Proposed Commit Message:
```
Fix comment-editor.component tests

Async tests in `comment-editor.component.spec.ts` never fail even when
written to intentionally fail.

Let's fix the tests so that they fail when they should.
```
