### PR TITLE
Faulty list view when back navigating

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,6 @@ import { GithubServiceFactory } from './core/services/factories/factory.github.s
 import { IssueServiceFactory } from './core/services/factories/factory.issue.service';
 import { GithubService } from './core/services/github.service';
 import { GithubEventService } from './core/services/githubevent.service';
-import { IssueTableSettingsService } from './core/services/issue-table-settings.service';
 import { IssueService } from './core/services/issue.service';
 import { LoggingService } from './core/services/logging.service';
 import { PhaseService } from './core/services/phase.service';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { GithubServiceFactory } from './core/services/factories/factory.github.s
 import { IssueServiceFactory } from './core/services/factories/factory.issue.service';
 import { GithubService } from './core/services/github.service';
 import { GithubEventService } from './core/services/githubevent.service';
+import { IssueTableSettingsService } from './core/services/issue-table-settings.service';
 import { IssueService } from './core/services/issue.service';
 import { LoggingService } from './core/services/logging.service';
 import { PhaseService } from './core/services/phase.service';
@@ -36,7 +37,6 @@ import { LabelDefinitionPopupComponent } from './shared/label-definition-popup/l
 import { HeaderComponent } from './shared/layout';
 import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
-import { IssueTableSettingsService } from './core/services/issue-table-settings.service';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { LabelDefinitionPopupComponent } from './shared/label-definition-popup/l
 import { HeaderComponent } from './shared/layout';
 import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
+import { IssueTableSettingsService } from './core/services/issue-table-settings.service';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],
@@ -76,6 +77,9 @@ import { SharedModule } from './shared/shared.module';
     {
       provide: ErrorHandler,
       useClass: ErrorHandlingService
+    },
+    {
+      provide: IssueTableSettingsService
     }
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,9 +77,6 @@ import { SharedModule } from './shared/shared.module';
     {
       provide: ErrorHandler,
       useClass: ErrorHandlingService
-    },
-    {
-      provide: IssueTableSettingsService
     }
   ],
   bootstrap: [AppComponent]

--- a/src/app/core/models/table-settings.model.ts
+++ b/src/app/core/models/table-settings.model.ts
@@ -1,5 +1,5 @@
 export class TableSettings {
-  public sortActiveId = '';
+  public sortActiveId = ''; // The ID of the column the table is sorted by
   public sortDirection = '';
   public pageSize = 20;
   public pageIndex = 0;

--- a/src/app/core/models/table-settings.model.ts
+++ b/src/app/core/models/table-settings.model.ts
@@ -1,0 +1,6 @@
+export class TableSettings {
+  public sortActiveId = '';
+  public sortDirection = '';
+  public pageSize = 20;
+  public pageIndex = 0;
+}

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -3,6 +3,11 @@ import { TableSettings } from '../models/table-settings.model';
 @Injectable({
   providedIn: 'root'
 })
+
+/**
+ * Responsible for storing and retrieving the table settings for issue tables created
+ * Map is required since there can be multiple tables within the same page
+ */
 export class IssueTableSettingsService {
   private _tableSettingsMap = {};
 

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -12,7 +12,6 @@ export class IssueTableSettingsService {
   private _tableSettingsMap: { [index: string]: TableSettings } = {};
 
   public getTableSettings(tableName: string): TableSettings {
-    console.log(this._tableSettingsMap);
     return this._tableSettingsMap[tableName] || new TableSettings();
   }
 

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -11,16 +11,16 @@ import { TableSettings } from '../models/table-settings.model';
 export class IssueTableSettingsService {
   private _tableSettingsMap: { [index: string]: TableSettings } = {};
 
-  public getTableSettings(tableName: string) {
+  public getTableSettings(tableName: string): TableSettings {
     console.log(this._tableSettingsMap);
     return this._tableSettingsMap[tableName] || new TableSettings();
   }
 
-  public setTableSettings(tableName: string, tableSettings: TableSettings) {
+  public setTableSettings(tableName: string, tableSettings: TableSettings): void {
     this._tableSettingsMap[tableName] = tableSettings;
   }
 
-  public clearTableSettings() {
+  public clearTableSettings(): void {
     this._tableSettingsMap = {};
   }
 }

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -1,10 +1,20 @@
 import { Injectable } from '@angular/core';
+import { TableSettings } from '../models/table-settings.model';
 @Injectable({
   providedIn: 'root'
 })
 export class IssueTableSettingsService {
-  public sortActiveId = '';
-  public sortDirection = '';
-  public pageSize = 20;
-  public pageIndex = 0;
+  private _tableSettingsMap = {};
+
+  public getTableSettings(tableName: string) {
+    return this._tableSettingsMap[tableName] || new TableSettings();
+  }
+
+  public setTableSettings(tableName: string, tableSettings: TableSettings) {
+    this._tableSettingsMap[tableName] = tableSettings;
+  }
+
+  public clearTableSettings() {
+    this._tableSettingsMap = {};
+  }
 }

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+@Injectable({
+  providedIn: 'root'
+})
+export class IssueTableSettingsService {
+  public sortActiveId = '';
+  public sortDirection = '';
+  public pageSize = 20;
+  public pageIndex = 0;
+}

--- a/src/app/core/services/issue-table-settings.service.ts
+++ b/src/app/core/services/issue-table-settings.service.ts
@@ -9,9 +9,10 @@ import { TableSettings } from '../models/table-settings.model';
  * Map is required since there can be multiple tables within the same page
  */
 export class IssueTableSettingsService {
-  private _tableSettingsMap = {};
+  private _tableSettingsMap: { [index: string]: TableSettings } = {};
 
   public getTableSettings(tableName: string) {
+    console.log(this._tableSettingsMap);
     return this._tableSettingsMap[tableName] || new TableSettings();
   }
 

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -1,4 +1,11 @@
-<mat-table [dataSource]="this.issues" matSort class="mat-elevation-z8">
+<mat-table
+  [dataSource]="this.issues"
+  matSort
+  [matSortActive]="this.issueTableSettingsService.sortActiveId"
+  [matSortDirection]="this.issueTableSettingsService.sortDirection"
+  (matSortChange)="this.sortChange($event)"
+  class="mat-elevation-z8"
+>
   <!-- ID Column -->
   <ng-container matColumnDef="id">
     <mat-header-cell *matHeaderCellDef mat-sort-header> ID </mat-header-cell>
@@ -262,4 +269,10 @@
 <mat-card *ngIf="this.issues.isLoading$ | async" style="display: flex; justify-content: center; align-items: center">
   <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
 </mat-card>
-<mat-paginator [paginatorLocalStorage]="this.table_name" [pageSize]="20" [pageSizeOptions]="[10, 20, 50]"></mat-paginator>
+<mat-paginator
+  [paginatorLocalStorage]="this.table_name"
+  [pageSize]="this.issueTableSettingsService.pageSize"
+  [pageSizeOptions]="[10, 20, 50]"
+  [pageIndex]="this.issueTableSettingsService.pageIndex"
+  (page)="this.pageChange($event)"
+></mat-paginator>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -1,8 +1,8 @@
 <mat-table
   [dataSource]="this.issues"
   matSort
-  [matSortActive]="this.issueTableSettingsService.sortActiveId"
-  [matSortDirection]="this.issueTableSettingsService.sortDirection"
+  [matSortActive]="this.tableSettings.sortActiveId"
+  [matSortDirection]="this.tableSettings.sortDirection"
   (matSortChange)="this.sortChange($event)"
   class="mat-elevation-z8"
 >
@@ -271,8 +271,8 @@
 </mat-card>
 <mat-paginator
   [paginatorLocalStorage]="this.table_name"
-  [pageSize]="this.issueTableSettingsService.pageSize"
+  [pageSize]="this.tableSettings.pageSize"
   [pageSizeOptions]="[10, 20, 50]"
-  [pageIndex]="this.issueTableSettingsService.pageIndex"
+  [pageIndex]="this.tableSettings.pageIndex"
   (page)="this.pageChange($event)"
 ></mat-paginator>

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -16,6 +16,7 @@ import { PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
 import { UndoActionComponent } from '../../shared/action-toasters/undo-action/undo-action.component';
 import { IssuesDataTable } from './IssuesDataTable';
+import { TableSettings } from '../../core/models/table-settings.model';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,
@@ -45,6 +46,8 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   issues: IssuesDataTable;
   issuesPendingDeletion: { [id: number]: boolean };
 
+  public tableSettings: TableSettings;
+
   public readonly action_buttons = ACTION_BUTTONS;
 
   // Messages for the modal popup window upon deleting an issue
@@ -69,6 +72,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.issues = new IssuesDataTable(this.issueService, this.sort, this.paginator, this.headers, this.filters);
     this.issuesPendingDeletion = {};
+    this.tableSettings = this.issueTableSettingsService.getTableSettings(this.table_name);
   }
 
   ngAfterViewInit(): void {
@@ -78,13 +82,15 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   }
 
   sortChange(newSort: Sort) {
-    this.issueTableSettingsService.sortActiveId = newSort.active;
-    this.issueTableSettingsService.sortDirection = newSort.direction;
+    this.tableSettings.sortActiveId = newSort.active;
+    this.tableSettings.sortDirection = newSort.direction;
+    this.issueTableSettingsService.setTableSettings(this.table_name, this.tableSettings);
   }
 
   pageChange(pageEvent: PageEvent) {
-    this.issueTableSettingsService.pageSize = pageEvent.pageSize;
-    this.issueTableSettingsService.pageIndex = pageEvent.pageIndex;
+    this.tableSettings.pageSize = pageEvent.pageSize;
+    this.tableSettings.pageIndex = pageEvent.pageIndex;
+    this.issueTableSettingsService.setTableSettings(this.table_name, this.tableSettings);
   }
 
   isActionVisible(action: ACTION_BUTTONS): boolean {

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
-import { MatPaginator } from '@angular/material/paginator';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 import { finalize } from 'rxjs/operators';
 import { Issue, STATUS } from '../../core/models/issue.model';
 import { DialogService } from '../../core/services/dialog.service';
@@ -15,6 +15,7 @@ import { PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
 import { UndoActionComponent } from '../../shared/action-toasters/undo-action/undo-action.component';
 import { IssuesDataTable } from './IssuesDataTable';
+import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,
@@ -57,6 +58,7 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     public labelService: LabelService,
     private githubService: GithubService,
     public issueService: IssueService,
+    public issueTableSettingsService: IssueTableSettingsService,
     private phaseService: PhaseService,
     private errorHandlingService: ErrorHandlingService,
     private logger: LoggingService,
@@ -73,6 +75,16 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     setTimeout(() => {
       this.issues.loadIssues();
     });
+  }
+
+  sortChange(newSort: Sort) {
+    this.issueTableSettingsService.sortActiveId = newSort.active;
+    this.issueTableSettingsService.sortDirection = newSort.direction;
+  }
+
+  pageChange(pageEvent: PageEvent) {
+    this.issueTableSettingsService.pageSize = pageEvent.pageSize;
+    this.issueTableSettingsService.pageIndex = pageEvent.pageIndex;
   }
 
   isActionVisible(action: ACTION_BUTTONS): boolean {

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -7,6 +7,7 @@ import { Issue, STATUS } from '../../core/models/issue.model';
 import { DialogService } from '../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { GithubService } from '../../core/services/github.service';
+import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 import { IssueService } from '../../core/services/issue.service';
 import { LabelService } from '../../core/services/label.service';
 import { LoggingService } from '../../core/services/logging.service';
@@ -15,7 +16,6 @@ import { PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
 import { UndoActionComponent } from '../../shared/action-toasters/undo-action/undo-action.component';
 import { IssuesDataTable } from './IssuesDataTable';
-import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -4,6 +4,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatSort, Sort } from '@angular/material/sort';
 import { finalize } from 'rxjs/operators';
 import { Issue, STATUS } from '../../core/models/issue.model';
+import { TableSettings } from '../../core/models/table-settings.model';
 import { DialogService } from '../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { GithubService } from '../../core/services/github.service';
@@ -16,7 +17,6 @@ import { PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
 import { UndoActionComponent } from '../../shared/action-toasters/undo-action/undo-action.component';
 import { IssuesDataTable } from './IssuesDataTable';
-import { TableSettings } from '../../core/models/table-settings.model';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -14,6 +14,7 @@ import { IssueService } from '../../core/services/issue.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { PhaseDescription, PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
+import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 
 const ISSUE_TRACKER_URL = 'https://github.com/CATcher-org/CATcher/issues';
 
@@ -45,7 +46,8 @@ export class HeaderComponent implements OnInit {
     private issueService: IssueService,
     private errorHandlingService: ErrorHandlingService,
     private githubService: GithubService,
-    private dialogService: DialogService
+    private dialogService: DialogService,
+    private issueTableSettingsService: IssueTableSettingsService
   ) {
     router.events
       .pipe(
@@ -80,6 +82,9 @@ export class HeaderComponent implements OnInit {
     this.githubService.reset();
     this.issueService.reset(false);
     this.reload();
+
+    // Reset Issue Table Settings
+    this.issueTableSettingsService.clearTableSettings();
 
     // Route app to new phase.
     this.router.navigateByUrl(this.phaseService.currentPhase);

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -10,11 +10,11 @@ import { DialogService } from '../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { GithubService } from '../../core/services/github.service';
 import { GithubEventService } from '../../core/services/githubevent.service';
+import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 import { IssueService } from '../../core/services/issue.service';
 import { LoggingService } from '../../core/services/logging.service';
 import { PhaseDescription, PhaseService } from '../../core/services/phase.service';
 import { UserService } from '../../core/services/user.service';
-import { IssueTableSettingsService } from '../../core/services/issue-table-settings.service';
 
 const ISSUE_TRACKER_URL = 'https://github.com/CATcher-org/CATcher/issues';
 


### PR DESCRIPTION
### Summary:
Fixes #1227 

### Changes Made:
* New model table-settings which stores kept settings
* New service issue-table-settings service which stores these table settings by table name
* Synchronization of component table settings and service table settings
* Clear of service table settings on routing
* Settings saved include page index, page size, active sort and active sort direction 

### Proposed Commit Message:
```
Issue table settings such as page index are not 
saved when table is re-mounted.

This behavior inconveniences users as their settings 
are reset everytime they navigate to a specific issue and back.

Let's lift up the table settings of each mounted table to 
a service which the tables pull from when mounted.
```
