### PR TITLE
Downgrade ubuntu version in playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]


### PR DESCRIPTION
### Summary:
Fixes #1292 

### Changes Made:
* Downgraded ubuntu version to v22.04 in playwright GitHub workflow. Refer to #1292 for more details.

### Proposed Commit Message:
Downgrade ubuntu version to v22.04 in playwright.yml

Playwright v1.33~ is incompatible with ubuntu-latest
(v24.x at the point of writing), causing the playwright 
workflow to fail at installing browser stage.

Let's fix the ubuntu version to v22.04 (i.e. the latest 
compatible ubuntu version).

Note that if we were to upgrade the playwright version
(instead of downgrading ubuntu version), it would 
require us to upgrade node version to >= 18, which 
is non-trivial.


