### PR TITLE
Fix timeline-header css

### DIFF
--- a/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
+++ b/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
@@ -2,7 +2,7 @@
 <form [formGroup]="tutorResponseForm" #tutorForm="ngForm" (ngSubmit)="submitTutorResponseForm(tutorForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span style="vertical-align: middle; margin-left: 5px"> Post your response here. </span>
+      <span> Post your response here. </span>
       <button mat-button style="float: right" *ngIf="!isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div>

--- a/src/app/shared/view-issue/new-team-response/new-team-response.component.html
+++ b/src/app/shared/view-issue/new-team-response/new-team-response.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="newTeamResponseForm" #myForm="ngForm" (ngSubmit)="submitNewTeamResponse(myForm)">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span style="vertical-align: middle; margin-left: 5px"> Post your team's response here. </span>
+      <span> Post your team's response here. </span>
     </div>
 
     <div>

--- a/src/app/shared/view-issue/parse-error/parse-error.component.css
+++ b/src/app/shared/view-issue/parse-error/parse-error.component.css
@@ -6,6 +6,9 @@
   color: #586069;
   height: 35px;
   padding: 5px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .timeline-comment {

--- a/src/app/shared/view-issue/tester-response/tester-response.component.html
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.html
@@ -2,8 +2,8 @@
 <form [formGroup]="testerResponseForm" (ngSubmit)="submitTesterResponseForm()">
   <div class="timeline-comment">
     <div class="timeline-header">
-      <span style="vertical-align: middle; margin-left: 5px" *ngIf="this.isNewResponse()"> Please verify the following item(s). </span>
-      <span style="vertical-align: middle; margin-left: 5px" *ngIf="!this.isNewResponse()"> <strong>Tester</strong> responded. </span>
+      <span *ngIf="this.isNewResponse()"> Please verify the following item(s). </span>
+      <span *ngIf="!this.isNewResponse()"> <strong>Tester</strong> responded. </span>
       <button mat-button style="float: right" *ngIf="!isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,10 @@ body {
   color: #586069;
   height: 35px;
   padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-left: 10px;
 }
 
 .timeline-comment {


### PR DESCRIPTION
### Summary:
Fixes #1195 

### Changes Made:
* Add styles to `timeline-header` class in `styles.css` and `parse-error.component.css`
* Removed inline styling from the span of the following components:
  * issue-dispute.component
  * new-team-response.component
  * tester-response.component

![image](https://github.com/CATcher-org/CATcher/assets/110801974/613cbdb0-53a5-44c9-929f-2fbc04c3308f)

### Proposed Commit Message:
```
Vertically center titles of timeline-header class
```
