### PR TITLE
Refactor: unify delete and restore issue actions and move conditional logic into typescript file

### DIFF
--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -257,7 +257,7 @@
       <button
         mat-button
         color="warn"
-        *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)"
+        *ngIf="isActionPerformAllowed(true, issue.id)"
         (click)="deleteOrRestoreIssue(true, issue.id, $event); $event.stopPropagation()"
         matTooltip="Delete this issue"
         style="transform: scale(0.8)"
@@ -268,7 +268,7 @@
       <button
         mat-button
         color="primary"
-        *ngIf="permissions.isIssueRestorable() && !issuesPendingRestore[issue.id] && this.isActionVisible(action_buttons.RESTORE_ISSUE)"
+        *ngIf="isActionPerformAllowed(false, issue.id)"
         (click)="deleteOrRestoreIssue(false, issue.id, $event); $event.stopPropagation()"
         matTooltip="Restore this issue"
         style="transform: scale(0.8)"

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -258,7 +258,7 @@
         mat-button
         color="warn"
         *ngIf="permissions.isIssueDeletable() && !issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)"
-        (click)="deleteIssue(issue.id, $event); $event.stopPropagation()"
+        (click)="deleteOrRestoreIssue(true, issue.id, $event); $event.stopPropagation()"
         matTooltip="Delete this issue"
         style="transform: scale(0.8)"
         data-testid="delete_issue_button"
@@ -269,7 +269,7 @@
         mat-button
         color="primary"
         *ngIf="permissions.isIssueRestorable() && !issuesPendingRestore[issue.id] && this.isActionVisible(action_buttons.RESTORE_ISSUE)"
-        (click)="undeleteIssue(issue.id, $event); $event.stopPropagation()"
+        (click)="deleteOrRestoreIssue(false, issue.id, $event); $event.stopPropagation()"
         matTooltip="Restore this issue"
         style="transform: scale(0.8)"
       >
@@ -280,8 +280,8 @@
         [diameter]="25"
         style="display: inline; padding-right: 30px; margin-left: 5px"
         *ngIf="
-          (issuesPendingDeletion[issue.id] && this.isActionVisible(action_buttons.DELETE_ISSUE)) ||
-          (issuesPendingRestore[issue.id] && this.isActionVisible(action_buttons.RESTORE_ISSUE))
+          issuesPendingAction[issue.id] &&
+          (this.isActionVisible(action_buttons.DELETE_ISSUE) || this.isActionVisible(action_buttons.RESTORE_ISSUE))
         "
       ></mat-spinner>
     </mat-cell>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -246,10 +246,7 @@
         mat-button
         (click)="markAsPending(issue, $event)"
         style="transform: scale(0.8)"
-        *ngIf="
-          (userService.currentUser.role === 'Student' || userService.currentUser.role === 'Admin') &&
-          this.isActionVisible(action_buttons.MARK_AS_PENDING)
-        "
+        *ngIf="shouldEnablePendingButton()"
         data-testid="mark_pending_button"
       >
         <mat-icon>cancel</mat-icon>
@@ -279,10 +276,7 @@
         color="warn"
         [diameter]="25"
         style="display: inline; padding-right: 30px; margin-left: 5px"
-        *ngIf="
-          issuesPendingAction[issue.id] &&
-          (this.isActionVisible(action_buttons.DELETE_ISSUE) || this.isActionVisible(action_buttons.RESTORE_ISSUE))
-        "
+        *ngIf="shouldEnablePendingActionSpinner(issue.id)"
       ></mat-spinner>
     </mat-cell>
   </ng-container>

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -207,7 +207,7 @@
         <mat-icon>open_in_new</mat-icon>
       </button>
       <button
-        *ngIf="this.isResponseEditable() && !issue.status && this.isActionVisible(action_buttons.RESPOND_TO_ISSUE); else tryEditIssue"
+        *ngIf="shouldEnableRespondToIssue(issue); else tryEditIssue"
         [routerLink]="'issues/' + issue.id"
         mat-button
         color="accent"
@@ -219,7 +219,7 @@
       </button>
       <ng-template #tryEditIssue>
         <button
-          *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
+          *ngIf="shouldEnableEditIssue()"
           mat-button
           color="accent"
           style="transform: scale(0.8)"
@@ -230,7 +230,7 @@
         </button>
       </ng-template>
       <button
-        *ngIf="this.isResponseEditable() && issue.status && this.isActionVisible(action_buttons.MARK_AS_RESPONDED)"
+        *ngIf="shouldEnableMarkAsResponded(issue)"
         mat-button
         color="primary"
         (click)="markAsResponded(issue, $event)"

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -45,8 +45,6 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   issues: IssuesDataTable;
-  issuesPendingDeletion: { [id: number]: boolean };
-  issuesPendingRestore: { [id: number]: boolean };
   issuesPendingAction: { [id: number]: boolean };
 
   public tableSettings: TableSettings;
@@ -68,8 +66,6 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {
     this.issues = new IssuesDataTable(this.issueService, this.sort, this.paginator, this.headers, this.filters);
-    this.issuesPendingDeletion = {};
-    this.issuesPendingRestore = {};
     this.issuesPendingAction = {};
     this.tableSettings = this.issueTableSettingsService.getTableSettings(this.table_name);
   }
@@ -202,5 +198,18 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     snackBarRef.onAction().subscribe(() => {
       this.deleteOrRestoreIssue(!isDeleteAction, id, event, false);
     });
+  }
+
+  isActionPerformAllowed(isDeleteAction: boolean, id: number) {
+    const actionButton = isDeleteAction ? this.action_buttons.DELETE_ISSUE : this.action_buttons.RESTORE_ISSUE;
+    const isPermissionGranted = this.isIssueActionPermitted(isDeleteAction);
+    return isPermissionGranted && !this.issuesPendingAction[id] && this.isActionVisible(actionButton);
+  }
+
+  private isIssueActionPermitted(isDeleteAction: boolean) {
+    if (isDeleteAction) {
+      return this.permissions.isIssueDeletable();
+    }
+    return this.permissions.isIssueRestorable();
   }
 }

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -212,4 +212,18 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
     }
     return this.permissions.isIssueRestorable();
   }
+
+  shouldEnablePendingButton() {
+    return (
+      (this.userService.currentUser.role === 'Student' || this.userService.currentUser.role === 'Admin') &&
+      this.isActionVisible(this.action_buttons.MARK_AS_PENDING)
+    );
+  }
+
+  shouldEnablePendingActionSpinner(id: number) {
+    return (
+      this.issuesPendingAction[id] &&
+      (this.isActionVisible(this.action_buttons.DELETE_ISSUE) || this.isActionVisible(this.action_buttons.RESTORE_ISSUE))
+    );
+  }
 }

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -226,4 +226,16 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
       (this.isActionVisible(this.action_buttons.DELETE_ISSUE) || this.isActionVisible(this.action_buttons.RESTORE_ISSUE))
     );
   }
+
+  shouldEnableRespondToIssue(issue: Issue) {
+    return this.isResponseEditable() && !issue.status && this.isActionVisible(this.action_buttons.RESPOND_TO_ISSUE);
+  }
+
+  shouldEnableMarkAsResponded(issue: Issue) {
+    return this.isResponseEditable() && issue.status && this.isActionVisible(this.action_buttons.MARK_AS_RESPONDED);
+  }
+
+  shouldEnableEditIssue() {
+    return this.permissions.isIssueEditable() && this.isActionVisible(this.action_buttons.FIX_ISSUE);
+  }
 }


### PR DESCRIPTION
### Summary:
Fixes #1315 

### Changes Made:
* Moved long boolean statements from the html to the typescript file for better readability.
* Combined the delete and restore issue actions into a single method, alongside with one handler helper method that is toggled by passing in a boolean argument.
* Combined the 2 separate lists `issuesPendingDeletion` and `issuesPendingRestore` into a single `issuesPendingAction`.

### Proposed Commit Message:
```
Refactor issue actions and conditions for clarity and maintainability

Moved complex boolean logic from template to component methods.
This is done for better readability from the html file.

Combined delete and restore issue flows into a single unified method 
with a boolean toggle to reduce code repetition in the typescript file.

Consolidated issuesPendingDeletion and issuesPendingRestore into 
a single issuesPendingAction list.
```
