### PR TITLE
Upgrade Octokit authentication to fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "main": "main.js",
   "engines": {
     "node": ">=14.0.0"
@@ -61,14 +61,14 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~13.3.11",
+    "@angular/cli": "^13.3.11",
+    "@angular/compiler-cli": "^13.4.0",
+    "@angular/language-service": "^13.4.0",
     "@angular-eslint/builder": "12.7.0",
     "@angular-eslint/eslint-plugin": "13.5.0",
     "@angular-eslint/eslint-plugin-template": "13.5.0",
     "@angular-eslint/schematics": "13.5.0",
     "@angular-eslint/template-parser": "13.5.0",
-    "@angular/cli": "^13.3.11",
-    "@angular/compiler-cli": "^13.4.0",
-    "@angular/language-service": "^13.4.0",
     "@graphql-codegen/cli": "2.16.4",
     "@graphql-codegen/fragment-matcher": "^1.17.7",
     "@graphql-codegen/typescript": "1.17.7",
@@ -84,7 +84,6 @@
     "@typescript-eslint/eslint-plugin": "5.0.0",
     "@typescript-eslint/parser": "5.0.0",
     "angular-cli-ghpages": "^1.0.0-rc.2",
-    "engine.io": "6.6.2",
     "eslint": "^8.57.0",
     "husky": "^4.2.5",
     "jasmine": "^3.9.0",
@@ -102,6 +101,7 @@
     "scuri": "^0.9.4",
     "ts-node": "^10.9.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "4.6.4"
+    "typescript": "4.6.4",
+    "engine.io": "6.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CATcher",
-  "version": "3.6.0",
+  "version": "3.5.5",
   "main": "main.js",
   "engines": {
     "node": ">=14.0.0"
@@ -42,8 +42,9 @@
     "@angular/router": "^13.4.0",
     "@apollo/client": "3.3.0",
     "@github/markdown-toolbar-element": "^2.1.1",
-    "@octokit/rest": "^16.37.0",
+    "@octokit/auth-oauth-user": "^2.1.2",
     "@octokit/core": "^4.2.1",
+    "@octokit/rest": "^17.11.0",
     "apollo-angular": "^3.0.1",
     "arcsecond": "^4.1.0",
     "core-js": "^3.16.4",
@@ -60,14 +61,14 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~13.3.11",
-    "@angular/cli": "^13.3.11",
-    "@angular/compiler-cli": "^13.4.0",
-    "@angular/language-service": "^13.4.0",
     "@angular-eslint/builder": "12.7.0",
     "@angular-eslint/eslint-plugin": "13.5.0",
     "@angular-eslint/eslint-plugin-template": "13.5.0",
     "@angular-eslint/schematics": "13.5.0",
     "@angular-eslint/template-parser": "13.5.0",
+    "@angular/cli": "^13.3.11",
+    "@angular/compiler-cli": "^13.4.0",
+    "@angular/language-service": "^13.4.0",
     "@graphql-codegen/cli": "2.16.4",
     "@graphql-codegen/fragment-matcher": "^1.17.7",
     "@graphql-codegen/typescript": "1.17.7",
@@ -83,6 +84,7 @@
     "@typescript-eslint/eslint-plugin": "5.0.0",
     "@typescript-eslint/parser": "5.0.0",
     "angular-cli-ghpages": "^1.0.0-rc.2",
+    "engine.io": "6.6.2",
     "eslint": "^8.57.0",
     "husky": "^4.2.5",
     "jasmine": "^3.9.0",
@@ -100,7 +102,6 @@
     "scuri": "^0.9.4",
     "ts-node": "^10.9.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "4.6.4",
-    "engine.io": "6.6.2"
+    "typescript": "4.6.4"
   }
 }

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -83,7 +83,7 @@ export class AuthComponent implements OnInit, OnDestroy {
           throw new Error(data.error);
         }
         this.authService.storeOAuthAccessToken(data.token);
-        this.logger.info('AuthComponent: Sucessfully obtained access token');
+        this.logger.info('AuthComponent: Successfully octained access token');
       })
       .catch((err) => {
         this.logger.info(`AuthComponent: Error in data fetched from access token URL: ${err}`);

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -33,6 +33,7 @@ import { SessionData } from '../models/session.model';
 import { ERRORCODE_NOT_FOUND, ErrorHandlingService } from './error-handling.service';
 import { LoggingService } from './logging.service';
 import { GithubRestIssue } from '../models/github/github-rest-issue';
+import { createOAuthUserAuth } from '@octokit/auth-oauth-user';
 
 const { Octokit } = require('@octokit/rest');
 const CATCHER_ORG = 'CATcher-org';
@@ -72,8 +73,9 @@ export class GithubService {
 
   storeOAuthAccessToken(accessToken: string) {
     octokit = new Octokit({
-      auth() {
-        return `Token ${accessToken}`;
+      authStrategy: createOAuthUserAuth,
+      auth: {
+        token: accessToken
       },
       log: {
         debug: (message, ...otherInfo) => this.logger.debug('GithubService: ' + message, ...otherInfo),

--- a/src/app/core/services/github.service.ts
+++ b/src/app/core/services/github.service.ts
@@ -441,7 +441,7 @@ export class GithubService {
 
   fetchDataFile(): Observable<{}> {
     return from(
-      octokit.repos.getContents({ owner: MOD_ORG, repo: DATA_REPO, path: 'data.csv', headers: GithubService.IF_NONE_MATCH_EMPTY })
+      octokit.repos.getContent({ owner: MOD_ORG, repo: DATA_REPO, path: 'data.csv', headers: GithubService.IF_NONE_MATCH_EMPTY })
     ).pipe(
       map((rawData) => {
         return { data: atob(rawData['data']['content']) };
@@ -472,7 +472,7 @@ export class GithubService {
    */
   fetchSettingsFile(): Observable<SessionData> {
     return from(
-      octokit.repos.getContents({ owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json', headers: GithubService.IF_NONE_MATCH_EMPTY })
+      octokit.repos.getContent({ owner: MOD_ORG, repo: DATA_REPO, path: 'settings.json', headers: GithubService.IF_NONE_MATCH_EMPTY })
     ).pipe(
       map((rawData) => JSON.parse(atob(rawData['data']['content']))),
       catchError((err) => {


### PR DESCRIPTION
### Summary:
Fixes #1343 

### Changes Made:
* Upgraded `@octokit/rest` to v17
* Included new package `@octokit/auth-oauth-user` for indicating `authStrategy` used
* Fix typo in logging

### Proposed Commit Message:
```
Upgrade @octokit/rest to v17

@octokit/rest v16 uses a format that will be 
deprecated starting from v17 to construct
an Octokit object, and will cause authentication
request to fail.

Let's upgrade the octokit version to v17
and use the new format so that future upgrades
can happen more smoothly.
```
