### PR TITLE
Retain github manual edit warning

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -13,6 +13,7 @@ import { TesterResponseTemplate } from './templates/tester-response-template.mod
 import { TutorModerationIssueTemplate } from './templates/tutor-moderation-issue-template.model';
 import { TutorModerationTodoTemplate } from './templates/tutor-moderation-todo-template.model';
 import { TesterResponse } from './tester-response.model';
+import { GITHUB_UI_EDIT_WARNING } from './templates/tester-response-template.model';
 
 export class Issue {
   /** Basic Fields */
@@ -286,6 +287,8 @@ export class Issue {
   // Template url: https://github.com/CATcher-org/templates#teams-response-1
   createGithubTesterResponse(): string {
     return (
+      GITHUB_UI_EDIT_WARNING +
+      '\n' +
       `# Team\'s Response\n${this.teamResponse}\n` +
       `# Items for the Tester to Verify\n${this.getTesterResponsesString(this.testerResponses)}`
     );

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -74,7 +74,7 @@ const DISAGREE_CHECKBOX_DESCRIPTION = 'I disagree';
 const TeamResponseSectionParser = buildTeamResponseSectionParser(TESTER_RESPONSES_HEADER);
 
 export const TesterResponseParser = coroutine(function* () {
-  yield possibly(str(GITHUB_UI_EDIT_WARNING));
+  yield str(GITHUB_UI_EDIT_WARNING);
   yield optionalWhitespace;
 
   const teamResponse = yield TeamResponseSectionParser;

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -65,7 +65,7 @@ interface TesterResponseParseResult {
   teamChosenType: string;
 }
 
-const GITHUB_UI_EDIT_WARNING =
+export const GITHUB_UI_EDIT_WARNING =
   // eslint-disable-next-line max-len
   '[IMPORTANT!: Please do not edit or reply to this comment using the GitHub UI. You can respond to it using CATcher during the next phase of the PE]';
 const TESTER_RESPONSES_HEADER = '# Items for the Tester to Verify';

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -15,7 +15,6 @@ import { UserService } from '../../../core/services/user.service';
 import { CommentEditorComponent } from '../../comment-editor/comment-editor.component';
 import { SUBMIT_BUTTON_TEXT } from '../view-issue.component';
 import { ConflictDialogComponent, TesterResponseConflictData } from './conflict-dialog/conflict-dialog.component';
-import { GITHUB_UI_EDIT_WARNING } from '../../../core/models/templates/tester-response-template.model';
 
 @Component({
   selector: 'app-tester-response',
@@ -79,7 +78,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
           if (isSaveToSubmit || this.isUpdatingDeletedResponse() || this.submitButtonText === SUBMIT_BUTTON_TEXT.OVERWRITE) {
             return this.issueService.updateTesterResponse(this.issue, <IssueComment>{
               ...this.issue.issueComment,
-              description: GITHUB_UI_EDIT_WARNING + '\n' + this.getTesterResponseFromForm()
+              description: this.getTesterResponseFromForm()
             });
           } else {
             this.submitButtonText = SUBMIT_BUTTON_TEXT.OVERWRITE;

--- a/src/app/shared/view-issue/tester-response/tester-response.component.ts
+++ b/src/app/shared/view-issue/tester-response/tester-response.component.ts
@@ -15,6 +15,7 @@ import { UserService } from '../../../core/services/user.service';
 import { CommentEditorComponent } from '../../comment-editor/comment-editor.component';
 import { SUBMIT_BUTTON_TEXT } from '../view-issue.component';
 import { ConflictDialogComponent, TesterResponseConflictData } from './conflict-dialog/conflict-dialog.component';
+import { GITHUB_UI_EDIT_WARNING } from '../../../core/models/templates/tester-response-template.model';
 
 @Component({
   selector: 'app-tester-response',
@@ -78,7 +79,7 @@ export class TesterResponseComponent implements OnInit, OnChanges {
           if (isSaveToSubmit || this.isUpdatingDeletedResponse() || this.submitButtonText === SUBMIT_BUTTON_TEXT.OVERWRITE) {
             return this.issueService.updateTesterResponse(this.issue, <IssueComment>{
               ...this.issue.issueComment,
-              description: this.getTesterResponseFromForm()
+              description: GITHUB_UI_EDIT_WARNING + '\n' + this.getTesterResponseFromForm()
             });
           } else {
             this.submitButtonText = SUBMIT_BUTTON_TEXT.OVERWRITE;

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -116,14 +116,20 @@ describe('Issue', () => {
     phaseTesterResponseIssue.teamResponse = 'Sample Text';
     phaseTesterResponseIssue.testerResponses = [];
     expect(phaseTesterResponseIssue.createGithubTesterResponse()).toEqual(
-      `# Team\'s Response\n${phaseTesterResponseIssue.teamResponse}\n` + `# Items for the Tester to Verify\n${''}`
+      `[IMPORTANT!: Please do not edit or reply to this comment using the GitHub UI. ` +
+        `You can respond to it using CATcher during the next phase of the PE]\n` +
+        `# Team\'s Response\n${phaseTesterResponseIssue.teamResponse}\n` +
+        `# Items for the Tester to Verify\n${''}`
     );
 
     const phaseTesterResponseIssue2 = dummyIssueWithTeam.clone(Phase.phaseTesterResponse);
     phaseTesterResponseIssue2.teamResponse = 'Sample Text';
     phaseTesterResponseIssue2.testerResponses = [newTesterResponse];
     expect(phaseTesterResponseIssue2.createGithubTesterResponse()).toEqual(
-      `# Team\'s Response\n${phaseTesterResponseIssue.teamResponse}\n` + `# Items for the Tester to Verify\n${newTesterResponse.toString()}`
+      `[IMPORTANT!: Please do not edit or reply to this comment using the GitHub UI. ` +
+        `You can respond to it using CATcher during the next phase of the PE]\n` +
+        `# Team\'s Response\n${phaseTesterResponseIssue.teamResponse}\n` +
+        `# Items for the Tester to Verify\n${newTesterResponse.toString()}`
     );
   });
 


### PR DESCRIPTION
### Summary:
Fixes #1021

### Changes Made:
* Added github manual edit warning to tester response so that the warning remains on the github comment when tester edits/submits a response
* Updated test code to reflect new changes

### Proposed Commit Message:
```
Retain github manual edit warning when editing/submitting in tester response phase

Github manual edit warning message disappears after editing/submitting in 
tester response phase.

The warning message should remain in the issue comment to warn testers 
against editing directly their response on GitHub directly.
```
