### PR TITLE
Fix navigability issue caused by shared table name

### DIFF
--- a/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-reporting/issues-deleted/issues-deleted.component.html
@@ -17,7 +17,7 @@
 
   <app-issue-tables
     class="text-strike-through"
-    table_name="tableBugReporting"
+    table_name="tableIssuesDeleted"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
+++ b/src/app/phase-bug-reporting/issues-posted/issues-posted.component.html
@@ -30,7 +30,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableBugReporting"
+    table_name="tableIssuesPosted"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
+++ b/src/app/phase-bug-trimming/issues-deleted/issues-deleted.component.html
@@ -17,7 +17,7 @@
 
   <app-issue-tables
     class="text-strike-through"
-    table_name="tableBugReporting"
+    table_name="tableIssuesDeleted"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"

--- a/src/app/phase-bug-trimming/issues-posted/issues-posted.component.html
+++ b/src/app/phase-bug-trimming/issues-posted/issues-posted.component.html
@@ -30,7 +30,7 @@
   </mat-grid-list>
 
   <app-issue-tables
-    table_name="tableBugReporting"
+    table_name="tableIssuesPosted"
     [headers]="this.displayedColumns"
     [actions]="this.actionButtons"
     [filters]="this.filter"


### PR DESCRIPTION
### Summary:
Fixes #1351 

### Changes Made:
* The bug was caused by both tables having the same table name, resulting in the table settings clashing, thus the tables were renamed in this PR.

### Proposed Commit Message:
```
Fix navigability issue caused by shared table name

The tables for issues deleted and issues posted have the same name,
resulting in unexpected behavior as the table settings are shared.

Rename both tables to prevent unexpected behavior for pagination.
```
