### PR TITLE
Remove unauth GitHub api

### DIFF
--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -36,6 +36,9 @@ const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
 const CATCHER_REPO = 'CATcher';
 const UNABLE_TO_OPEN_IN_BROWSER = 'Unable to open this issue in Browser';
+function getSettingsUrl(org: string, repoName: string): string {
+  return `https://raw.githubusercontent.com/${org}/${repoName}/master/settings.json`;
+}
 
 let ORG_NAME = '';
 let MOD_ORG = '';
@@ -398,10 +401,8 @@ export class GithubService {
    * @return Observable<SessionData> representing session information.
    */
   fetchSettingsFile(): Observable<SessionData> {
-    return from(
-      octokit.repos.getContents({ owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json', headers: GithubService.IF_NONE_MATCH_EMPTY })
-    ).pipe(
-      map((rawData) => JSON.parse(atob(rawData['data']['content']))),
+    return from(fetch(getSettingsUrl(MOD_ORG, DATA_REPO))).pipe(
+      mergeMap((res) => res.json()),
       catchError((err) => throwError('Failed to fetch settings file.'))
     );
   }


### PR DESCRIPTION
### Summary:
Fixes #1220

### Changes Made:
* Use the unauthenticated REST API to fetch the settings first, and only fall back to using raw.githubusercontent.com if the REST API fails.
* To test it out you can run the following bash command on your computer to hit the rate limit of 60
`for i in {1..60}; do curl https://api.github.com/repos/CATcher-org/public_data/contents/settings.json; done;`

### Proposed Commit Message:
```
Use rest api first, then raw githubusercontent

REST API should be more reliable, but it has a rate limit
for unauthenticated requests. Let's use REST API call for
the fetching of settings.json, with a failsafe being
raw.githubusercontent.com.
```
