### PR TITLE
Remove feature branch from github-actions.yml

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,9 +6,9 @@ name: Setup Builds and Tests
 
 on:
   push:
-    branches: [master, release, feature-bug-trimming]
+    branches: [master, release]
   pull_request:
-    branches: [master, release, feature-bug-trimming]
+    branches: [master, release]
 
 jobs:
   linux-setup-and-tests:


### PR DESCRIPTION
### Summary:
Fixes #1323 

### Changes Made:
* Remove feature branch from github-actions.yml

### Proposed Commit Message:
```
Remove feature branch from github-actions.yml

This feature branch was used to create the 
bug-trimming phase and it required to run
the tests when we merge into it
```
