### PR TITLE
Fix broken duplicate link

### DIFF
--- a/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
+++ b/src/app/shared/issue/duplicatedIssues/duplicated-issues.component.html
@@ -8,7 +8,7 @@
       matTooltipPosition="above"
       (removed)="removeDuplicateStatus(duplicatedIssue)"
     >
-      <a class="no-underline link-grey-dark" [routerLink]="['./' + duplicatedIssue.id]"> #{{ duplicatedIssue.id }} </a>
+      <a class="no-underline link-grey-dark" [routerLink]="['../' + duplicatedIssue.id]"> #{{ duplicatedIssue.id }} </a>
       <mat-icon *ngIf="permissions.isTeamResponseEditable() || permissions.isTutorResponseEditable()" matChipRemove>cancel</mat-icon>
     </mat-chip>
   </mat-chip-list>


### PR DESCRIPTION
### Summary:
Fixes CATcher-org/CATcher#1228

### Changes Made:
I made the link work as expected.

Originally, the anchor tag appends the issue ID to the path. Hence the link from issue 1 to issue 2 looks like `<phase>/issues/1/2`, but it should be something like `<phase>/issues/2`. The link in the anchor tag now yields the correct path to the duplicate issue.

There are two places that this component is used, both of which I have (manually) tested:
1. Issue view (responded)
2. New team response

### Proposed Commit Message:
```
Fix the broken link of a duplicate issue

Currently, the user cannot open the link to a duplicate issue
when opening an issue, as described in CATcher-org/CATcher#1228.

The links now work as expected.
```