### PR TITLE
Add strikethrough to deleted tables

### DIFF
--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
@@ -1,0 +1,3 @@
+::ng-deep .text-strike-through > mat-table > mat-row {
+  text-decoration: line-through;
+}

--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
@@ -1,3 +1,8 @@
-::ng-deep .text-strike-through > mat-table > mat-row {
-  text-decoration: line-through;
+::ng-deep .text-strike-through > mat-table {
+  box-shadow: none;
+  border: 1px solid #f44336;
+
+  mat-row {
+    text-decoration: line-through;
+  }
 }

--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
@@ -1,6 +1,4 @@
 ::ng-deep .text-strike-through > mat-table {
-  box-shadow: none;
-
   mat-row {
     text-decoration: line-through;
   }

--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.css
@@ -1,6 +1,5 @@
 ::ng-deep .text-strike-through > mat-table {
   box-shadow: none;
-  border: 1px solid #f44336;
 
   mat-row {
     text-decoration: line-through;

--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
@@ -16,6 +16,7 @@
   </mat-grid-list>
 
   <app-issue-tables
+    class="text-strike-through"
     table_name="tableBugReporting"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
@@ -1,0 +1,3 @@
+::ng-deep .text-strike-through > mat-table > mat-row {
+  text-decoration: line-through;
+}

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
@@ -1,3 +1,8 @@
-::ng-deep .text-strike-through > mat-table > mat-row {
-  text-decoration: line-through;
+::ng-deep .text-strike-through > mat-table {
+  box-shadow: none;
+  border: 1px solid #f44336;
+
+  mat-row {
+    text-decoration: line-through;
+  }
 }

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
@@ -1,6 +1,4 @@
 ::ng-deep .text-strike-through > mat-table {
-  box-shadow: none;
-
   mat-row {
     text-decoration: line-through;
   }

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.css
@@ -1,6 +1,5 @@
 ::ng-deep .text-strike-through > mat-table {
   box-shadow: none;
-  border: 1px solid #f44336;
 
   mat-row {
     text-decoration: line-through;

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
@@ -16,6 +16,7 @@
   </mat-grid-list>
 
   <app-issue-tables
+    class="text-strike-through"
     table_name="tableBugReporting"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"


### PR DESCRIPTION
Add strikethrough to all text contents in
deleted tables. Note that we only target the
non-header rows with the CSS.

### Summary:
Fixes part of #1324 

### Changes Made:
Add CSS style `text-decoration: line-through` to tables which require a strikethrough

![image](https://github.com/user-attachments/assets/46ffae6c-3d77-4376-9ce1-fe428aee4f0a)


### Proposed Commit Message:
```
Make it easier to see which issues are deleted

Allow for further differentiation between issues
that the user wants and doesn't want by 
striking-through all text in the table.

This helps to give a visual difference between the
un-deleted issues, which should prevent confusion 
when the table headers are not visible.

Styles are applied via CSS override when referencing 
the component in CSS, using ::ng-deep.
```
