### PR TITLE
Uncaught error when invalid link is clicked

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,7 +12,8 @@ const routes: Routes = [
   { path: 'phaseBugReporting', loadChildren: () => PhaseBugReportingModule, canLoad: [AuthGuard] },
   { path: 'phaseTeamResponse', loadChildren: () => PhaseTeamResponseModule, canLoad: [AuthGuard] },
   { path: 'phaseTesterResponse', loadChildren: () => PhaseTesterResponseModule, canLoad: [AuthGuard] },
-  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] }
+  { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] },
+  { path: '**', redirectTo: '' }
 ];
 
 @NgModule({

--- a/src/app/core/directives/internal-link-disable.directive.ts
+++ b/src/app/core/directives/internal-link-disable.directive.ts
@@ -1,0 +1,32 @@
+import { Directive, HostListener } from '@angular/core';
+import { ErrorHandlingService } from '../services/error-handling.service';
+
+class InvalidLinkError extends Error {
+  constructor() {
+    super('Invalid link!');
+    Object.setPrototypeOf(this, InvalidLinkError.prototype);
+  }
+}
+
+@Directive({
+  selector: '[disableInternalLink]'
+})
+export class InternalLinkDisableDirective {
+  constructor(private errorHandlingService: ErrorHandlingService) {}
+
+  @HostListener('click', ['$event'])
+  public onClick(e: MouseEvent): void {
+    const srcElement = e.target;
+
+    if (srcElement instanceof HTMLAnchorElement) {
+      const baseURI = srcElement.baseURI;
+      const href = srcElement.href;
+
+      if (href.startsWith(baseURI)) {
+        this.errorHandlingService.handleError(new InvalidLinkError());
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }
+  }
+}

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -57,7 +57,7 @@
     </mat-tab>
     <mat-tab label="Preview">
       <div class="tab-content" style="min-height: 228px">
-        <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)"></markdown>
+        <markdown #markdownArea *ngIf="commentField.value !== ''" [data]="sanitize(commentField.value)" disableInternalLink></markdown>
         <div *ngIf="commentField.value === ''">Nothing to preview.</div>
       </div>
     </mat-tab>

--- a/src/app/shared/issue/description/description.component.html
+++ b/src/app/shared/issue/description/description.component.html
@@ -8,7 +8,7 @@
       </button>
     </div>
     <div *ngIf="!isEditing" class="comment">
-      <markdown [data]="issue.description"></markdown>
+      <markdown [data]="issue.description" disableInternalLink></markdown>
     </div>
     <div *ngIf="isEditing">
       <app-comment-editor

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,12 +7,14 @@ import { FormDisableControlDirective } from '../core/directives/form-disable-con
 import { ActionToasterModule } from './action-toasters/action-toasters.module';
 import { ErrorToasterModule } from './error-toasters/error-toaster.module';
 import { MaterialModule } from './material.module';
+import { InternalLinkDisableDirective } from '../core/directives/internal-link-disable.directive';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, HttpClientModule, RouterModule, MaterialModule, ErrorToasterModule],
-  declarations: [FormDisableControlDirective],
+  declarations: [FormDisableControlDirective, InternalLinkDisableDirective],
   exports: [
     FormDisableControlDirective,
+    InternalLinkDisableDirective,
     CommonModule,
     FormsModule,
     ReactiveFormsModule,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -4,10 +4,10 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { FormDisableControlDirective } from '../core/directives/form-disable-control.directive';
+import { InternalLinkDisableDirective } from '../core/directives/internal-link-disable.directive';
 import { ActionToasterModule } from './action-toasters/action-toasters.module';
 import { ErrorToasterModule } from './error-toasters/error-toaster.module';
 import { MaterialModule } from './material.module';
-import { InternalLinkDisableDirective } from '../core/directives/internal-link-disable.directive';
 
 @NgModule({
   imports: [CommonModule, FormsModule, ReactiveFormsModule, HttpClientModule, RouterModule, MaterialModule, ErrorToasterModule],

--- a/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
+++ b/src/app/shared/view-issue/issue-dispute/issue-dispute.component.html
@@ -9,10 +9,10 @@
       <div class="container" *ngFor="let dispute of issue.issueDisputes; index as i; trackBy: trackDisputeList">
         <div style="display: flex; align-items: center">
           <div class="question-mark">?</div>
-          <markdown [data]="this.getItemTitleText(dispute.title)"></markdown>
+          <markdown [data]="this.getItemTitleText(dispute.title)" disableInternalLink></markdown>
         </div>
         <br />
-        <markdown [data]="dispute.description"></markdown>
+        <markdown [data]="dispute.description" disableInternalLink></markdown>
         <br />
         <div>
           <mat-checkbox
@@ -27,7 +27,7 @@
         <br />
         <div>
           <markdown data="### Tutor's Response: "></markdown>
-          <markdown [data]="dispute.tutorResponse" *ngIf="!isEditing"></markdown>
+          <markdown [data]="dispute.tutorResponse" *ngIf="!isEditing" disableInternalLink></markdown>
         </div>
         <div *ngIf="isEditing">
           <app-comment-editor

--- a/src/app/shared/view-issue/team-response/team-response.component.html
+++ b/src/app/shared/view-issue/team-response/team-response.component.html
@@ -6,7 +6,7 @@
       <button style="float: right" mat-button *ngIf="canEditIssue() && !isEditing" (click)="changeToEditMode()">Edit</button>
     </div>
     <div *ngIf="!isEditing" class="comment">
-      <markdown [data]="issue.teamResponse"></markdown>
+      <markdown [data]="issue.teamResponse" disableInternalLink></markdown>
     </div>
     <div *ngIf="isEditing">
       <app-comment-editor

--- a/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.html
+++ b/src/app/shared/view-issue/tester-response/conflict-dialog/conflict-dialog.component.html
@@ -14,7 +14,7 @@
       <mat-expansion-panel-header>
         <mat-panel-title class="response-title">
           <div class="question-mark">?</div>
-          <markdown [data]="data.updatedResponses[i].getTitleInMarkDown()"></markdown>
+          <markdown [data]="data.updatedResponses[i].getTitleInMarkDown()" disableInternalLink></markdown>
         </mat-panel-title>
         <mat-panel-description>
           <mat-chip-list>
@@ -25,7 +25,7 @@
         </mat-panel-description>
       </mat-expansion-panel-header>
       <br />
-      <markdown [data]="data.updatedResponses[i].description"></markdown>
+      <markdown [data]="data.updatedResponses[i].description" disableInternalLink></markdown>
       <br />
       <div
         *ngIf="data.updatedResponses[i].isDisagree() === data.outdatedResponses[i].isDisagree() || !showDiff"

--- a/src/app/shared/view-issue/tester-response/tester-response.component.html
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.html
@@ -10,10 +10,10 @@
       <div class="container" *ngFor="let response of issue.testerResponses; index as i; trackBy: trackDisagreeList">
         <div style="display: flex; align-items: center">
           <div class="question-mark">?</div>
-          <markdown [data]="response.getTitleInMarkDown()"></markdown>
+          <markdown [data]="response.getTitleInMarkDown()" disableInternalLink></markdown>
         </div>
         <br />
-        <markdown [data]="response.description"></markdown>
+        <markdown [data]="response.description" disableInternalLink></markdown>
         <br />
         <div>
           <mat-radio-group
@@ -31,7 +31,7 @@
         <div *ngIf="testerResponseForm.get(getDisagreeRadioFormId(i)).value">
           <div>
             <p style="font-weight: 500">Reason for Disagreement:</p>
-            <markdown [data]="response.reasonForDisagreement" *ngIf="!isEditing"></markdown>
+            <markdown [data]="response.reasonForDisagreement" *ngIf="!isEditing" disableInternalLink></markdown>
           </div>
           <div *ngIf="isEditing">
             <app-comment-editor


### PR DESCRIPTION
### Summary:
Fixes #1171

### Issue Summary:
Users encounter an uncaught error when attempting to navigate to invalid links within the application. This issue manifests in two scenarios:

1. Users clicking on Markdown links may face errors when the link contains an incomplete URL. Incomplete URLs append to the base URL, resulting in invalid links and triggering uncaught errors.
2. Users enter an incorrect URL directly into the browser will encounter uncaught errors.

### Solutions

**Markdown Link Click Issue:**
- Considering that internal links are unlikely to be used for bug reporting and are more likely to be invalid
- If the link is internal, display an error snackbar.
- e.g. For markdown link `[link](images/123)`, the target link will be https://github.com/CATcher-org/images/123 which is an internal link

**Enter invalid link in browser:**
- Use Angular Router to redirect users to the login page.

### Changes Made:

- Created a directive to listen click events and identify internal links. It will open an error snackbar for internal links and prevent link navigation.
- Applied the directive to markdown tag in html
- Added a wildcard route to redirect invalid routes to the login page

### Result:

https://github.com/CATcher-org/CATcher/assets/107099783/00718b5a-41c3-4c5d-8ddf-bd8cfee12cb2

https://github.com/CATcher-org/CATcher/assets/107099783/28e48f97-6db2-45c3-bbeb-a33cb9e2da04

### Proposed Commit Message:
```
Fix uncaught errors when attempting to access an invalid route

There is an uncaught error when the users click on an invalid internal link in Markdown or enter an invalid link in browser.

Internal links are unlikely to be used for bug reporting and are more likely to be invalid.

Let's show an error toaster and stop the navigation when clicking on an internal link in Markdown. Also, redirect the users to the login page if the users enter invalid link in browser.
```
