### PR TITLE
Fix formats in the comments

### DIFF
--- a/src/app/core/models/templates/section-parsers/issue-dispute-section-parser.model.ts
+++ b/src/app/core/models/templates/section-parsers/issue-dispute-section-parser.model.ts
@@ -19,8 +19,8 @@
  *
  * ### Team says:
  *
- * Team chose [`type.DocumentationBug`].
- * Originally [`type.FunctionalityBug`].
+ * Team chose [`type.DocumentationBug`]
+ * Originally [`type.FunctionalityBug`]
  *
  * This use case is just not in the docs.
  *

--- a/src/app/core/models/templates/section-parsers/tester-response-section-parser.model.ts
+++ b/src/app/core/models/templates/section-parsers/tester-response-section-parser.model.ts
@@ -8,8 +8,7 @@
  *
  * - [ ] I disagree
  *
- * **Reason for disagreement:**
- * { disagreement reason }
+ * **Reason for disagreement:** { disagreement reason }
  *
  * <catcher-end-of-segment><hr>
  *
@@ -17,13 +16,12 @@
  *
  * ## :question: Issue severity
  *
- * Team chose [`severity.Low`].
- * Originally [`severity.Medium`].
+ * Team chose [`severity.Low`]
+ * Originally [`severity.Medium`]
  *
  * - [x] I disagree
  *
- * **Reason for disagreement:**
- * The team is silly and doesn't understand how bad this bug is!!!
+ * **Reason for disagreement:** The team is silly and doesn't understand how bad this bug is!!!
  *
  * <catcher-end-of-segment><hr>
  */

--- a/src/app/core/models/templates/tester-response-template.model.ts
+++ b/src/app/core/models/templates/tester-response-template.model.ts
@@ -25,25 +25,23 @@
  *
  * ## :question: Issue type
  *
- * Team chose [`type.DocumentationBug`].
- * Originally [`type.FunctionalityBug`].
+ * Team chose [`type.DocumentationBug`]
+ * Originally [`type.FunctionalityBug`]
  *
  * [x] - I disagree
  *
- * **Reason for disagreement:**
- * It's not a use case, it's a bug! This has nothing to do with the docs.
+ * **Reason for disagreement:** It's not a use case, it's a bug! This has nothing to do with the docs.
  *
  * <catcher-end-of-segment><hr>
  *
  * ## :question: Issue severity
  *
- * Team chose [`severity.VeryLow`].
- * Originally [`severity.High`].
+ * Team chose [`severity.VeryLow`]
+ * Originally [`severity.High`]
  *
  * [x] - I disagree
  *
- * **Reason for disagreement:**
- * You don't understand how frustrating this bug is!!
+ * **Reason for disagreement:** You don't understand how frustrating this bug is!!
  *
  * <catcher-end-of-segment><hr>
  */


### PR DESCRIPTION
### Summary:
Addresses part of #1299 

### Changes Made:
* Remove the extra full stop after `Team Chose [ {{ tag }} ]` and `Originally [ {{ tag }} ]` from commented templates
* Replace the newline after `**Reason for disagreement:**` with a space from commented templates

### Proposed Commit Message:
```
Fix incorrect format of commented templates

Templates for the tester response phase's comments on GitHub found in 
the code comments are incorrect. The templates include an extra full 
stop after "Team Chose [ {{ tag }} ]" and "Originally [ {{ tag }} ]" and 
a new line after "**Reason for disagreement:**". 

This causes the issue to be filed under faulty issues when viewed in the 
Tester response phase on CATcher.

Let's fix the formats by removing the extra full stops and replacing the 
new line with a space.
```
