### PR TITLE
Add parsing of subsets

### DIFF
--- a/src/app/shared/lib/marked.ts
+++ b/src/app/shared/lib/marked.ts
@@ -16,7 +16,7 @@ export function markedOptionsFactory(): MarkedOptions {
   return {
     renderer,
     gfm: true,
-    breaks: false,
+    breaks: true,
     pedantic: false,
     smartLists: true,
     smartypants: false


### PR DESCRIPTION
### Summary:
Fixes #1230

### Changes Made:
* Allow preserving line breaks. This is done by changing the `breaks` option in the app module markdown declaration.

Note that in #1230, the subset list is not exactly rendered as a list, but is rendered with linebreaks.

![image](https://github.com/CATcher-org/CATcher/assets/87511888/5010dfc3-4164-4490-b18b-0ff78d705ebd)

Github preserves linebreaks when rendering markdown, hence it looks like the items are rendered as list items.

One consequence of this PR is that, whenever two sentences are separated only by one line break, in html, instead of the two being one paragraph (as expected from standard markdown syntax), the two are preserved and rendered as two paragraphs (as expected behaviour of github markdown).

Summarising everything in one example, the following markdown code:

```md
1. Item 1
  A. Sub item 1
  B. Sub item 2


| Header 1 | Header 2 |
|---|---|
| Cell 1 | Content 2 |

* Name
* Space

Line 1.
Line 2.

Paragraph 1.

Paragraph 2.
```

is rendered as:

![image](https://github.com/CATcher-org/CATcher/assets/87511888/103f7329-487c-44e7-a35c-6169d441757c)

### Proposed Commit Message:
```
Preserve line breaks

With preserving linebreaks, subset list items are rendered as a list,
and paragraph rendering is the same as Github.
```