### PR TITLE
Improve tab navigation flow for accessibility

### DIFF
--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -30,6 +30,7 @@
           mat-stroked-button
           color="primary"
           [disabled]="!newIssueForm.valid || isFormPending"
+          tabindex="4"
         >
           {{ this.submitButtonText }}
         </button>

--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="column left">
         <mat-form-field>
-          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" />
+          <input id="title" formControlName="title" matInput placeholder="Title" required maxlength="256" tabindex="1"/>
           <mat-error *ngIf="title.errors && title.errors['required'] && (title.touched || title.dirty)"> Title required. </mat-error>
           <mat-error *ngIf="title.errors && title.errors['whitespace']"> Title cannot contain only whitespaces. </mat-error>
           <mat-error *ngIf="title.errors && title.errors['maxlength']"> Title cannot exceed 256 characters. </mat-error>

--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -13,6 +13,7 @@
         <mat-form-field appearance="outline" style="width: 100%">
           <mat-label></mat-label>
           <textarea
+            tabindex="2"
             (paste)="onPaste($event)"
             (keydown)="onKeyPress($event)"
             (beforeinput)="handleBeforeInputChange($event)"

--- a/src/app/shared/label-dropdown/label-dropdown.component.html
+++ b/src/app/shared/label-dropdown/label-dropdown.component.html
@@ -1,6 +1,7 @@
 <form [formGroup]="dropdownForm">
   <mat-form-field style="width: 100%">
     <mat-select
+      tabindex="3"
       [ngClass]="dropdownTextColor"
       formControlName="{{ attributeName }}"
       placeholder="{{ this.labelService.getLabelTitle(attributeName) }}"


### PR DESCRIPTION
Restructured tabindex order to ensure a logical navigation sequence: focus now moves from the issue title to the description field, followed by the severity and type dropdowns, then the submit button before reaching less important form elements. Enhances usability for keyboard users and improves overall accessibility.

### Summary:
Fixes #1266 

### Changes Made:
* Reordered the tab navigation sequence in the New Issue form for improved accessibility and user experience.
* Ensured that pressing Tab now correctly moves focus from the issue title input to the description editor, followed by the severity and type dropdowns, then finally the submit button.

![ScreenRecording2025-07-09at12 23 01AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/8a6f5bc7-87b1-47aa-932a-adaab4c419aa)

### Proposed Commit Message:
```
Improve tab navigation flow for accessibility

Restructured tabindex order to ensure a logical navigation sequence:
focus now moves from the issue title to the description field, followed
by the severity and type dropdowns, then the submit button before reaching less important form
elements. Enhances usability for keyboard users and improves overall
accessibility.
```
