### PR TITLE
Downgrade Devcontainer to Debian Bullseye and Preinstall Playwright Dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
   "name": "CATcher-development",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-16",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-16-bullseye",
   "features": {
     "ghcr.io/kreemer/features/chrometesting:1": {}
   },
@@ -14,7 +14,8 @@
   ],
   "onCreateCommand": {
     "Giving rw permissions to mounted dir": "sudo chown -R node:node ${containerWorkspaceFolder}/*",
-    "Adding CATcher as upstream": "git remote add upstream https://github.com/CATcher-org/CATcher.git || echo 'already exists'"
+    "Adding CATcher as upstream": "git remote add upstream https://github.com/CATcher-org/CATcher.git || echo 'already exists'",
+    "Installing playwright browsers...": "sudo npx playwright install-deps && npx playwright install firefox webkit chromium"
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   // npm with default registry seems to hang frequently, thus a more reliable mirror is used.


### PR DESCRIPTION
Fixes #1346 

**Description:**  
This PR addresses the issue of Playwright not being supported in our current devcontainer, which uses Debian Bookworm. To resolve this, we are:  
1. Downgrading the devcontainer base image from Debian Bookworm to Debian Bullseye, which is supported by Playwright.  
2. Preinstalling Playwright's browser dependencies to ensure seamless setup for development and testing workflows.  

**Changes Included:**  
- Updated base image to use `debian:bullseye`.  
- Added necessary commands to preinstall Playwright's browser dependencies.  

**Why This Change is Necessary:**  
Playwright is a critical tool for end-to-end testing in our project, and the lack of support in the current devcontainer is blocking development and testing efforts. This change ensures compatibility and a smoother developer experience.  

**Proposed Commit message**
```
Preinstall Playwright Dependencies in devcontainer

Playwright dependencies is currently not readily supported in Debian
bookworm which is used by the devcontainer.

As CATcher uses Playwright to do e2e testing, let's
- downgrade the devcontainer to Debian bullseye to support Playwright
- Preinstalls the Playwright testing browser dependencies in the
  container

```