### PR TITLE
Fix incorrect Github REST API response types

### DIFF
--- a/src/app/core/models/github/cache-manager/issues-cache-manager.model.ts
+++ b/src/app/core/models/github/cache-manager/issues-cache-manager.model.ts
@@ -1,5 +1,5 @@
-import { GithubIssue } from '../github-issue.model';
 import { GithubResponse } from '../github-response.model';
+import { GithubRestIssue } from '../github-rest-issue';
 
 /**
  * A model that is used to manage the cache of multiple list of issues paginated by pages.
@@ -8,7 +8,7 @@ import { GithubResponse } from '../github-response.model';
 export class IssuesCacheManager {
   // An array of cache github responses containing the array of GithubIssue as its data
   // The index in this array represents (page number - 1)
-  private issuesCache: GithubResponse<GithubIssue[]>[];
+  private issuesCache: GithubResponse<GithubRestIssue[]>[];
 
   constructor() {
     this.issuesCache = [];
@@ -23,11 +23,11 @@ export class IssuesCacheManager {
     return latestEtag;
   }
 
-  get(pageNumber: number): GithubResponse<GithubIssue[]> {
+  get(pageNumber: number): GithubResponse<GithubRestIssue[]> {
     return this.issuesCache[pageNumber - 1];
   }
 
-  set(pageNumber: number, response: GithubResponse<GithubIssue[]>): void {
+  set(pageNumber: number, response: GithubResponse<GithubRestIssue[]>): void {
     response.isCached = true;
     this.issuesCache[pageNumber - 1] = response;
   }

--- a/src/app/core/models/github/github-issue-filter.model.ts
+++ b/src/app/core/models/github/github-issue-filter.model.ts
@@ -1,6 +1,6 @@
 import { IssueFilters, IssueState } from '../../../../../graphql/graphql-types';
+import { RestGithubIssueState } from './github-rest-issue';
 
-export type RestGithubIssueState = 'open' | 'closed' | 'all';
 export type RestGithubSortBy = 'created' | 'updated' | 'comments';
 export type RestGithubSortDir = 'asc' | 'desc';
 

--- a/src/app/core/models/github/github-issue.model.ts
+++ b/src/app/core/models/github/github-issue.model.ts
@@ -26,6 +26,13 @@ export class GithubIssue {
   };
   comments: Array<GithubComment>;
 
+  static fromRestGithubIssue(restGithubIssue: GithubRestIssue): GithubIssue {
+    return new GithubIssue({
+      ...restGithubIssue,
+      state: restGithubIssue.state.toUpperCase()
+    });
+  }
+
   constructor(githubIssue: {}) {
     Object.assign(this, githubIssue);
     this.labels = [];
@@ -67,12 +74,5 @@ export class GithubIssue {
 
   findTeamId(): string {
     return `${this.findLabel('team')}.${this.findLabel('tutorial')}`;
-  }
-
-  static fromRestGithubIssue(restGithubIssue: GithubRestIssue): GithubIssue {
-    return new GithubIssue({
-      ...restGithubIssue,
-      state: restGithubIssue.state.toUpperCase()
-    });
   }
 }

--- a/src/app/core/models/github/github-issue.model.ts
+++ b/src/app/core/models/github/github-issue.model.ts
@@ -1,6 +1,7 @@
 import { IssueState } from '../../../../../graphql/graphql-types';
 import { GithubComment } from './github-comment.model';
 import { GithubLabel } from './github-label.model';
+import { GithubRestIssue } from './github-rest-issue';
 
 export class GithubIssue {
   id: string; // Github's backend's id
@@ -66,5 +67,12 @@ export class GithubIssue {
 
   findTeamId(): string {
     return `${this.findLabel('team')}.${this.findLabel('tutorial')}`;
+  }
+
+  static fromRestGithubIssue(restGithubIssue: GithubRestIssue): GithubIssue {
+    return new GithubIssue({
+      ...restGithubIssue,
+      state: restGithubIssue.state.toUpperCase()
+    });
   }
 }

--- a/src/app/core/models/github/github-rest-issue.ts
+++ b/src/app/core/models/github/github-rest-issue.ts
@@ -1,0 +1,26 @@
+import { GithubComment } from './github-comment.model';
+import { GithubLabel } from './github-label.model';
+
+export type GithubRestIssue = {
+  id: string; // Github's backend's id
+  number: number; // Issue's display id
+  assignees: Array<{
+    id: number;
+    login: string;
+    url: string;
+  }>;
+  body: string;
+  created_at: string;
+  labels: Array<GithubLabel>;
+  state: 'open' | 'closed';
+  title: string;
+  updated_at: string;
+  url: string;
+  user: {
+    // Author of the issue
+    login: string;
+    avatar_url: string;
+    url: string;
+  };
+  comments: Array<GithubComment>;
+};

--- a/src/app/core/models/github/github-rest-issue.ts
+++ b/src/app/core/models/github/github-rest-issue.ts
@@ -1,4 +1,5 @@
 import { GithubComment } from './github-comment.model';
+import { RestGithubIssueState } from './github-issue-filter.model';
 import { GithubLabel } from './github-label.model';
 
 export type GithubRestIssue = {
@@ -12,7 +13,7 @@ export type GithubRestIssue = {
   body: string;
   created_at: string;
   labels: Array<GithubLabel>;
-  state: 'open' | 'closed';
+  state: RestGithubIssueState;
   title: string;
   updated_at: string;
   url: string;

--- a/src/app/core/models/github/github-rest-issue.ts
+++ b/src/app/core/models/github/github-rest-issue.ts
@@ -1,6 +1,7 @@
 import { GithubComment } from './github-comment.model';
-import { RestGithubIssueState } from './github-issue-filter.model';
 import { GithubLabel } from './github-label.model';
+
+export type RestGithubIssueState = 'open' | 'closed' | 'all';
 
 export type GithubRestIssue = {
   id: string; // Github's backend's id

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -32,6 +32,7 @@ import { GithubRelease } from '../models/github/github.release';
 import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { LoggingService } from './logging.service';
+import { GithubRestIssue } from '../models/github/github-rest-issue';
 
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
@@ -362,25 +363,25 @@ export class GithubService {
 
   closeIssue(id: number): Observable<GithubIssue> {
     return from(octokit.issues.update({ owner: ORG_NAME, repo: REPO, issue_number: id, state: 'closed' })).pipe(
-      map((response: GithubResponse<GithubIssue>) => {
+      map((response: GithubResponse<GithubRestIssue>) => {
         this.issuesLastModifiedManager.set(id, response.headers['last-modified']);
-        return new GithubIssue(response.data);
+        return GithubIssue.fromRestGithubIssue(response.data);
       })
     );
   }
 
   reopenIssue(id: number): Observable<GithubIssue> {
     return from(octokit.issues.update({ owner: ORG_NAME, repo: REPO, issue_number: id, state: 'open' })).pipe(
-      map((response: GithubResponse<GithubIssue>) => {
+      map((response: GithubResponse<GithubRestIssue>) => {
         this.issuesLastModifiedManager.set(id, response.headers['last-modified']);
-        return new GithubIssue(response.data);
+        return GithubIssue.fromRestGithubIssue(response.data);
       })
     );
   }
 
   createIssue(title: string, description: string, labels: string[]): Observable<GithubIssue> {
     return from(octokit.issues.create({ owner: ORG_NAME, repo: REPO, title: title, body: description, labels: labels })).pipe(
-      map((response: GithubResponse<GithubIssue>) => new GithubIssue(response.data))
+      map((response: GithubResponse<GithubRestIssue>) => GithubIssue.fromRestGithubIssue(response.data))
     );
   }
 
@@ -402,9 +403,9 @@ export class GithubService {
         assignees: assignees
       })
     ).pipe(
-      map((response: GithubResponse<GithubIssue>) => {
+      map((response: GithubResponse<GithubRestIssue>) => {
         this.issuesLastModifiedManager.set(id, response.headers['last-modified']);
-        return new GithubIssue(response.data);
+        return GithubIssue.fromRestGithubIssue(response.data);
       }),
       catchError((err) => throwError(err))
     );

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -154,20 +154,20 @@ export class GithubService {
    * @returns Observable<boolean> that returns true if there are pages that do not exist in the cache model.
    */
   private toFetchIssues(filter: RestGithubIssueFilter): Observable<boolean> {
-    let responseInFirstPage: GithubResponse<GithubIssue[]>;
+    let responseInFirstPage: GithubResponse<GithubRestIssue[]>;
     return this.getIssuesAPICall(filter, 1).pipe(
-      map((response: GithubResponse<GithubIssue[]>) => {
+      map((response: GithubResponse<GithubRestIssue[]>) => {
         responseInFirstPage = response;
         return getNumberOfPages(response);
       }),
       mergeMap((numOfPages: number) => {
-        const apiCalls: Observable<GithubResponse<GithubIssue[]>>[] = [];
+        const apiCalls: Observable<GithubResponse<GithubRestIssue[]>>[] = [];
         for (let i = 2; i <= numOfPages; i++) {
           apiCalls.push(this.getIssuesAPICall(filter, i));
         }
         return apiCalls.length === 0 ? of([]) : forkJoin(apiCalls);
       }),
-      map((resultArray: GithubResponse<GithubIssue[]>[]) => {
+      map((resultArray: GithubResponse<GithubRestIssue[]>[]) => {
         const responses = [responseInFirstPage, ...resultArray];
         const isCached = responses.reduce((result, response) => result && response.isCached, true);
         responses.forEach((resp, index) => this.issuesCacheManager.set(index + 1, resp));
@@ -321,7 +321,7 @@ export class GithubService {
         headers: { 'If-Modified-Since': this.issuesLastModifiedManager.get(id) }
       })
     ).pipe(
-      map((response: GithubResponse<GithubIssue>) => {
+      map((response: GithubResponse<GithubRestIssue>) => {
         this.issuesLastModifiedManager.set(id, response.headers['last-modified']);
         return true;
       }),
@@ -525,8 +525,8 @@ export class GithubService {
    * @param pageNumber - The page to be fetched
    * @returns An observable representing the response containing a single page of filtered issues
    */
-  private getIssuesAPICall(filter: RestGithubIssueFilter, pageNumber: number): Observable<GithubResponse<GithubIssue[]>> {
-    const apiCall: Promise<GithubResponse<GithubIssue[]>> = octokit.issues.listForRepo({
+  private getIssuesAPICall(filter: RestGithubIssueFilter, pageNumber: number): Observable<GithubResponse<GithubRestIssue[]>> {
+    const apiCall: Promise<GithubResponse<GithubRestIssue[]>> = octokit.issues.listForRepo({
       ...filter,
       owner: ORG_NAME,
       repo: REPO,


### PR DESCRIPTION
### Summary:
Fixes #1314

### Changes Made:
* Added GithubRestIssue, a type to accept issue responses from the REST API
* Replaced the type GithubIssue with GithubRestIssue where relevant
* Added a factory method in GithubIssue to convert GithubRestIssue to GithubIssue

### Proposed Commit Message:
```
Add type to correctly process issues from the REST API

Issue responses from the REST API are being accepted as the GithubIssue
class. This is incorrectly typed since the REST API returns a lower
cased state, while GithubIssue expects an upper cased state.

This causes an inconsistency when updating the issues in
issue.service.ts with the response from these REST API queries, which
is done during close and reopen. This prevents us from filtering based
on the state correctly.

Let's add a new type called GithubRestIssue that accurately represents
the issue response from the REST API. We then add a factory method in
GithubIssue that creates a GithubIssue from a GithubRestIssue and
replace all incorrect GithubIssue usages with GithubRestIssue.
```
