### PR TITLE
Add white-space style to markdown code block css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "main": "main.js",
   "engines": {
     "node": ">=14.0.0"

--- a/src/markdown.css
+++ b/src/markdown.css
@@ -606,6 +606,7 @@ markdown code {
   font-size: 85%;
   background-color: rgba(27, 31, 35, 0.05);
   border-radius: 3px;
+  white-space: break-spaces;
 }
 
 markdown pre {


### PR DESCRIPTION
### Summary:
Fixes #1273 

### Changes Made:
* Added `white-space: break-spaces;` to ngx-markdown `code` class in CSS
* Input preview
    * ![image](https://github.com/user-attachments/assets/2972fe02-49c7-4b77-a3bd-1384bd4ceca7)
* Display view
    * ![image](https://github.com/user-attachments/assets/7351ef53-cf89-43fe-9945-51a959d22b58)

### Proposed Commit Message:
```
Add break-space style to the code CSS class of ngx-markdown

When ngx-markdown generates HTML for comments, the browser collapses
whitespace by default, which incorrectly renders code blocks with
extra whitespaces.

To address this, let's add the style `white-space: break-spaces;` to
the code CSS class of ngx-markdown.

This solution aligns with how GitHub styles its markdown code
elements, ensuring that whitespace is preserved and the rendered
output meets user expectations.
```