### PR TITLE
Fix e2e regression caused by changes in AuthService

### DIFF
--- a/src/app/core/services/mocks/mock.auth.service.ts
+++ b/src/app/core/services/mocks/mock.auth.service.ts
@@ -98,4 +98,14 @@ export class MockAuthService {
   startOAuthProcess() {
     this.accessToken.next('FabricatedToken');
   }
+
+  navigateToLandingPage() {
+    this.router.navigateByUrl(this.phaseService.currentPhase);
+  }
+
+  clearNext() {}
+
+  getNext() {}
+
+  storeNext(next: any) {}
 }


### PR DESCRIPTION
### Summary:
Fixes #1274 

### Changes Made:
Added missing method signatures in `MockAuthService` so that it exists and can be called when the application is running in a test environment such as Playwright. They are:

- `navigateToLandingPage`
- `clearNext`
- `storeNext`
- `getNext`

It is also the reason why our Playwright tests are failing - the test environment crashes when it runs into the new method signatures that are not defined in MockAuthService.

### Proposed Commit Message:
```
Fix e2e regression caused by changes in AuthService

Previously, a PR introduced new method signatures in AuthService.
However, these were not introduced in MockAuthService, causing 
the testing environment to fail when the application encountered these
undefined method signatures.

Lets address this regression by adding the method signatures for these
methods.
```
