### PR TITLE
Redirect invalid routes to 404 not found page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,13 +6,15 @@ import { PhaseBugReportingModule } from './phase-bug-reporting/phase-bug-reporti
 import { PhaseModerationModule } from './phase-moderation/phase-moderation.module';
 import { PhaseTeamResponseModule } from './phase-team-response/phase-team-response.module';
 import { PhaseTesterResponseModule } from './phase-tester-response/phase-tester-response.module';
+import { PageNotFoundModule } from './shared/page-not-found/page-not-found.module';
 
 const routes: Routes = [
   { path: '', loadChildren: () => AuthModule },
   { path: 'phaseBugReporting', loadChildren: () => PhaseBugReportingModule, canLoad: [AuthGuard] },
   { path: 'phaseTeamResponse', loadChildren: () => PhaseTeamResponseModule, canLoad: [AuthGuard] },
   { path: 'phaseTesterResponse', loadChildren: () => PhaseTesterResponseModule, canLoad: [AuthGuard] },
-  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] }
+  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] },
+  { path: '**', loadChildren: () => PageNotFoundModule, canLoad: [AuthGuard] }
 ];
 
 @NgModule({

--- a/src/app/shared/page-not-found/page-not-found.component.css
+++ b/src/app/shared/page-not-found/page-not-found.component.css
@@ -1,0 +1,18 @@
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  height: 80vh;
+}
+
+h1 {
+  font-size: 2em;
+  margin-bottom: 10px;
+}
+
+p {
+  font-size: 1.2em;
+  color: #555;
+}

--- a/src/app/shared/page-not-found/page-not-found.component.html
+++ b/src/app/shared/page-not-found/page-not-found.component.html
@@ -1,0 +1,4 @@
+<div class="error-container">
+  <h1>404 - Page Not Found</h1>
+  <p>Sorry, the requested page could not be found.</p>
+</div>

--- a/src/app/shared/page-not-found/page-not-found.component.ts
+++ b/src/app/shared/page-not-found/page-not-found.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  templateUrl: './page-not-found.component.html',
+  styleUrls: ['./page-not-found.component.css']
+})
+export class PageNotFoundComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/page-not-found/page-not-found.module.ts
+++ b/src/app/shared/page-not-found/page-not-found.module.ts
@@ -1,7 +1,7 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PageNotFoundComponent } from './page-not-found.component';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { PageNotFoundComponent } from './page-not-found.component';
 
 @NgModule({
   declarations: [PageNotFoundComponent],

--- a/src/app/shared/page-not-found/page-not-found.module.ts
+++ b/src/app/shared/page-not-found/page-not-found.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PageNotFoundComponent } from './page-not-found.component';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [PageNotFoundComponent],
+  imports: [CommonModule, RouterModule.forChild([{ path: '', component: PageNotFoundComponent }])]
+})
+export class PageNotFoundModule {}


### PR DESCRIPTION
### Summary:
Fixes #1171

### Changes Made:
* Created `PageNotFoundModule`
* Added wildcard route to `app-routing` module to redirect invalid routes to `PageNotFoundModule`

### Screenshot:
![image](https://github.com/CATcher-org/CATcher/assets/107099783/63f0d5d7-2a94-4e35-9e9e-5f35f58723ff)

### Proposed Commit Message:
```
Redirect invalid routes to 404 not found page

There is an uncaught error when the application tries to redirect to invalid routes. 

Redirecting users to a 404 not found page enhances the user experience.

Let's create a PageNotFoundModule and redirect invalid routes to it.
```
