### PR TITLE
Add explicit engine.io dependency to resolve incompatibility errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "scuri": "^0.9.4",
     "ts-node": "^10.9.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "4.6.4"
+    "typescript": "4.6.4",
+    "engine.io": "6.6.2"
   }
 }


### PR DESCRIPTION
### Summary:
Fixes #1304

### Changes Made:
* Explicit declaration of ``engine.io@6.6.2`` package, a dependency of ``karma``
* Necessary as current stable node version of 16.20.2 does not support ``cookie@1.0.2``, a dependency of ``engine.io@6.6.3`` which is the latest and implicitly imported package of ``karma``

### Proposed Commit Message:
```
Add explicit engine.io dependency

karma uses the latest release of engine.io which has dependencies 
incompatible with our project's stable node version.

Let's use an explicit package declaration for engine.io to fix this error.

This is preferrable to updating the node version which could cause many
unforeseen errors in existing packages.
```
