### PR TITLE
Save pageSize setting into sessionStorage

### DIFF
--- a/src/app/core/directives/item-per-page.directive.ts
+++ b/src/app/core/directives/item-per-page.directive.ts
@@ -1,10 +1,10 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, Input, OnInit } from '@angular/core';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 
 @Directive({
   selector: '[itemsPerPage]'
 })
-export class ItemsPerPageDirective {
+export class ItemsPerPageDirective implements OnInit {
   private element: MatPaginator;
   private key: string;
 

--- a/src/app/core/directives/item-per-page.directive.ts
+++ b/src/app/core/directives/item-per-page.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, Input } from '@angular/core';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+
+@Directive({
+  selector: '[itemsPerPage]'
+})
+export class ItemsPerPageDirective {
+  private element: MatPaginator;
+  private key: string;
+
+  @Input('itemsPerPage') id: string;
+
+  get pageSize() {
+    const cachedPageSize = sessionStorage.getItem(this.key) || this.element.pageSize;
+    return +cachedPageSize;
+  }
+
+  set pageSize(num: number) {
+    const pageSizeToCache = String(num);
+    sessionStorage.setItem(this.key, pageSizeToCache);
+  }
+
+  constructor(private el: MatPaginator) {
+    this.element = el;
+  }
+
+  ngOnInit(): void {
+    this.key = this.id + '-PageSize';
+    this.element.pageSize = this.pageSize;
+    this.element.page.subscribe((page: PageEvent) => {
+      this.pageSize = page.pageSize;
+    });
+  }
+}

--- a/src/app/core/directives/paginator-local-storage.directive.ts
+++ b/src/app/core/directives/paginator-local-storage.directive.ts
@@ -2,17 +2,17 @@ import { Directive, Input, OnInit } from '@angular/core';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 
 @Directive({
-  selector: '[itemsPerPage]'
+  selector: '[paginatorLocalStorage]'
 })
-export class ItemsPerPageDirective implements OnInit {
+export class PaginatorLocalStorageDirective implements OnInit {
   private element: MatPaginator;
   private key: string;
 
-  @Input('itemsPerPage') id: string;
+  @Input() paginatorLocalStorage: string;
 
   get pageSize() {
     const cachedPageSize = sessionStorage.getItem(this.key) || this.element.pageSize;
-    return +cachedPageSize;
+    return Number(cachedPageSize);
   }
 
   set pageSize(num: number) {
@@ -25,7 +25,7 @@ export class ItemsPerPageDirective implements OnInit {
   }
 
   ngOnInit(): void {
-    this.key = this.id + '-PageSize';
+    this.key = this.paginatorLocalStorage + '-PageSize';
     this.element.pageSize = this.pageSize;
     this.element.page.subscribe((page: PageEvent) => {
       this.pageSize = page.pageSize;

--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -29,5 +29,5 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
+  <app-issue-tables table_name="tableBugReporting" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
 </div>

--- a/src/app/phase-moderation/phase-moderation.component.html
+++ b/src/app/phase-moderation/phase-moderation.component.html
@@ -23,5 +23,5 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
+  <app-issue-tables table_name="tableModeration" [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
 </div>

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableFaulty"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
+++ b/src/app/phase-team-response/issues-faulty/issues-faulty.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableFaulty"
+    table_name="tableTeamResponseFaulty"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tablePending"
+    table_name="tableTeamResponsePending"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-team-response/issues-pending/issues-pending.component.html
+++ b/src/app/phase-team-response/issues-pending/issues-pending.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tablePending"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableResponded"
+    table_name="tableTeamResponseResponded"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-team-response/issues-responded/issues-responded.component.html
+++ b/src/app/phase-team-response/issues-responded/issues-responded.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableResponded"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-accepted/issue-accepted.component.html
+++ b/src/app/phase-tester-response/issue-accepted/issue-accepted.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableAccepted"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-accepted/issue-accepted.component.html
+++ b/src/app/phase-tester-response/issue-accepted/issue-accepted.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableAccepted"
+    table_name="tableTesterResponseAccepted"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-tester-response/issue-faulty/issue-faulty.component.html
+++ b/src/app/phase-tester-response/issue-faulty/issue-faulty.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableFaultyIssue"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-faulty/issue-faulty.component.html
+++ b/src/app/phase-tester-response/issue-faulty/issue-faulty.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableFaultyIssue"
+    table_name="tableTesterResponseFaulty"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.html
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tablePendingIssue"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/phase-tester-response/issue-pending/issue-pending.component.html
+++ b/src/app/phase-tester-response/issue-pending/issue-pending.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tablePendingIssue"
+    table_name="tableTesterResponsePending"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.html
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.html
@@ -12,7 +12,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableRespondedIssue"
+    table_name="tableTesterResponseResponded"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-tester-response/issue-responded/issue-responded.component.html
+++ b/src/app/phase-tester-response/issue-responded/issue-responded.component.html
@@ -11,5 +11,10 @@
     </mat-grid-tile>
   </mat-grid-list>
 
-  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons" [filters]="this.filter"></app-issue-tables>
+  <app-issue-tables
+    table_name="tableRespondedIssue"
+    [headers]="this.displayedColumns"
+    [actions]="this.actionButtons"
+    [filters]="this.filter"
+  ></app-issue-tables>
 </div>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -262,4 +262,4 @@
 <mat-card *ngIf="this.issues.isLoading$ | async" style="display: flex; justify-content: center; align-items: center">
   <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
 </mat-card>
-<mat-paginator [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>
+<mat-paginator [itemsPerPage]="this.table_name" [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -262,4 +262,4 @@
 <mat-card *ngIf="this.issues.isLoading$ | async" style="display: flex; justify-content: center; align-items: center">
   <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
 </mat-card>
-<mat-paginator [itemsPerPage]="this.table_name" [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>
+<mat-paginator [paginatorLocalStorage]="this.table_name" [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -36,6 +36,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   @Input() headers: string[];
   @Input() actions: ACTION_BUTTONS[];
   @Input() filters?: any = undefined;
+  @Input() table_name: string;
 
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;

--- a/src/app/shared/issue-tables/issue-tables.module.ts
+++ b/src/app/shared/issue-tables/issue-tables.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { ItemsPerPageDirective } from '../../core/directives/item-per-page.directive';
 import { MaterialModule } from '../material.module';
 import { IssueTablesComponent } from './issue-tables.component';
-import { ItemsPerPageDirective } from '../../core/directives/item-per-page.directive';
 
 @NgModule({
   exports: [IssueTablesComponent],

--- a/src/app/shared/issue-tables/issue-tables.module.ts
+++ b/src/app/shared/issue-tables/issue-tables.module.ts
@@ -3,10 +3,11 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from '../material.module';
 import { IssueTablesComponent } from './issue-tables.component';
+import { ItemsPerPageDirective } from '../../core/directives/item-per-page.directive';
 
 @NgModule({
   exports: [IssueTablesComponent],
-  declarations: [IssueTablesComponent],
+  declarations: [IssueTablesComponent, ItemsPerPageDirective],
   imports: [CommonModule, MaterialModule, RouterModule]
 })
 export class IssueTablesModule {}

--- a/src/app/shared/issue-tables/issue-tables.module.ts
+++ b/src/app/shared/issue-tables/issue-tables.module.ts
@@ -1,13 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ItemsPerPageDirective } from '../../core/directives/item-per-page.directive';
+import { PaginatorLocalStorageDirective } from '../../core/directives/paginator-local-storage.directive';
 import { MaterialModule } from '../material.module';
 import { IssueTablesComponent } from './issue-tables.component';
 
 @NgModule({
   exports: [IssueTablesComponent],
-  declarations: [IssueTablesComponent, ItemsPerPageDirective],
+  declarations: [IssueTablesComponent, PaginatorLocalStorageDirective],
   imports: [CommonModule, MaterialModule, RouterModule]
 })
 export class IssueTablesModule {}


### PR DESCRIPTION
### Summary:
Fixes #1051 

### Changes Made:
* Create a new attribute directive for `<mat-paginator>` found in `issue-tables` component
  * This directive provides a getter and setter for the pageSize selected in `<mat-paginator>`
  * pageSize is stored in sessionStorage
  * Each `app-issue-table` stores its own pageSize using a unique key
  
* Add an `@input` table_name to issue-tables component
  * This table_name is passed into the new attribute directive to be used as the table key of the pageSize variable in sessionStorage

* Add the attribute 'table_name' to the `<app-issue-tables>` tag in the following component html templates:
  * `phase-bug-reporting`
  * `phase-moderation`
  * `issues-faulty`
  * `issues-pending`
  * `issues-responded`
  * `issue-faulty`
  * `issue-pending`
  * `issue-accepted`
  * `issue-responded`

### Demo
![CATcher-Issue1051](https://github.com/CATcher-org/CATcher/assets/110801974/a177b070-e5dc-4cbc-92c1-753ae831742f)


### Proposed Commit Message:
```
Add attribute directive to mat-paginator

The selected items per page setting for each issue table is lost 
after navigation to a different page or on refresh.

Caching this setting is more user-friendly because users do 
not need to re-input the same page settings.

Let's save this setting to session storage using an attribute directive.
```
