### PR TITLE
Create new phase for bug trimming

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AuthModule } from './auth/auth.module';
 import { AuthGuard } from './core/guards/auth.guard';
 import { PhaseBugReportingModule } from './phase-bug-reporting/phase-bug-reporting.module';
+import { PhaseBugTrimmingModule } from './phase-bug-trimming/phase-bug-trimming.module';
 import { PhaseModerationModule } from './phase-moderation/phase-moderation.module';
 import { PhaseTeamResponseModule } from './phase-team-response/phase-team-response.module';
 import { PhaseTesterResponseModule } from './phase-tester-response/phase-tester-response.module';
@@ -10,6 +11,7 @@ import { PhaseTesterResponseModule } from './phase-tester-response/phase-tester-
 const routes: Routes = [
   { path: '', loadChildren: () => AuthModule },
   { path: 'phaseBugReporting', loadChildren: () => PhaseBugReportingModule, canLoad: [AuthGuard] },
+  { path: 'phaseBugTrimming', loadChildren: () => PhaseBugTrimmingModule, canLoad: [AuthGuard] },
   { path: 'phaseTeamResponse', loadChildren: () => PhaseTeamResponseModule, canLoad: [AuthGuard] },
   { path: 'phaseTesterResponse', loadChildren: () => PhaseTesterResponseModule, canLoad: [AuthGuard] },
   { path: 'phaseModeration', loadChildren: () => PhaseModerationModule, canLoad: [AuthGuard] },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,9 +37,17 @@ import { LabelDefinitionPopupComponent } from './shared/label-definition-popup/l
 import { HeaderComponent } from './shared/layout';
 import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
+import { PhaseBugTrimmingComponent } from './phase-bug-trimming/phase-bug-trimming.component';
 
 @NgModule({
-  declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],
+  declarations: [
+    AppComponent,
+    HeaderComponent,
+    UserConfirmationComponent,
+    LabelDefinitionPopupComponent,
+    SessionFixConfirmationComponent,
+    PhaseBugTrimmingComponent
+  ],
   imports: [
     BrowserModule,
     PhaseTesterResponseModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { PhaseService } from './core/services/phase.service';
 import { SessionFixConfirmationComponent } from './core/services/session-fix-confirmation/session-fix-confirmation.component';
 import { UserService } from './core/services/user.service';
 import { PhaseBugReportingModule } from './phase-bug-reporting/phase-bug-reporting.module';
+import { PhaseBugTrimmingModule } from './phase-bug-trimming/phase-bug-trimming.module';
 import { PhaseModerationModule } from './phase-moderation/phase-moderation.module';
 import { PhaseTeamResponseModule } from './phase-team-response/phase-team-response.module';
 import { PhaseTesterResponseModule } from './phase-tester-response/phase-tester-response.module';
@@ -37,23 +38,16 @@ import { LabelDefinitionPopupComponent } from './shared/label-definition-popup/l
 import { HeaderComponent } from './shared/layout';
 import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
-import { PhaseBugTrimmingComponent } from './phase-bug-trimming/phase-bug-trimming.component';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    HeaderComponent,
-    UserConfirmationComponent,
-    LabelDefinitionPopupComponent,
-    SessionFixConfirmationComponent,
-    PhaseBugTrimmingComponent
-  ],
+  declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],
   imports: [
     BrowserModule,
     PhaseTesterResponseModule,
     BrowserAnimationsModule,
     AuthModule,
     PhaseBugReportingModule,
+    PhaseBugTrimmingModule,
     PhaseTeamResponseModule,
     PhaseModerationModule,
     SharedModule,

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -129,6 +129,10 @@ export class Issue {
     return new Issue(githubIssue);
   }
 
+  public static createPhaseBugTrimmingIssue(githubIssue: GithubIssue): Issue {
+    return new Issue(githubIssue);
+  }
+
   public static createPhaseTeamResponseIssue(githubIssue: GithubIssue, teamData: Team): Issue {
     const issue = new Issue(githubIssue);
     const template = new TeamResponseTemplate(githubIssue.comments);
@@ -337,6 +341,11 @@ export enum FILTER {
 
 export const IssuesFilter = {
   phaseBugReporting: {
+    Student: FILTER.FilterByCreator,
+    Tutor: FILTER.NoFilter,
+    Admin: FILTER.NoFilter
+  },
+  phaseBugTrimming: {
     Student: FILTER.FilterByCreator,
     Tutor: FILTER.NoFilter,
     Admin: FILTER.NoFilter

--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -201,6 +201,8 @@ export class Issue {
     switch (phase) {
       case Phase.phaseBugReporting:
         return Issue.createPhaseBugReportingIssue(this.githubIssue);
+      case Phase.phaseBugTrimming:
+        return Issue.createPhaseBugTrimmingIssue(this.githubIssue);
       case Phase.phaseTeamResponse:
         return Issue.createPhaseTeamResponseIssue(this.githubIssue, this.teamAssigned);
       case Phase.phaseTesterResponse:
@@ -224,6 +226,9 @@ export class Issue {
     this.githubComments = issue.githubComments;
     switch (phase) {
       case Phase.phaseBugReporting:
+        this.description = issue.description;
+        break;
+      case Phase.phaseBugTrimming:
         this.description = issue.description;
         break;
       case Phase.phaseTeamResponse:

--- a/src/app/core/models/phase.model.ts
+++ b/src/app/core/models/phase.model.ts
@@ -1,5 +1,6 @@
 export enum Phase {
   phaseBugReporting = 'phaseBugReporting',
+  phaseBugTrimming = 'phaseBugTrimming',
   phaseTeamResponse = 'phaseTeamResponse',
   phaseTesterResponse = 'phaseTesterResponse',
   phaseModeration = 'phaseModeration'

--- a/src/app/core/models/session.model.ts
+++ b/src/app/core/models/session.model.ts
@@ -5,6 +5,7 @@ import { Phase } from './phase.model';
 export interface SessionData {
   openPhases: Phase[];
   [Phase.phaseBugReporting]: string;
+  [Phase.phaseBugTrimming]: string;
   [Phase.phaseTeamResponse]: string;
   [Phase.phaseTesterResponse]: string;
   [Phase.phaseModeration]: string;

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -87,15 +87,14 @@ export class IssueService {
           return EMPTY;
         }
         return this.githubService.fetchIssueGraphql(issueId).pipe(
-            map((response) => {
-              const issue = this.createIssueModel(response);
-              this.updateLocalStore(issue);
-              return issue;
-            }),
-            catchError((err) => this.getIssue(issueId))
-          );
-        }
-      )
+          map((response) => {
+            const issue = this.createIssueModel(response);
+            this.updateLocalStore(issue);
+            return issue;
+          }),
+          catchError((err) => this.getIssue(issueId))
+        );
+      })
     );
   }
 
@@ -419,7 +418,11 @@ export class IssueService {
   private createLabelsForIssue(issue: Issue): string[] {
     const result = [];
 
-    if (this.phaseService.currentPhase !== Phase.phaseBugReporting && this.phaseService.currentPhase !== Phase.phaseTesterResponse) {
+    if (
+      this.phaseService.currentPhase !== Phase.phaseBugReporting &&
+      this.phaseService.currentPhase !== Phase.phaseBugTrimming &&
+      this.phaseService.currentPhase !== Phase.phaseTesterResponse
+    ) {
       const studentTeam = issue.teamAssigned.id.split('-');
       result.push(this.createLabel('tutorial', `${studentTeam[0]}-${studentTeam[1]}`), this.createLabel('team', studentTeam[2]));
     }
@@ -471,6 +474,9 @@ export class IssueService {
     switch (this.phaseService.currentPhase) {
       case Phase.phaseBugReporting:
         issue = Issue.createPhaseBugReportingIssue(githubIssue);
+        break;
+      case Phase.phaseBugTrimming:
+        issue = Issue.createPhaseBugTrimmingIssue(githubIssue);
         break;
       case Phase.phaseTeamResponse:
         issue = Issue.createPhaseTeamResponseIssue(githubIssue, this.dataService.getTeam(this.extractTeamIdFromGithubIssue(githubIssue)));

--- a/src/app/core/services/issue.service.ts
+++ b/src/app/core/services/issue.service.ts
@@ -87,14 +87,15 @@ export class IssueService {
           return EMPTY;
         }
         return this.githubService.fetchIssueGraphql(issueId).pipe(
-          map((response) => {
-            const issue = this.createIssueModel(response);
-            this.updateLocalStore(issue);
-            return issue;
-          }),
-          catchError((err) => this.getIssue(issueId))
-        );
-      })
+            map((response) => {
+              const issue = this.createIssueModel(response);
+              this.updateLocalStore(issue);
+              return issue;
+            }),
+            catchError((err) => this.getIssue(issueId))
+          );
+        }
+      )
     );
   }
 

--- a/src/app/core/services/mocks/mock.github.service.ts
+++ b/src/app/core/services/mocks/mock.github.service.ts
@@ -122,8 +122,15 @@ export class MockGithubService {
    */
   fetchSettingsFile(): Observable<SessionData> {
     return of({
-      openPhases: [Phase.phaseBugReporting, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration],
+      openPhases: [
+        Phase.phaseBugReporting,
+        Phase.phaseBugTrimming,
+        Phase.phaseTeamResponse,
+        Phase.phaseTesterResponse,
+        Phase.phaseModeration
+      ],
       [Phase.phaseBugReporting]: 'undefined',
+      [Phase.phaseBugTrimming]: 'undefined',
       [Phase.phaseTeamResponse]: 'undefined',
       [Phase.phaseTesterResponse]: 'undefined',
       [Phase.phaseModeration]: 'undefined'

--- a/src/app/core/services/mocks/mock.issue.service.ts
+++ b/src/app/core/services/mocks/mock.issue.service.ts
@@ -278,7 +278,11 @@ export class MockIssueService {
   private createLabelsForIssue(issue: Issue): string[] {
     const result = [];
 
-    if (this.phaseService.currentPhase !== Phase.phaseBugReporting && this.phaseService.currentPhase !== Phase.phaseTesterResponse) {
+    if (
+      this.phaseService.currentPhase !== Phase.phaseBugReporting &&
+      this.phaseService.currentPhase !== Phase.phaseBugTrimming &&
+      this.phaseService.currentPhase !== Phase.phaseTesterResponse
+    ) {
       const studentTeam = issue.teamAssigned.id.split('-');
       result.push(this.createLabel('tutorial', `${studentTeam[0]}-${studentTeam[1]}`), this.createLabel('team', studentTeam[2]));
     }
@@ -328,6 +332,8 @@ export class MockIssueService {
     switch (this.phaseService.currentPhase) {
       case Phase.phaseBugReporting:
         return Issue.createPhaseBugReportingIssue(githubIssue);
+      case Phase.phaseBugTrimming:
+        return Issue.createPhaseBugTrimmingIssue(githubIssue);
       case Phase.phaseTeamResponse:
         return Issue.createPhaseTeamResponseIssue(githubIssue, this.dataService.getTeam(this.extractTeamIdFromGithubIssue(githubIssue)));
       case Phase.phaseTesterResponse:

--- a/src/app/core/services/permission.service.ts
+++ b/src/app/core/services/permission.service.ts
@@ -42,7 +42,38 @@ const PERMISSIONS = {
       isTutorResponseEditable: false
     }
   },
-
+  [Phase.phaseBugTrimming]: {
+    [UserRole.Student]: {
+      isIssueCreatable: false,
+      isIssueDeletable: true,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
+    },
+    [UserRole.Tutor]: {
+      isIssueCreatable: false,
+      isIssueDeletable: false,
+      isIssueTitleEditable: false,
+      isIssueDescriptionEditable: false,
+      isIssueLabelsEditable: false,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
+    },
+    [UserRole.Admin]: {
+      isIssueCreatable: true,
+      isIssueDeletable: true,
+      isIssueTitleEditable: true,
+      isIssueDescriptionEditable: true,
+      isIssueLabelsEditable: true,
+      isTeamResponseEditable: false,
+      isTesterResponseEditable: false,
+      isTutorResponseEditable: false
+    }
+  },
   [Phase.phaseTeamResponse]: {
     [UserRole.Student]: {
       isIssueCreatable: false,

--- a/src/app/core/services/phase.service.ts
+++ b/src/app/core/services/phase.service.ts
@@ -12,6 +12,7 @@ export const SESSION_AVALIABILITY_FIX_FAILED = 'Session Availability Fix failed.
 
 export const PhaseDescription = {
   [Phase.phaseBugReporting]: 'Bug Reporting Phase',
+  [Phase.phaseBugTrimming]: 'Bug Trimming Phase',
   [Phase.phaseTeamResponse]: "Team's Response Phase",
   [Phase.phaseTesterResponse]: "Tester's Response Phase",
   [Phase.phaseModeration]: 'Moderation Phase'
@@ -34,6 +35,7 @@ export class PhaseService {
 
   private phaseRepoOwners = {
     phaseBugReporting: '',
+    phaseBugTrimming: '',
     phaseTeamResponse: '',
     phaseTesterResponse: '',
     phaseModeration: ''
@@ -49,6 +51,7 @@ export class PhaseService {
   setPhaseOwners(org: string, user: string): void {
     this.orgName = org;
     this.phaseRepoOwners.phaseBugReporting = user;
+    this.phaseRepoOwners.phaseBugTrimming = user;
     this.phaseRepoOwners.phaseTeamResponse = org;
     this.phaseRepoOwners.phaseTesterResponse = user;
     this.phaseRepoOwners.phaseModeration = org;

--- a/src/app/phase-bug-trimming/phase-bug-trimming-routing.module.ts
+++ b/src/app/phase-bug-trimming/phase-bug-trimming-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from '../core/guards/auth.guard';
+import { CanDeactivateIssueGuard } from '../core/guards/can-deactivate-issue-guard.service';
+import { PhaseBugTrimmingComponent } from './phase-bug-trimming.component';
+
+const routes: Routes = [
+  { path: 'phaseBugTrimming', component: PhaseBugTrimmingComponent, canActivate: [AuthGuard] }
+  // Insert new route here to view an issue to change label during bug trimming phase
+  // {
+  //   path: 'phaseBugTrimming/issues/:issue_id',
+  //   component: IssueComponent,
+  //   canActivate: [AuthGuard],
+  //   canDeactivate: [CanDeactivateIssueGuard]
+  // }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PhaseBugTrimmingRoutingModule {}

--- a/src/app/phase-bug-trimming/phase-bug-trimming.component.html
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.component.html
@@ -1,0 +1,1 @@
+<p>phase-bug-trimming works!</p>

--- a/src/app/phase-bug-trimming/phase-bug-trimming.component.ts
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+import { PermissionService } from '../core/services/permission.service';
+import { UserService } from '../core/services/user.service';
+
+@Component({
+  selector: 'app-phase-bug-trimming',
+  templateUrl: './phase-bug-trimming.component.html',
+  styleUrls: ['./phase-bug-trimming.component.css']
+})
+export class PhaseBugTrimmingComponent implements OnInit {
+  constructor(public permissions: PermissionService, public userService: UserService) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/phase-bug-trimming/phase-bug-trimming.module.ts
+++ b/src/app/phase-bug-trimming/phase-bug-trimming.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { SharedModule } from '../shared/shared.module';
+import { PhaseBugTrimmingRoutingModule } from './phase-bug-trimming-routing.module';
+import { PhaseBugTrimmingComponent } from './phase-bug-trimming.component';
+
+@NgModule({
+  imports: [PhaseBugTrimmingRoutingModule, SharedModule],
+  declarations: [PhaseBugTrimmingComponent]
+})
+export class PhaseBugTrimmingModule {}

--- a/src/app/shared/layout/header.component.ts
+++ b/src/app/shared/layout/header.component.ts
@@ -101,6 +101,7 @@ export class HeaderComponent implements OnInit {
   isOpenUrlButtonShown(): boolean {
     return (
       this.phaseService.currentPhase === Phase.phaseBugReporting ||
+      this.phaseService.currentPhase === Phase.phaseBugTrimming ||
       this.userService.currentUser.role === UserRole.Student ||
       this.issueService.getIssueTeamFilter() !== 'All Teams' ||
       this.router.url.includes('/issues')
@@ -146,7 +147,11 @@ export class HeaderComponent implements OnInit {
 
   private getTeamFilterString() {
     // First Phase does not need team filtering
-    if (this.phaseService.currentPhase === Phase.phaseBugReporting || this.phaseService.currentPhase === Phase.phaseTesterResponse) {
+    if (
+      this.phaseService.currentPhase === Phase.phaseBugReporting ||
+      this.phaseService.currentPhase === Phase.phaseBugTrimming ||
+      this.phaseService.currentPhase === Phase.phaseTesterResponse
+    ) {
       return '';
     }
 

--- a/tests/constants/session.constants.ts
+++ b/tests/constants/session.constants.ts
@@ -22,5 +22,5 @@ export const NO_OPEN_PHASES_SESSION_DATA: SessionData = {
 
 export const MULTIPLE_OPEN_PHASES_SESSION_DATA: SessionData = {
   ...BUG_REPORTING_PHASE_SESSION_DATA,
-  openPhases: [Phase.phaseBugReporting, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration]
+  openPhases: [Phase.phaseBugReporting, Phase.phaseBugTrimming, Phase.phaseTeamResponse, Phase.phaseTesterResponse, Phase.phaseModeration]
 };

--- a/tests/constants/session.constants.ts
+++ b/tests/constants/session.constants.ts
@@ -4,6 +4,7 @@ import { SessionData } from '../../src/app/core/models/session.model';
 export const BUG_REPORTING_PHASE_SESSION_DATA: SessionData = {
   openPhases: [Phase.phaseBugReporting],
   [Phase.phaseBugReporting]: 'bugreporting',
+  [Phase.phaseBugTrimming]: 'bugtrimming',
   [Phase.phaseTeamResponse]: 'pe-results',
   [Phase.phaseTesterResponse]: 'testerresponse',
   [Phase.phaseModeration]: 'pe-evaluation'

--- a/tests/model/issue.model.spec.ts
+++ b/tests/model/issue.model.spec.ts
@@ -64,6 +64,9 @@ describe('Issue', () => {
     const phaseBugReportingIssue = dummyIssue.clone(Phase.phaseBugReporting);
     expect(phaseBugReportingIssue).toEqual(dummyIssue);
 
+    const phaseBugTrimmingIssue = dummyIssue.clone(Phase.phaseBugTrimming);
+    expect(phaseBugTrimmingIssue).toEqual(dummyIssue);
+
     const phaseTeamResponseIssue = dummyIssueWithTeam.clone(Phase.phaseTeamResponse);
     expect(phaseTeamResponseIssue.githubComments).toEqual(dummyIssueWithTeam.githubComments);
     expect(phaseTeamResponseIssue.teamAssigned).toEqual(dummyTeam);

--- a/tests/services/permissions.service.spec.ts
+++ b/tests/services/permissions.service.spec.ts
@@ -29,6 +29,12 @@ describe('Test a few permissions for each role in each phase', () => {
     mockUserService.currentUser = testStudent;
     expect(permissionService.isIssueCreatable()).toBe(true);
     expect(permissionService.isTutorResponseEditable()).toBe(false);
+    mockPhaseService.currentPhase = Phase.phaseBugTrimming;
+    expect(permissionService.isIssueCreatable()).toBe(false);
+    expect(permissionService.isIssueDeletable()).toBe(true);
+    expect(permissionService.isIssueTitleEditable()).toBe(false);
+    expect(permissionService.isIssueDescriptionEditable()).toBe(false);
+    expect(permissionService.isIssueLabelsEditable()).toBe(true);
     mockPhaseService.currentPhase = Phase.phaseTeamResponse;
     expect(permissionService.isIssueLabelsEditable()).toBe(true);
     expect(permissionService.isTeamResponseEditable()).toBe(true);
@@ -44,6 +50,10 @@ describe('Test a few permissions for each role in each phase', () => {
     mockPhaseService.currentPhase = Phase.phaseBugReporting;
     mockUserService.currentUser = testTutor;
     expect(permissionService.isIssueCreatable()).toBe(false);
+    expect(permissionService.isIssueTitleEditable()).toBe(false);
+    mockPhaseService.currentPhase = Phase.phaseBugTrimming;
+    expect(permissionService.isIssueCreatable()).toBe(false);
+    expect(permissionService.isIssueDeletable()).toBe(false);
     expect(permissionService.isIssueTitleEditable()).toBe(false);
     mockPhaseService.currentPhase = Phase.phaseTeamResponse;
     expect(permissionService.isIssueLabelsEditable()).toBe(false);
@@ -61,6 +71,10 @@ describe('Test a few permissions for each role in each phase', () => {
     mockUserService.currentUser = testAdmin;
     expect(permissionService.isIssueCreatable()).toBe(true);
     expect(permissionService.isTutorResponseEditable()).toBe(false);
+    mockPhaseService.currentPhase = Phase.phaseBugTrimming;
+    expect(permissionService.isIssueCreatable()).toBe(true);
+    expect(permissionService.isIssueLabelsEditable()).toBe(true);
+    expect(permissionService.isTeamResponseEditable()).toBe(false);
     mockPhaseService.currentPhase = Phase.phaseTeamResponse;
     expect(permissionService.isIssueLabelsEditable()).toBe(true);
     expect(permissionService.isTeamResponseEditable()).toBe(true);


### PR DESCRIPTION
### Summary:
Fixes #1306

### Changes Made:
- Added a new component called bug-trimming
- Added new phase into `phase.model.ts`
- Added new phase into `session.model.ts`
- Added new phase into `permission.service.ts`
- Updated `issue.service.ts` to handle new bug trimming phase

### Proposed Commit Message:
```
Add new phase called bug trimming to CATcher

This new implementation is needed to support the new phase of
CATcher.

Multiple phases have to be updated to support the phase. These files
are phase.model.ts, session.model.ts, permission.service.ts and
issue.service.ts.

The new implementation of the phase is similar to how previous
phases are implemented.

The new public_data setting for the new phase can be found in
PR #1308.
```

### Additional info
Since we are still enabling students to update during this phase, The following section in `phase-bug-trimming-routing.module.ts` should be updated to the correct IssueComponent.

```ts
  // Insert new route here to view an issue to change label during bug trimming phase
  // {
  //   path: 'phaseBugTrimming/issues/:issue_id',
  //   component: IssueComponent,
  //   canActivate: [AuthGuard],
  //   canDeactivate: [CanDeactivateIssueGuard]
  // }
  ```
  
  The new public_data setting should be similar to this new configuration
  

  ```
{
    "openPhases" : ["phaseBugReporting", "phaseBugTrimming", "phaseTeamResponse", "phaseTesterResponse", "phaseModeration"],
    "phaseBugReporting": "bugreporting",
    "phaseBugTrimming": "bugreporting",
    "phaseTeamResponse": "pe-results",
    "phaseTesterResponse": "bugreporting",
    "phaseModeration": "pe-evaluation"
}
```
