### PR TITLE
Fix RestGithubIssueState value for closed states

### DIFF
--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -1,6 +1,6 @@
 import { IssueFilters, IssueState } from '../../../../../graphql/graphql-types';
 
-export type RestGithubIssueState = 'open' | 'closed';
+export type RestGithubIssueState = 'open' | 'closed' | 'all';
 export type RestGithubSortBy = 'created' | 'updated' | 'comments';
 export type RestGithubSortDir = 'asc' | 'desc';
 
@@ -42,7 +42,8 @@ export default class RestGithubIssueFilter implements RestGithubIssueFilterData 
       mentioned: this.mentioned,
       milestone: this.milestone,
       since: this.since,
-      states: [this.state === 'closed' ? IssueState.Closed : IssueState.Open]
+      states:
+        this.state === 'all' ? [IssueState.Closed, IssueState.Open] : this.state === 'closed' ? [IssueState.Closed] : [IssueState.Open]
     };
   }
 }

--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -1,6 +1,6 @@
 import { IssueFilters, IssueState } from '../../../../../graphql/graphql-types';
 
-export type RestGithubIssueState = 'open' | 'close';
+export type RestGithubIssueState = 'open' | 'closed';
 export type RestGithubSortBy = 'created' | 'updated' | 'comments';
 export type RestGithubSortDir = 'asc' | 'desc';
 
@@ -42,7 +42,7 @@ export default class RestGithubIssueFilter implements RestGithubIssueFilterData 
       mentioned: this.mentioned,
       milestone: this.milestone,
       since: this.since,
-      states: [this.state === 'close' ? IssueState.Closed : IssueState.Open]
+      states: [this.state === 'closed' ? IssueState.Closed : IssueState.Open]
     };
   }
 }


### PR DESCRIPTION
### Summary:
Fixes #1310 

### Changes Made:
* Fix the value for RestGithubIssueState close state
Can correctly fetch closed issues when added a filter as follows in `issue.service.ts` file:
<img width="1081" alt="Screenshot 2025-02-04 at 4 41 13 PM" src="https://github.com/user-attachments/assets/eb4bb757-2a96-4d33-adfe-3ce4a6765e8f" />

Results when running the app (these issues are closed issues):
<img width="1448" alt="Screenshot 2025-02-04 at 4 41 58 PM" src="https://github.com/user-attachments/assets/7ba27d3c-eb88-45f0-a8e4-716e5c61648d" />

On top of that, also added the value 'all' which is also a valid value according to GitHub Api [docs](https://docs.github.com/en/rest/issues/issues#list-repository-issues--parameters):



### Proposed Commit Message:
```
Fix value of close state in RestGithubIssueState
to follow GitHub api standards

According to GitHub standards, the value for 
closed state when filtering for issues should be 
`closed` instead of `close`

Let's fix the value to the correct value: `closed`,
and add the valid `all` value together
```
